### PR TITLE
[EpoxyModel] Use getLayout() method instead of layout field in toStri…

### DIFF
--- a/epoxy-model/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-model/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -169,7 +169,7 @@ public abstract class EpoxyModel<T> {
   public String toString() {
     return "EpoxyModel{"
         + "id=" + id
-        + ", layout=" + layout
+        + ", layout=" + getLayout()
         + ", shown=" + shown
         + '}';
   }

--- a/epoxy-processor/build.gradle
+++ b/epoxy-processor/build.gradle
@@ -11,7 +11,6 @@ dependencies {
   testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
 
   compile project(':epoxy-model')
-  compile 'com.android.support:support-annotations:24.1.1'
 }
 
 checkstyle {

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   testCompile 'com.google.testing.compile:compile-testing:0.6'
 
   compile project(':annotations')
-  compile 'com.android.support:support-annotations:24.1.1'
+  compile 'com.android.support:support-annotations:24.2.1'
   compile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
@gpeal 

the field won't be set if the model is using the default layout. Using the getter is the correct way to access the current layout.