### PR TITLE
Ensure list capacity before adding models

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyAdapter.java
@@ -253,8 +253,11 @@ public abstract class EpoxyAdapter extends RecyclerView.Adapter<EpoxyViewHolder>
    */
   protected void addModels(EpoxyModel<?>... modelsToAdd) {
     int initialSize = models.size();
+    int numModelsToAdd = modelsToAdd.length;
+
+    ((ArrayList) models).ensureCapacity(initialSize + numModelsToAdd);
     Collections.addAll(models, modelsToAdd);
-    notifyItemRangeInserted(initialSize, modelsToAdd.length);
+    notifyItemRangeInserted(initialSize, numModelsToAdd);
   }
 
   /**


### PR DESCRIPTION
There isn't a great way to add an array to an ArrayList.

Using the Collections.addAll helper works, but just does an individual add for each object. This improves it by allocating enough space before hand to avoid multiple resizes