### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Epoxy is an Android library for building complex screens in a RecyclerView. It a
 <img alt="Sample app demo gif" src="https://github.com/airbnb/epoxy/raw/master/epoxy-sample/epoxy_sample_app.gif" width="200" height="354" />
 </p>
 
-## Download
+## Installation
 
 Gradle is the only supported build configuration, so just add the dependency to your project `build.gradle` file:
 


### PR DESCRIPTION
## Problem
A link to installation section in table of contents is broken because the link's anchor name(Installation) is not same with target section title(Download).

## Solution
Change the section title to "Installation"