### PR TITLE
Cleanup after using actual names instead of paramN

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.2'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ClassToGenerateInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ClassToGenerateInfo.java
@@ -136,13 +136,12 @@ public class ClassToGenerateInfo {
   private List<ParameterSpec> buildParamList(List<? extends VariableElement> params) {
     List<ParameterSpec> result = new ArrayList<>();
 
-    // We don't know the name of the variable, just the type. So just use generic parameter names
-    int paramCount = 1;
     for (VariableElement param : params) {
       result.add(ParameterSpec.builder(TypeName.get(param.asType()),
-          param.getSimpleName().toString()).build());
-      paramCount++;
+          param.getSimpleName().toString())
+          .build());
     }
+
     return result;
   }
 


### PR DESCRIPTION
Also, I tried to implement your idea about getting rid of specific layout method implementation, but for some reason, if a parameter is annotated then I am getting just generic `arg0` name instead of the actual `layoutRes` parameter name. You can try to investigate with it if you want.