### PR TITLE
Remove object pools in differ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.0-rc1'
+    classpath 'com.android.tools.build:gradle:2.2.0-rc2'
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelState.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelState.java
@@ -1,19 +1,7 @@
 package com.airbnb.epoxy;
 
-import android.support.v4.util.Pools;
-
-import java.util.Collection;
-
 /** Helper to store relevant information about a model that we need to determine if it changed. */
 class ModelState {
-  /**
-   * To have enough items in the pool it should be twice as big as the list size, since we track old
-   * and new list state. It's hard to predict list size and some users may have long lists that this
-   * won't be well suited to. It may be worth looking into dynamically resizing this based on list
-   * size.
-   */
-  private static final Pools.Pool<ModelState> POOL = new Pools.SimplePool<>(200);
-
   long id;
   int hashCode;
   int position;
@@ -36,7 +24,7 @@ class ModelState {
   int lastMoveOp;
 
   static ModelState build(EpoxyModel<?> model, int position) {
-    ModelState state = get();
+    ModelState state = new ModelState();
 
     state.lastMoveOp = 0;
     state.pair = null;
@@ -47,39 +35,21 @@ class ModelState {
     return state;
   }
 
-  private static ModelState get() {
-    ModelState state = POOL.acquire();
-    if (state == null) {
-      state = new ModelState();
-    }
-    return state;
-  }
-
   /**
    * Used for an item inserted into the new list when we need to track moves that effect the
    * inserted item in the old list.
    */
-  public void pairWithSelf() {
+  void pairWithSelf() {
     if (pair != null) {
       throw new IllegalStateException("Already paired.");
     }
 
-    pair = get();
+    pair = new ModelState();
     pair.lastMoveOp = 0;
     pair.id = id;
     pair.position = position;
     pair.hashCode = hashCode;
     pair.pair = this;
-  }
-
-  static void release(Collection<ModelState> states) {
-    for (ModelState state : states) {
-      release(state);
-    }
-  }
-
-  public static void release(ModelState state) {
-    POOL.release(state);
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/UpdateOp.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/UpdateOp.java
@@ -2,16 +2,12 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.IntDef;
-import android.support.v4.util.Pools;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.List;
 
 /** Defines an operation that makes a change to the epoxy model list. */
 class UpdateOp {
-  private static final Pools.Pool<UpdateOp> UPDATE_OP_POOL = new Pools.SimplePool<>(10);
-
   @IntDef({ADD, REMOVE, UPDATE, MOVE})
   @Retention(RetentionPolicy.SOURCE)
   @interface Type {
@@ -31,10 +27,7 @@ class UpdateOp {
   }
 
   static UpdateOp instance(@Type int type, int positionStart, int itemCount) {
-    UpdateOp op = UPDATE_OP_POOL.acquire();
-    if (op == null) {
-      op = new UpdateOp();
-    }
+    UpdateOp op = new UpdateOp();
 
     op.type = type;
     op.positionStart = positionStart;
@@ -45,12 +38,6 @@ class UpdateOp {
 
   static UpdateOp instance(@Type int type, int positionStart) {
     return instance(type, positionStart, 1);
-  }
-
-  static void release(List<UpdateOp> diff) {
-    for (UpdateOp updateOp : diff) {
-      UPDATE_OP_POOL.release(updateOp);
-    }
   }
 
   @Override


### PR DESCRIPTION
I previously added object pools for the ModelState and UpdateOp objects which are used in the diffing algorithm.

A ModelState object is created for each model in the adapter, and an UpdateOp was created for each separate notify action. I did this to prevent memory thrashing, since if you have lots of models in your adapter and run the differ a lot it would create many of these objects each time.

I spent more time profiling this and found the pools to not be worth while. The objects are too small, and created too efficiently, to really make a difference pooling. In fact, the overhead of pooling slows down the diff quite a bit.

Removing the pools gives about a 14% speed improvement. It adds a little bit more memory overhead, but in tests with the sample app it seems like 10x more memory and object allocation is done just to handle the drawing and recycler view updates when a diff happens.

I seem to have prematurely optimized here. Removing the pools simplifies the code and will make it faster.