### PR TITLE
Add an optional hash param to @EpoxyAttribute

### DIFF
--- a/epoxy-model/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
+++ b/epoxy-model/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
@@ -13,4 +13,11 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.CLASS)
 public @interface EpoxyAttribute {
+  /**
+   * Whether or not to include this attribute in equals and hashCode calculations.
+   *
+   * It may be useful to disable this for objects that get recreated without the underlying data
+   * changing such as a click listener that gets created inline in every bind call.
+   */
+  boolean hash() default true;
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
@@ -19,6 +19,7 @@ public class AttributeInfo {
   private final List<AnnotationSpec> getterAnnotations = new ArrayList<>();
   private final String name;
   private final TypeName type;
+  private final boolean useInHash;
   /**
    * Track whether there is a setter method for this attribute on a super class so that we can call
    * through to super.
@@ -26,10 +27,12 @@ public class AttributeInfo {
   private final boolean hasSuperSetter;
 
   public AttributeInfo(String name, TypeName type,
-      List<? extends AnnotationMirror> annotationMirrors, boolean hasSuperSetter) {
+      List<? extends AnnotationMirror> annotationMirrors, EpoxyAttribute annotation,
+      boolean hasSuperSetter) {
     this.name = name;
     this.type = type;
     this.hasSuperSetter = hasSuperSetter;
+    useInHash = annotation.hash();
     buildAnnotationLists(annotationMirrors);
   }
 
@@ -73,6 +76,10 @@ public class AttributeInfo {
 
   public TypeName getType() {
     return type;
+  }
+
+  public boolean useInHash() {
+    return useInHash;
   }
 
   public List<AnnotationSpec> getSetterAnnotations() {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -383,6 +383,9 @@ public class EpoxyProcessor extends AbstractProcessor {
         .addStatement("int result = super.hashCode()");
 
     for (AttributeInfo attributeInfo : helperClass.getAttributeInfo()) {
+      if (!attributeInfo.useInHash()) {
+        continue;
+      }
       if (attributeInfo.getType() == DOUBLE) {
         builder.addStatement("long temp");
         break;

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -127,7 +127,8 @@ public class EpoxyProcessor extends AbstractProcessor {
     TypeName type = TypeName.get(attribute.asType());
     boolean hasSuper = hasSuperMethod(classElement, name);
     helperClass.addAttribute(
-        new AttributeInfo(name, type, attribute.getAnnotationMirrors(), hasSuper));
+        new AttributeInfo(name, type, attribute.getAnnotationMirrors(),
+            attribute.getAnnotation(EpoxyAttribute.class), hasSuper));
   }
 
   /**
@@ -337,6 +338,10 @@ public class EpoxyProcessor extends AbstractProcessor {
             helperClass.getOriginalClassNameWithoutType());
 
     for (AttributeInfo attributeInfo : helperClass.getAttributeInfo()) {
+      if (!attributeInfo.useInHash()) {
+        continue;
+      }
+
       TypeName type = attributeInfo.getType();
       String name = attributeInfo.getName();
       if (type == FLOAT) {
@@ -385,6 +390,10 @@ public class EpoxyProcessor extends AbstractProcessor {
     }
 
     for (AttributeInfo attributeInfo : helperClass.getAttributeInfo()) {
+      if (!attributeInfo.useInHash()) {
+        continue;
+      }
+
       TypeName type = attributeInfo.getType();
       String name = attributeInfo.getName();
 

--- a/epoxy-processor/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
+++ b/epoxy-processor/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
@@ -118,6 +118,21 @@ public class EpoxyProcessorTest {
   }
 
   @Test
+  public void testModelWithoutHash() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelWithoutHash.java");
+
+    JavaFileObject generatedModel = JavaFileObjects.forResource("ModelWithoutHash_.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
+  }
+
+  @Test
   public void testModelWithPrivateAttributeFails() {
     JavaFileObject model = JavaFileObjects
         .forResource("ModelWithPrivateField.java");

--- a/epoxy-processor/src/test/resources/ModelWithoutHash.java
+++ b/epoxy-processor/src/test/resources/ModelWithoutHash.java
@@ -1,0 +1,11 @@
+package com.airbnb.epoxy;
+
+public class ModelWithoutHash extends EpoxyModel<Object> {
+  @EpoxyAttribute int value;
+  @EpoxyAttribute(hash=false) int value2;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processor/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processor/src/test/resources/ModelWithoutHash_.java
@@ -1,0 +1,86 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import java.lang.Object;
+import java.lang.Override;
+
+/**
+ * Generated file. Do not modify! */
+public class ModelWithoutHash_ extends ModelWithoutHash {
+  public ModelWithoutHash_() {
+    super();
+  }
+
+  public ModelWithoutHash_ value2(int value2) {
+    this.value2 = value2;
+    return this;
+  }
+
+  public int value2() {
+    return value2;
+  }
+
+  public ModelWithoutHash_ value(int value) {
+    this.value = value;
+    return this;
+  }
+
+  public int value() {
+    return value;
+  }
+
+  @Override
+  public ModelWithoutHash_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithoutHash_ layout(@LayoutRes int layoutRes) {
+    super.layout(layoutRes);
+    return this;
+  }
+
+  @Override
+  public ModelWithoutHash_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public ModelWithoutHash_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public ModelWithoutHash_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof ModelWithoutHash)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    ModelWithoutHash that = (ModelWithoutHash) o;
+    if (value != that.value) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + value;
+    return result;
+  }
+}


### PR DESCRIPTION
You can now annotate @EpoxyAttribute(hash=false) to skip that attribute
for the equals and hash function. This is useful for fields that can
change on each bind but don't affect the underlying data such as a
click listener that gets created on each bind call.