### PR TITLE
Allow string ids

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -87,6 +87,76 @@ public abstract class EpoxyModel<T> {
     return this;
   }
 
+  /**
+   * Use a string as the model id. Useful for models that don't clearly map to a numerical id. This
+   * is preferable to using {@link String#hashCode()} because that is a 32 bit hash and this is a 64
+   * bit hash, giving better spread and less chance of collision with other ids.
+   * <p>
+   * Since this uses a hashcode method to convert the String to a long there is a very small
+   * chance that you may have a collision with another id. Assuming an even spread of hashcodes, and
+   * several hundred models in the adapter, there would be roughly 1 in 100 trillion chance of a
+   * collision. (http://preshing.com/20110504/hash-collision-probabilities/)
+   *
+   * @see EpoxyModel#hashString64Bit(CharSequence)
+   */
+  public EpoxyModel<T> id(CharSequence key) {
+    id(hashString64Bit(key));
+    return this;
+  }
+
+  /**
+   * Set an id that is namespaced with a string. This is useful when you need to show models of
+   * multiple types, side by side and don't want to risk id collisions.
+   * <p>
+   * Since this uses a hashcode method to convert the String to a long there is a very small chance
+   * that you may have a collision with another id. Assuming an even spread of hashcodes, and
+   * several hundred models in the adapter, there would be roughly 1 in 100 trillion chance of a
+   * collision. (http://preshing.com/20110504/hash-collision-probabilities/)
+   *
+   * @see EpoxyModel#hashString64Bit(CharSequence)
+   * @see EpoxyModel#hashLong64Bit(long)
+   */
+  public EpoxyModel<T> id(CharSequence key, long id) {
+    long result = hashString64Bit(key);
+    result = 31 * result + hashLong64Bit(id);
+    id(result);
+    return this;
+  }
+
+  /**
+   * Hash a long into 64 bits instead of the normal 32. This uses a xor shift implementation to
+   * attempt psuedo randomness so object ids have an even spread for less chance of collisions.
+   * <p>
+   * From http://stackoverflow.com/a/11554034
+   * <p>
+   * http://www.javamex.com/tutorials/random_numbers/xorshift.shtml
+   */
+  private static long hashLong64Bit(long value) {
+    value ^= (value << 21);
+    value ^= (value >>> 35);
+    value ^= (value << 4);
+    return value;
+  }
+
+  /**
+   * Hash a string into 64 bits instead of the normal 32. This allows us to better use strings as a
+   * model id with less chance of collisions. This uses the FNV-1a algorithm for a good mix of speed
+   * and distribution.
+   * <p>
+   * Performance comparisons found at http://stackoverflow.com/a/1660613
+   * <p>
+   * Hash implementation from http://www.isthe.com/chongo/tech/comp/fnv/index.html#FNV-1a
+   */
+  private static long hashString64Bit(CharSequence str) {
+    long result = 0xcbf29ce484222325L;
+    final int len = str.length();
+    for (int i = 0; i < len; i++) {
+      result ^= str.charAt(i);
+      result *= 0x100000001b3L;
+    }
+    return result;
+  }
+
   @LayoutRes
   protected abstract int getDefaultLayout();
 

--- a/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
+++ b/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -25,6 +26,18 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute {
   @Override
   public BasicModelWithAttribute_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public BasicModelWithAttribute_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public BasicModelWithAttribute_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -37,6 +38,18 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
   @Override
   public ModelReturningClassTypeWithVarargs_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelReturningClassTypeWithVarargs_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelReturningClassTypeWithVarargs_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -44,6 +45,18 @@ public class ModelReturningClassType_ extends ModelReturningClassType {
   @Override
   public ModelReturningClassType_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelReturningClassType_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelReturningClassType_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
@@ -3,6 +3,7 @@ package com.airbnb.epoxy;
 import android.support.annotation.LayoutRes;
 import java.lang.Boolean;
 import java.lang.Byte;
+import java.lang.CharSequence;
 import java.lang.Character;
 import java.lang.Double;
 import java.lang.Float;
@@ -214,6 +215,18 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes {
   @Override
   public ModelWithAllFieldTypes_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithAllFieldTypes_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithAllFieldTypes_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -24,6 +25,18 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
   @Override
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -24,6 +25,18 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
   @Override
   public ModelWithAnnotatedClassAndSuperAttributes_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithAnnotatedClassAndSuperAttributes_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithAnnotatedClassAndSuperAttributes_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -16,6 +17,18 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass {
   @Override
   public ModelWithAnnotatedClass_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithAnnotatedClass_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithAnnotatedClass_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -32,6 +33,18 @@ public class ModelWithConstructors_ extends ModelWithConstructors {
   @Override
   public ModelWithConstructors_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithConstructors_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithConstructors_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
@@ -2,6 +2,7 @@ package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -26,6 +27,18 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation {
   @Override
   public ModelWithFieldAnnotation_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithFieldAnnotation_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithFieldAnnotation_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -19,6 +20,18 @@ public class ModelWithFinalField_ extends ModelWithFinalField {
   @Override
   public ModelWithFinalField_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithFinalField_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithFinalField_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy.models;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -25,6 +26,18 @@ public class ModelWithIntDef_ extends ModelWithIntDef {
   @Override
   public ModelWithIntDef_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithIntDef_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithIntDef_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -33,6 +34,18 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
   @Override
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithSuperAttributes$SubModelWithSuperAttributes_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithSuperAttributes$SubModelWithSuperAttributes_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -24,6 +25,18 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes {
   @Override
   public ModelWithSuperAttributes_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithSuperAttributes_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithSuperAttributes_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithSuper_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuper_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -25,6 +26,18 @@ public class ModelWithSuper_ extends ModelWithSuper {
   @Override
   public ModelWithSuper_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithSuper_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithSuper_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithType_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithType_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -24,6 +25,18 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> {
   @Override
   public ModelWithType_<T> id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithType_<T> id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithType_<T> id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -38,6 +39,18 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
   @Override
   public ModelWithVarargsConstructors_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithVarargsConstructors_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithVarargsConstructors_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -42,6 +43,18 @@ public class ModelWithoutHash_ extends ModelWithoutHash {
   @Override
   public ModelWithoutHash_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithoutHash_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithoutHash_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -20,6 +21,18 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter {
   @Override
   public ModelWithoutSetter_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithoutSetter_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithoutSetter_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 


### PR DESCRIPTION
@gpeal @felipecsl @seanabraham 

Internally we've been using this for a while and it has worked well for us. I was a bit reluctant to officially release this since a hash collision would break the adapter, but there isn't a better solution in some cases, and the chance of a collision is exceedingly small. This is better than people doing string.hashcode() on their own :P