### PR TITLE
Getting rid of layout method corner case

### DIFF
--- a/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
+++ b/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
@@ -29,8 +29,8 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute {
   }
 
   @Override
-  public BasicModelWithAttribute_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public BasicModelWithAttribute_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
@@ -48,8 +48,8 @@ public class ModelReturningClassType_ extends ModelReturningClassType {
   }
 
   @Override
-  public ModelReturningClassType_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelReturningClassType_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
@@ -218,8 +218,8 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes {
   }
 
   @Override
-  public ModelWithAllFieldTypes_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithAllFieldTypes_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
@@ -28,8 +28,8 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
   }
 
   @Override
-  public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
@@ -28,8 +28,8 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
   }
 
   @Override
-  public ModelWithAnnotatedClassAndSuperAttributes_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithAnnotatedClassAndSuperAttributes_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
@@ -20,8 +20,8 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass {
   }
 
   @Override
-  public ModelWithAnnotatedClass_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithAnnotatedClass_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
@@ -36,8 +36,8 @@ public class ModelWithConstructors_ extends ModelWithConstructors {
   }
 
   @Override
-  public ModelWithConstructors_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithConstructors_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
@@ -30,8 +30,8 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation {
   }
 
   @Override
-  public ModelWithFieldAnnotation_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithFieldAnnotation_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
@@ -23,8 +23,8 @@ public class ModelWithFinalField_ extends ModelWithFinalField {
   }
 
   @Override
-  public ModelWithFinalField_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithFinalField_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
@@ -29,8 +29,8 @@ public class ModelWithIntDef_ extends ModelWithIntDef {
   }
 
   @Override
-  public ModelWithIntDef_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithIntDef_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
@@ -37,8 +37,8 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
   }
 
   @Override
-  public ModelWithSuperAttributes$SubModelWithSuperAttributes_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithSuperAttributes$SubModelWithSuperAttributes_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
@@ -28,8 +28,8 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes {
   }
 
   @Override
-  public ModelWithSuperAttributes_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithSuperAttributes_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithSuper_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuper_.java
@@ -29,8 +29,8 @@ public class ModelWithSuper_ extends ModelWithSuper {
   }
 
   @Override
-  public ModelWithSuper_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithSuper_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithType_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithType_.java
@@ -28,8 +28,8 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> {
   }
 
   @Override
-  public ModelWithType_<T> layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithType_<T> layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
@@ -46,8 +46,8 @@ public class ModelWithoutHash_ extends ModelWithoutHash {
   }
 
   @Override
-  public ModelWithoutHash_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithoutHash_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
@@ -24,8 +24,8 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter {
   }
 
   @Override
-  public ModelWithoutSetter_ layout(@LayoutRes int layout) {
-    super.layout(layout);
+  public ModelWithoutSetter_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
     return this;
   }
 


### PR DESCRIPTION
Despite the fact that with this solution we are losing `layout` method parameter name I still think that it is an overall improvement. The logic behind it became considerably simpler and it's always nice to avoid a corner case with more general solution.