### PR TITLE
Add test for classes in different package

### DIFF
--- a/epoxy-processor/src/test/java/com/airbnb/epoxy/TestModel.java
+++ b/epoxy-processor/src/test/java/com/airbnb/epoxy/TestModel.java
@@ -1,0 +1,12 @@
+package com.airbnb.epoxy;
+
+public class TestModel extends EpoxyModel<Object> {
+  @EpoxyAttribute public int publicValue;
+  @EpoxyAttribute protected int protectedValue;
+  @EpoxyAttribute int packagePrivateValue;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processor/src/test/java/com/airbnb/epoxy/testpackage/DifferentPackageTest.java
+++ b/epoxy-processor/src/test/java/com/airbnb/epoxy/testpackage/DifferentPackageTest.java
@@ -1,0 +1,25 @@
+package com.airbnb.epoxy.testpackage;
+
+import com.airbnb.epoxy.EpoxyAttribute;
+import com.airbnb.epoxy.TestModel;
+
+import org.junit.Test;
+
+/**
+ * A test to check that a model subclass in a different package from its super class does not
+ * include package private fields from its super class on its generated model.
+ */
+public class DifferentPackageTest {
+
+  @Test
+  public void differentPackageUsage() {
+    new DifferentPackageTest$Model_()
+        .publicValue(1)
+        .protectedValue(1)
+        .subclassValue(1);
+  }
+
+  public static class Model extends TestModel {
+    @EpoxyAttribute int subclassValue;
+  }
+}

--- a/epoxy-processor/src/test/resources/BasicModelWithAttribute_.java
+++ b/epoxy-processor/src/test/resources/BasicModelWithAttribute_.java
@@ -56,7 +56,7 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof BasicModelWithAttribute)) {
+    if (!(o instanceof BasicModelWithAttribute_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithAllFieldTypes_.java
+++ b/epoxy-processor/src/test/resources/ModelWithAllFieldTypes_.java
@@ -246,7 +246,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithAllFieldTypes)) {
+    if (!(o instanceof ModelWithAllFieldTypes_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processor/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
@@ -55,13 +55,15 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithAnnotatedClassAndSuperAttributes.SubModelWithAnnotatedClassAndSuperAttributes)) {
+    if (!(o instanceof ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_)) {
+
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-    ModelWithAnnotatedClassAndSuperAttributes.SubModelWithAnnotatedClassAndSuperAttributes that = (ModelWithAnnotatedClassAndSuperAttributes.SubModelWithAnnotatedClassAndSuperAttributes) o;
+    ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ that =
+        (ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_) o;
     if (superValue != that.superValue) {
       return false;
     }

--- a/epoxy-processor/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processor/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
@@ -55,13 +55,14 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithAnnotatedClassAndSuperAttributes)) {
+    if (!(o instanceof ModelWithAnnotatedClassAndSuperAttributes_)) {
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-    ModelWithAnnotatedClassAndSuperAttributes that = (ModelWithAnnotatedClassAndSuperAttributes) o;
+    ModelWithAnnotatedClassAndSuperAttributes_ that =
+        (ModelWithAnnotatedClassAndSuperAttributes_) o;
     if (superValue != that.superValue) {
       return false;
     }

--- a/epoxy-processor/src/test/resources/ModelWithAnnotatedClass_.java
+++ b/epoxy-processor/src/test/resources/ModelWithAnnotatedClass_.java
@@ -47,13 +47,13 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithAnnotatedClass)) {
+    if (!(o instanceof ModelWithAnnotatedClass_)) {
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-    ModelWithAnnotatedClass that = (ModelWithAnnotatedClass) o;
+    ModelWithAnnotatedClass_ that = (ModelWithAnnotatedClass_) o;
     return true;
   }
 

--- a/epoxy-processor/src/test/resources/ModelWithConstructors_.java
+++ b/epoxy-processor/src/test/resources/ModelWithConstructors_.java
@@ -63,7 +63,7 @@ public class ModelWithConstructors_ extends ModelWithConstructors {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithConstructors)) {
+    if (!(o instanceof ModelWithConstructors_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithFieldAnnotation_.java
+++ b/epoxy-processor/src/test/resources/ModelWithFieldAnnotation_.java
@@ -58,7 +58,7 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithFieldAnnotation)) {
+    if (!(o instanceof ModelWithFieldAnnotation_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithFinalField_.java
+++ b/epoxy-processor/src/test/resources/ModelWithFinalField_.java
@@ -50,7 +50,7 @@ public class ModelWithFinalField_ extends ModelWithFinalField {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithFinalField)) {
+    if (!(o instanceof ModelWithFinalField_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithIntDef_.java
+++ b/epoxy-processor/src/test/resources/ModelWithIntDef_.java
@@ -56,7 +56,7 @@ public class ModelWithIntDef_ extends ModelWithIntDef {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithIntDef)) {
+    if (!(o instanceof ModelWithIntDef_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
+++ b/epoxy-processor/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
@@ -64,13 +64,14 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithSuperAttributes.SubModelWithSuperAttributes)) {
+    if (!(o instanceof ModelWithSuperAttributes$SubModelWithSuperAttributes_)) {
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-    ModelWithSuperAttributes$SubModelWithSuperAttributes_ that = (ModelWithSuperAttributes$SubModelWithSuperAttributes_) o;
+    ModelWithSuperAttributes$SubModelWithSuperAttributes_ that =
+        (ModelWithSuperAttributes$SubModelWithSuperAttributes_) o;
     if (subValue != that.subValue) {
       return false;
     }

--- a/epoxy-processor/src/test/resources/ModelWithSuperAttributes_.java
+++ b/epoxy-processor/src/test/resources/ModelWithSuperAttributes_.java
@@ -55,7 +55,7 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithSuperAttributes)) {
+    if (!(o instanceof ModelWithSuperAttributes_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithSuper_.java
+++ b/epoxy-processor/src/test/resources/ModelWithSuper_.java
@@ -56,7 +56,7 @@ public class ModelWithSuper_ extends ModelWithSuper {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithSuper)) {
+    if (!(o instanceof ModelWithSuper_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithType.java
+++ b/epoxy-processor/src/test/resources/ModelWithType.java
@@ -14,7 +14,7 @@ public class ModelWithType<T extends String> extends EpoxyModel<Object> {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ModelWithType)) {
+    if (!(o instanceof ModelWithType_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithType_.java
+++ b/epoxy-processor/src/test/resources/ModelWithType_.java
@@ -56,7 +56,7 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithType)) {
+    if (!(o instanceof ModelWithType_)) {
       return false;
     }
     if (!super.equals(o)) {

--- a/epoxy-processor/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processor/src/test/resources/ModelWithoutHash_.java
@@ -64,7 +64,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelWithoutHash)) {
+    if (!(o instanceof ModelWithoutHash_)) {
       return false;
     }
     if (!super.equals(o)) {


### PR DESCRIPTION
@geralt-encore 

Adds a test for https://github.com/airbnb/epoxy/pull/44

Instead of using a processor this just uses a normal test and actual model class.

I also realized that in the equals method we changed the type to be the generated class in the cast, but not in the instance of check, which could cause crashes.