### PR TITLE
Generate model for abstract class if class annotation is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Epoxy is an Android library for building complex screens in a RecyclerView. It a
 * [Modifying the Models List](#models-list)
 * [Automatic Diffing](#diffing)
 * [Binding Models](#binding-models)
+* [Avoiding Memory Leaks](#memory-leaks)
 * [Using View Holders](#view-holders)
 * [Model IDs](#model-ids)
 * [Specifying Layouts](#specifying-layouts)
@@ -210,6 +211,46 @@ When the view is recycled, `EpoxyAdapter` will call `EpoxyModel#unbind(View)`, g
 Since RecyclerView reuses views when possible, a view may be bound multiple times, without `unbind` necessarily being called in between. You should make sure that your usage of `EpoxyModel#bind(View)` completely updates the view according to the data in your model.
 
 If the recycler view provided a non empty list of payloads with `onBindViewHolder(ViewHolder holder, int position, List<Object> payloads)`, then `EpoxyModel#bind(View, List<Object>)` will be called instead so that the model can be optimized to rebind according to what changed. This can help you prevent unnecessary layout changes if only part of the view changed.
+
+## <a name="memory-leaks"/>Avoiding Memory Leaks
+There are two possible memory leaks if you reuse an adapter with different RecyclerViews. A common case of this is creating and saving an adapter as a field in a Fragment's `onCreate` method, and reusing it across multiple view creation/destroy cycles if the fragment is put on the backstack or has its instance retained across rotation.
+
+#### Child Views
+
+Epoxy holds a reference to every bound view in order to allow state saving. To prevent leaking these, simply make sure the RecyclerView recycles all of its child views when you are done with it. One way to do this is to detach the adapter from the RecyclerView via `recyclerView.setAdapter(null)` (possibly in a fragment's `onDestroyView` method).
+
+The downside to this approach is that the view is immediately cleared, so if you are animating your screen out it will go blank before the animation finishes. A better option that avoids this is to have your `LayoutManager` recycle its children when the RecyclerView is detached from the window. `LinearLayoutManager` and `GridLayoutManager` will do this for you if you enable `setRecycleChildrenOnDetach(true)`.
+
+To automatically apply this you may wish to create a base adapter in your project that extends EpoxyAdapter.
+
+```java
+public class BaseAdapter extends EpoxyAdapter {
+
+        @Override
+        public void onAttachedToRecyclerView(RecyclerView recyclerView) {
+
+            // This will force all models to be unbound and their views recycled once the RecyclerView is no longer in use. We need this so resources
+            // are properly released, listeners are detached, and views can be returned to view pools (if applicable).
+            if (recyclerView.getLayoutManager() instanceof LinearLayoutManager) {
+                ((LinearLayoutManager) recyclerView.getLayoutManager()).setRecycleChildrenOnDetach(true);
+            }
+        }
+    }
+```
+
+#### Parent View
+
+Another, very similar, issue leaks a reference to the RecyclerView itself. This case is intrinsic to all RecyclerView adapters, not just Epoxy.
+
+The case where this happens is the same as above, when an adapter is kept after the RecyclerView is destroyed. When an adapter is set on a RecyclerView the RecyclerView registers an observer to listen for adapter item changes (`adapter.registerAdapterDataObserver(...)`). This is needed for the RecyclerView to know when adapter items have changed.
+
+This observer is only removed when the adapter is detached from the RecyclerView (eg `recyclerView.setAdapter(null)`). With the common pattern of recreating a view in a fragment it is easy to not do this.
+
+One option to avoid this is to detach your adapter when destroying the RecyclerView. This has the downside of immediately clearing the view as mentioned above.
+
+The other option is to clear the reference to your adapter and create a new one each time you create a new RecyclerView.
+
+It is easy to forget to do this though, and is hard to enforce in the project. I haven't found a better automated solution to this issue. Let me know if you have ideas!
 
 ## <a name="view-holders"/>Using View Holders
 

--- a/README.md
+++ b/README.md
@@ -255,33 +255,11 @@ public class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
 }
 ```
 
-Alternatively you can leave your model class abstract, annotate it with `@EpoxyClassModel` (see [Generating Helper Classes For Models](#annotations)), and not implement the `createNewHolder`. In this case a subclass will be generated that implements the method for you. This implementation will simply create a new instance of your Holder class by calling the no argument constructor, which is the same as what is implemented manually in the example above. This simplified approach would look like:
+Alternatively you can allow Epoxy's annotation processor to generate the `createNewHolder` method for you, reducing the boilerplate in your model.
 
+Just leave your model class abstract, annotate it with `@EpoxyClassModel` (see [Generating Helper Classes For Models](#annotations)), and don't implement the `createNewHolder`. A subclass will be generated that implements the method for you. This implementation will create a new instance of your Holder class by calling the no argument constructor, which is the same as what is implemented manually in the example above.
 
-```java
-  @EpoxyModelClass
-  public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
-    @EpoxyAttribute @StringRes int text;
-    @EpoxyAttribute OnClickListener clickListener;
-
-    @Override
-    protected int getDefaultLayout() {
-      return R.layout.model_button;
-    }
-
-    @Override
-    public void bind(ButtonHolder holder) {
-      holder.button.setText(text);
-      holder.button.setOnClickListener(clickListener);
-    }
-  }
-```
-  
-
-
-Another good pattern is to create a base Holder class that all view holders in your app can extend. Your base class can use [ButterKnife](https://github.com/JakeWharton/butterknife) to bind its view so that subclasses don't explicitly need to.
-
-It terms of our example from above this might look like:
+Another helpful pattern is to create a base Holder class that all view holders in your app can extend. Your base class can use [ButterKnife](https://github.com/JakeWharton/butterknife) to bind its view so that subclasses don't explicitly need to.
 
 ```java
 public abstract class BaseEpoxyHolder extends EpoxyHolder {
@@ -291,9 +269,30 @@ public abstract class BaseEpoxyHolder extends EpoxyHolder {
     ButterKnife.bind(this, itemView);
   }
 }
+```
 
-static class ButtonHolder extends BaseEpoxyHolder {
+Applying these two patterns helps shorten our example model to just:
+
+```java
+@EpoxyModelClass
+public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
+  @EpoxyAttribute @StringRes int text;
+  @EpoxyAttribute OnClickListener clickListener;
+
+  @Override
+  protected int getDefaultLayout() {
+    return R.layout.model_button;
+  }
+
+  @Override
+  public void bind(ButtonHolder holder) {
+    holder.button.setText(text);
+    holder.button.setOnClickListener(clickListener);
+  }
+
+  static class ButtonHolder extends BaseEpoxyHolder {
     @BindView(R.id.button) Button button;
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,11 @@ public class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
 
 Alternatively you can allow Epoxy's annotation processor to generate the `createNewHolder` method for you, reducing the boilerplate in your model.
 
-Just leave your model class abstract, annotate it with `@EpoxyClassModel` (see [Generating Helper Classes For Models](#annotations)), and don't implement the `createNewHolder`. A subclass will be generated that implements the method for you. This implementation will create a new instance of your Holder class by calling the no argument constructor, which is the same as what is implemented manually in the example above.
+Just leave your model class abstract, annotate it with `@EpoxyClassModel` (see [Generating Helper Classes For Models](#annotations)), and don't implement `createNewHolder`. A subclass will be generated that implements the method for you. This implementation will create a new instance of your Holder class by calling the no argument constructor, which is the same as what is implemented manually in the example above.
 
 Another helpful pattern is to create a base Holder class that all view holders in your app can extend. Your base class can use [ButterKnife](https://github.com/JakeWharton/butterknife) to bind its view so that subclasses don't explicitly need to.
+
+For example your base class may look like this:
 
 ```java
 public abstract class BaseEpoxyHolder extends EpoxyHolder {
@@ -428,7 +430,7 @@ models.add(new HeaderModel_()
 ```
 
 The setters return the model so that they can be used in a builder style. The generated class includes a `hashCode()` implementation for all of the annotated attributes so that the model can be used in [automatic diffing](#diffing).
-Sometimes, you may not want certain fields, such as a click listener, to be included in your hashCode and equals methods since that field may be change on every bind call. To tell Epoxy to skip that field, add `hash=false` to the annotation.
+Sometimes, you may not want certain fields, such as a click listener, to be included in your hashCode and equals methods since that field may change on every bind call. Add `hash=false` to the annotation to tell Epoxy to skip that field.
 
 The generated class will always be the name of the original class with an underscore appended at the end. If a model class is subclassed from other models that also have EpoxyAttributes, the generated class will include all of the super classes' attributes. The generated class will duplicate any constructors on the original model class. The generated class will also duplicate any methods that have a return type of the model class. The goal of that is to help with chaining calls to methods that exist on the original class. `super` will be called in all of these generated methods.
 

--- a/README.md
+++ b/README.md
@@ -369,9 +369,12 @@ Sometimes, you may not want certain fields, such as a click listener, to be incl
 The generated class will always be the name of the original class with an underscore appended at the end. If a model class is subclassed from other models that also have EpoxyAttributes, the generated class will include all of the super classes' attributes. The generated class will duplicate any constructors on the original model class. The generated class will also duplicate any methods that have a return type of the model class. The goal of that is to help with chaining calls to methods that exist on the original class. `super` will be called in all of these generated methods.
 
 If the original class is abstract then a class will not be generated for it by default. However, an `@EpoxyModelClass` annotation may be added on the class to force a subclass to be generated. There are several cases where this may be helful.
-1. Having your model class be abstract signals to other developers that the class should not be instantiated directly, and that the generated model should be instantiated instead. This may prevent accidentally instantiating the base class instead of the generated class. For larger projects this can be a good pattern to use for all models.
+
+1. Having your model class be abstract signals to other developers that the class should not be instantiated directly, and that the generated model should be used instead. This may prevent accidentally instantiating the base class instead of the generated class. For larger projects this can be a good pattern to establish for all models.
+
 2. If a class does not have any `@EpoxyAttribute` annotations itself, but one of its super classes does, it would not normally have a class generated for it. Using `@EpoxyModelClass` on the subclass is the only way to generate a model in that case.
-3. If you are using `EpoxyModelWithHolder` (see [Using View Holders](#view-holders)) you can leave the `createNewHolder` method unimplemented and the generated class will contain a default implementation to instantiate a new holder with a no argument constructor.
+
+3. If you are using `EpoxyModelWithHolder` (see [Using View Holders](#view-holders)) you can leave the `createNewHolder` method unimplemented and the generated class will contain a default implementation that creates a new holder by calling a no argument constructor of the holder class.
 
 These annotations are an optional aspect of Epoxy that you may choose not to use, but they can be helpful in reducing the boilerplate in your models.
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,31 @@ public class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
 }
 ```
 
-A good pattern is to create a base class that all view holders in your app can extend. Your base class can use [ButterKnife](https://github.com/JakeWharton/butterknife) to bind its view so that subclasses don't explicitly need to.
+Alternatively you can leave your model class abstract, annotate it with `@EpoxyClassModel` (see [Generating Helper Classes For Models](#annotations)), and not implement the `createNewHolder`. In this case a subclass will be generated that implements the method for you. This implementation will simply create a new instance of your Holder class by calling the no argument constructor, which is the same as what is implemented manually in the example above. This simplified approach would look like:
+
+
+```java
+  @EpoxyModelClass
+  public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
+    @EpoxyAttribute @StringRes int text;
+    @EpoxyAttribute OnClickListener clickListener;
+
+    @Override
+    protected int getDefaultLayout() {
+      return R.layout.model_button;
+    }
+
+    @Override
+    public void bind(ButtonHolder holder) {
+      holder.button.setText(text);
+      holder.button.setOnClickListener(clickListener);
+    }
+  }
+```
+  
+
+
+Another good pattern is to create a base Holder class that all view holders in your app can extend. Your base class can use [ButterKnife](https://github.com/JakeWharton/butterknife) to bind its view so that subclasses don't explicitly need to.
 
 It terms of our example from above this might look like:
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -287,10 +287,11 @@ public abstract class EpoxyModel<T> {
 
   @Override
   public String toString() {
-    return "{" + getClass().getSimpleName()
-        + "id=" + id
-        + ", layout=" + getLayout()
-        + ", shown=" + shown
-        + '}';
+    return getClass().getSimpleName() + "{" +
+        "id=" + id +
+        ", layout=" + getLayout() +
+        ", shown=" + shown +
+        ", addedToAdapter=" + addedToAdapter +
+        '}';
   }
 }

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyModelClass.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyModelClass.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate {@link EpoxyModel} classes in order to generate a
+ * Used to annotate EpoxyModel classes in order to generate a
  * subclass of that model with getters, setters, equals, and hashcode for the annotated fields.
  */
 @Target(ElementType.TYPE)

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
@@ -1,0 +1,168 @@
+package com.airbnb.epoxy;
+
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.TypeName;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+
+class ProcessorUtils {
+
+  static final String EPOXY_MODEL_TYPE = "com.airbnb.epoxy.EpoxyModel<?>";
+  static final String EPOXY_MODEL_HOLDER_TYPE = "com.airbnb.epoxy.EpoxyModelWithHolder<?>";
+
+  static boolean isEpoxyModel(TypeMirror type) {
+    return isSubtypeOfType(type, EPOXY_MODEL_TYPE);
+  }
+
+  static boolean isEpoxyModelWithHolder(TypeElement type) {
+    return isSubtypeOfType(type.asType(), EPOXY_MODEL_HOLDER_TYPE);
+  }
+
+  static boolean isSubtypeOfType(TypeMirror typeMirror, String otherType) {
+    if (otherType.equals(typeMirror.toString())) {
+      return true;
+    }
+    if (typeMirror.getKind() != TypeKind.DECLARED) {
+      return false;
+    }
+    DeclaredType declaredType = (DeclaredType) typeMirror;
+    List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
+    if (typeArguments.size() > 0) {
+      StringBuilder typeString = new StringBuilder(declaredType.asElement().toString());
+      typeString.append('<');
+      for (int i = 0; i < typeArguments.size(); i++) {
+        if (i > 0) {
+          typeString.append(',');
+        }
+        typeString.append('?');
+      }
+      typeString.append('>');
+      if (typeString.toString().equals(otherType)) {
+        return true;
+      }
+    }
+    Element element = declaredType.asElement();
+    if (!(element instanceof TypeElement)) {
+      return false;
+    }
+    TypeElement typeElement = (TypeElement) element;
+    TypeMirror superType = typeElement.getSuperclass();
+    if (isSubtypeOfType(superType, otherType)) {
+      return true;
+    }
+    for (TypeMirror interfaceType : typeElement.getInterfaces()) {
+      if (isSubtypeOfType(interfaceType, otherType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @return True if the clazz (or one of its superclasses) implements the given method. Returns
+   * false if the method doesn't exist anywhere in the class hierarchy or it is abstract.
+   */
+  static boolean implementsMethod(TypeElement clazz, MethodSpec method, Types typeUtils) {
+    ExecutableElement methodOnClass = getMethodOnClass(clazz, method, typeUtils);
+
+    if (methodOnClass == null) {
+      return false;
+    }
+
+    Set<Modifier> modifiers = methodOnClass.getModifiers();
+    return !modifiers.contains(Modifier.ABSTRACT);
+  }
+
+  static TypeMirror getMethodReturnType(TypeElement clazz, MethodSpec method, Types typeUtils) {
+    ExecutableElement methodOnClass = getMethodOnClass(clazz, method, typeUtils);
+
+    if (methodOnClass == null) {
+      return null;
+    }
+
+    return methodOnClass.getReturnType();
+  }
+
+  /**
+   * @return The first element matching the given method in the class's hierarchy, or null if there
+   * is no match.
+   */
+  static ExecutableElement getMethodOnClass(TypeElement clazz, MethodSpec method, Types typeUtils) {
+    if (clazz.asType().getKind() != TypeKind.DECLARED) {
+      return null;
+    }
+
+    for (Element subElement : clazz.getEnclosedElements()) {
+      if (subElement.getKind() == ElementKind.METHOD) {
+        ExecutableElement methodElement = ((ExecutableElement) subElement);
+        if (!methodElement.getSimpleName().toString().equals(method.name)) {
+          continue;
+        }
+
+        if (!areParamsTheSame(methodElement, method)) {
+          continue;
+        }
+
+        return methodElement;
+      }
+    }
+
+    TypeElement superClazz = (TypeElement) typeUtils.asElement(clazz.getSuperclass());
+    return getMethodOnClass(superClazz, method, typeUtils);
+  }
+
+  private static boolean areParamsTheSame(ExecutableElement method1, MethodSpec method2) {
+    List<? extends VariableElement> params1 = method1.getParameters();
+    List<ParameterSpec> params2 = method2.parameters;
+
+    if (params1.size() != params2.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < params1.size(); i++) {
+      VariableElement param1 = params1.get(i);
+      ParameterSpec param2 = params2.get(i);
+
+      if (!TypeName.get(param1.asType()).equals(param2.type)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns the type of the Epoxy model.
+   * <p>
+   * Eg for "class MyModel extends EpoxyModel<TextView>" it would return TextView.
+   */
+  static TypeMirror getEpoxyObjectType(TypeElement clazz, Types typeUtils) {
+    if (clazz.asType().getKind() != TypeKind.DECLARED) {
+      return null;
+    }
+
+    DeclaredType superclass = (DeclaredType) clazz.getSuperclass();
+    List<? extends TypeMirror> superTypeArguments = superclass.getTypeArguments();
+
+    if (superTypeArguments.isEmpty()) {
+      return getEpoxyObjectType((TypeElement) typeUtils.asElement(superclass), typeUtils);
+    }
+
+    // TODO: (eli_hart 2/2/17) If the class added additional types this won't be correct. That
+    // should be rare, but it would be nice to handle.
+    return superTypeArguments.get(0);
+  }
+}

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
@@ -8,6 +8,7 @@ import javax.tools.JavaFileObject;
 
 import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static junit.framework.Assert.assertTrue;
 
 /**
  * These processor tests are in their own module since the processor module can't depend on the
@@ -254,6 +255,44 @@ public class EpoxyProcessorTest {
   }
 
   @Test
+  public void testModelWithAbstractClass() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelWithAbstractClass.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+
+    // We don't generate subclasses if the model is abstract unless it has a class annotation.
+    boolean modelNotGenerated;
+    try {
+      JavaFileObject generatedModel = JavaFileObjects.forResource("ModelWithAbstractClass_.java");
+      modelNotGenerated = false;
+    } catch (IllegalArgumentException e) {
+      modelNotGenerated = true;
+    }
+
+    assertTrue(modelNotGenerated);
+  }
+
+  @Test
+  public void testModelWithAbstractClassAndAnnotation() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelWithAbstractClassAndAnnotation.java");
+
+    JavaFileObject generatedModel =
+        JavaFileObjects.forResource("ModelWithAbstractClassAndAnnotation_.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
+  }
+
+  @Test
   public void testModelWithAnnotatedClassAndSuperClass() {
     JavaFileObject model = JavaFileObjects
         .forResource("ModelWithAnnotatedClassAndSuperAttributes.java");
@@ -325,6 +364,22 @@ public class EpoxyProcessorTest {
 
     JavaFileObject generatedModel = JavaFileObjects
         .forResource("ModelWithVarargsConstructors_.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
+  }
+
+  @Test
+  public void testModelWithHolderGeneratesNewHolderMethod() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("AbstractModelWithHolder.java");
+
+    JavaFileObject generatedModel = JavaFileObjects
+        .forResource("AbstractModelWithHolder_.java");
 
     assert_().about(javaSource())
         .that(model)

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder.java
@@ -1,0 +1,20 @@
+package com.airbnb.epoxy;
+
+import android.view.View;
+
+@EpoxyModelClass
+public abstract class AbstractModelWithHolder extends EpoxyModelWithHolder<AbstractModelWithHolder.Holder> {
+  @EpoxyAttribute int value;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+
+  static class Holder extends EpoxyHolder {
+
+    protected void bindView(View itemView){
+
+    }
+  }
+}

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
@@ -1,0 +1,98 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+
+/**
+ * Generated file. Do not modify!
+ */
+public class AbstractModelWithHolder_ extends AbstractModelWithHolder {
+  public AbstractModelWithHolder_() {
+    super();
+  }
+
+  public AbstractModelWithHolder_ value(int value) {
+    this.value = value;
+    return this;
+  }
+
+  public int value() {
+    return value;
+  }
+
+  @Override
+  public AbstractModelWithHolder_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public AbstractModelWithHolder_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
+    return this;
+  }
+
+  @Override
+  public AbstractModelWithHolder_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public AbstractModelWithHolder_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public AbstractModelWithHolder_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  protected AbstractModelWithHolder.Holder createNewHolder() {
+    return new AbstractModelWithHolder.Holder();
+  }
+
+  @Override
+  public AbstractModelWithHolder_ reset() {
+    this.value = 0;
+    super.reset();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof AbstractModelWithHolder_)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    AbstractModelWithHolder_ that = (AbstractModelWithHolder_) o;
+    if (value != that.value) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + value;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "AbstractModelWithHolder_{" +
+        "value=" + value +
+        "}" + super.toString();
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelWithAbstractClass.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAbstractClass.java
@@ -1,0 +1,9 @@
+package com.airbnb.epoxy;
+
+public abstract class ModelWithAbstractClass extends EpoxyModel<Object> {
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation.java
@@ -1,0 +1,10 @@
+package com.airbnb.epoxy;
+
+@EpoxyModelClass
+public abstract class ModelWithAbstractClassAndAnnotation extends EpoxyModel<Object> {
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
@@ -1,0 +1,78 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+
+/**
+ * Generated file. Do not modify!
+ */
+public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClassAndAnnotation {
+  public ModelWithAbstractClassAndAnnotation_() {
+    super();
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
+    return this;
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ reset() {
+    super.reset();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof ModelWithAbstractClassAndAnnotation_)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    ModelWithAbstractClassAndAnnotation_ that = (ModelWithAbstractClassAndAnnotation_) o;
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ModelWithAbstractClassAndAnnotation_{" +
+        "}" + super.toString();
+  }
+}

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
@@ -5,6 +5,7 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 
 import com.airbnb.epoxy.EpoxyAttribute;
+import com.airbnb.epoxy.EpoxyModelClass;
 import com.airbnb.epoxy.EpoxyModelWithHolder;
 import com.airbnb.epoxy.R;
 import com.airbnb.epoxy.models.ButtonModel.ButtonHolder;
@@ -12,7 +13,8 @@ import com.airbnb.epoxy.models.ButtonModel.ButtonHolder;
 import butterknife.BindView;
 
 /** This model class gives an example of how to use a view holder pattern with your models. */
-public class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
+@EpoxyModelClass
+public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
   @EpoxyAttribute @StringRes int text;
   @EpoxyAttribute OnClickListener clickListener;
 
@@ -30,11 +32,6 @@ public class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
   public void bind(ButtonHolder holder) {
     holder.button.setText(text);
     holder.button.setOnClickListener(clickListener);
-  }
-
-  @Override
-  protected ButtonHolder createNewHolder() {
-    return new ButtonHolder();
   }
 
   static class ButtonHolder extends BaseEpoxyHolder {


### PR DESCRIPTION
@felipecsl @gpeal @seanabraham 

This forces the annotation processor to generate a model for abstract model classes if they have the `@EpoxyClassModel` attribute. Previously abstract classes never had a model generated for them since we couldn't know if they implemented every necessary method. This annotation approach allows users to tell the processor if they want a model generated.

We may like to use an abstract class for all our models to indicate that they shouldn't be instantiated directly, and to prevent people from accidentally using them instead of the generated class.

In this PR I also add a new feature to automatically generate the `createNewHolder` method on models that use view holders. This method was mostly boilerplate and we can generate it by looking at the type of the class and just returning a new object of that type.

For example, in our sample app we now have the class
```
@EpoxyModelClass
public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
```
This is a small win to reduce boilerplate.

Besides that I did some cleanup - moving util methods to a ProcessorUtils class - and a little other refactoring clean up since the processor is getting large and more complicated.