### PR TITLE
Clean up differ test

### DIFF
--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/DifferNotifyTest.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/DifferNotifyTest.java
@@ -171,7 +171,7 @@ public class DifferNotifyTest {
 
   private void setModelsOnAdapter() {
     testAdapter.models.clear();
-    testAdapter.models.addAll(ModelTestUtils.convertList(testModels));
+    testAdapter.models.addAll(ModelTestUtils.convertToGenericModels(testModels));
   }
 
   private void assertCorrectness() {

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/ModelTestUtils.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/ModelTestUtils.java
@@ -6,37 +6,37 @@ import java.util.List;
 class ModelTestUtils {
   private static final int DEFAULT_NUM_MODELS = 20;
 
-  static void changeValues(List<TestModel> models) {
+  static void changeValues(List models) {
     changeValues(models, 0, models.size());
   }
 
-  static void changeValues(List<TestModel> models, int start, int count) {
+  static void changeValues(List models, int start, int count) {
     for (int i = start; i < count; i++) {
-      models.set(i, models.get(i).clone().randomizeValue());
+      models.set(i, ((TestModel) models.get(i)).clone().randomizeValue());
     }
   }
 
-  static void remove(List<TestModel> models, int start, int count) {
+  static void remove(List models, int start, int count) {
     models.subList(start, start + count).clear();
   }
 
-  static void removeAfter(List<TestModel> models, int start) {
+  static void removeModelsAfterPosition(List models, int start) {
     remove(models, start, models.size() - start);
   }
 
-  static void addModels(List<TestModel> list) {
+  static void addModels(List list) {
     addModels(DEFAULT_NUM_MODELS, list);
   }
 
-  static void addModels(int count, List<TestModel> list) {
+  static void addModels(int count, List list) {
     addModels(count, list, list.size());
   }
 
-  static void addModels(List<TestModel> list, int index) {
+  static void addModels(List list, int index) {
     addModels(DEFAULT_NUM_MODELS, list, index);
   }
 
-  static void addModels(int count, List<TestModel> list, int index) {
+  static void addModels(int count, List list, int index) {
     List<TestModel> modelsToAdd = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
       modelsToAdd.add(new TestModel());
@@ -45,10 +45,18 @@ class ModelTestUtils {
     list.addAll(index, modelsToAdd);
   }
 
-  static List<EpoxyModel<?>> convertList(List<TestModel> list) {
+  static List<EpoxyModel<?>> convertToGenericModels(List<TestModel> list) {
     List<EpoxyModel<?>> result = new ArrayList<>(list.size());
     for (TestModel testModel : list) {
       result.add(testModel);
+    }
+    return result;
+  }
+
+  static List<TestModel> convertToTestModels(List<EpoxyModel<?>> list) {
+    List<TestModel> result = new ArrayList<>(list.size());
+    for (EpoxyModel<?> model : list) {
+      result.add((TestModel) model);
     }
     return result;
   }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/TestObserver.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/TestObserver.java
@@ -6,12 +6,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 class TestObserver extends AdapterDataObserver {
-  List<TestModel> diffedModels = new ArrayList<>();
+  List<TestModel> modelsAfterDiffing = new ArrayList<>();
+  List<TestModel> initialModels = new ArrayList<>();
   int operationCount = 0;
   private boolean showLogs;
 
   TestObserver(boolean showLogs) {
     this.showLogs = showLogs;
+  }
+
+  public void setUpForNextDiff(List<TestModel> models) {
+    initialModels = new ArrayList<>(models);
+    modelsAfterDiffing = new ArrayList<>(models);
   }
 
   @Override
@@ -20,7 +26,7 @@ class TestObserver extends AdapterDataObserver {
       System.out.println("Item range changed. Start: " + positionStart + " Count: " + itemCount);
     }
     for (int i = positionStart; i < positionStart + itemCount; i++) {
-      diffedModels.get(i).updated = true;
+      modelsAfterDiffing.get(i).updated = true;
     }
     operationCount++;
   }
@@ -35,7 +41,7 @@ class TestObserver extends AdapterDataObserver {
       modelsToAdd.add(InsertedModel.INSTANCE);
     }
 
-    diffedModels.addAll(positionStart, modelsToAdd);
+    modelsAfterDiffing.addAll(positionStart, modelsToAdd);
     operationCount++;
   }
 
@@ -44,7 +50,7 @@ class TestObserver extends AdapterDataObserver {
     if (showLogs) {
       System.out.println("Item range removed. Start: " + positionStart + " Count: " + itemCount);
     }
-    diffedModels.subList(positionStart, positionStart + itemCount).clear();
+    modelsAfterDiffing.subList(positionStart, positionStart + itemCount).clear();
     operationCount++;
   }
 
@@ -53,8 +59,8 @@ class TestObserver extends AdapterDataObserver {
     if (showLogs) {
       System.out.println("Item moved. From: " + fromPosition + " To: " + toPosition);
     }
-    TestModel itemToMove = diffedModels.remove(fromPosition);
-    diffedModels.add(toPosition, itemToMove);
+    TestModel itemToMove = modelsAfterDiffing.remove(fromPosition);
+    modelsAfterDiffing.add(toPosition, itemToMove);
     operationCount++;
   }
 }


### PR DESCRIPTION
@gpeal

Simplifies how tests for the differ are run. Before we were resetting the diff state every time.  Now test set up manipulates models directly on the adapter. This allows us to better test interactions with the adapter and differ behavior that is revealed by diffing multiple times in a row.

Timing functionality was also added to get the diff speed for all tests run.