### PR TITLE
Use correct layout in EpoxyModel hashcode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.0-beta3'
+    classpath 'com.android.tools.build:gradle:2.2.0-rc1'
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   }

--- a/epoxy-model/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-model/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -109,7 +109,7 @@ public abstract class EpoxyModel<T> {
     if (id != that.id) {
       return false;
     }
-    if (layout != that.layout) {
+    if (getLayout() != that.getLayout()) {
       return false;
     }
     return shown == that.shown;
@@ -118,7 +118,7 @@ public abstract class EpoxyModel<T> {
   @Override
   public int hashCode() {
     int result = (int) (id ^ (id >>> 32));
-    result = 31 * result + layout;
+    result = 31 * result + getLayout();
     result = 31 * result + (shown ? 1 : 0);
     return result;
   }


### PR DESCRIPTION
@gpeal 

Before hashcode and equals were using the layout field only, but since the `getDefaultLayout` could change its return value we need to use `getLayout()` instead.