### PR TITLE
Allow default layout res to be specified in class annotation

### DIFF
--- a/epoxy-annotations/build.gradle
+++ b/epoxy-annotations/build.gradle
@@ -3,9 +3,24 @@ apply plugin: 'java'
 sourceCompatibility = rootProject.JAVA_SOURCE_VERSION
 targetCompatibility = rootProject.JAVA_TARGET_VERSION
 
+// Hack to allow us to use android support library annotations (@LayoutRes) in this project.
+// Since this isn't an android module normally we couldn't access them otherwise.
+// Taken from https://github.com/JakeWharton/butterknife/pull/380
+def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
+def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
+for (File file : sdkHandler.sdkLoader.repositories) {
+  repositories.maven {
+    url = file.toURI()
+  }
+}
+
 checkstyle {
   configFile rootProject.file('checkstyle.xml')
   showViolations true
+}
+
+dependencies {
+  compile rootProject.deps.androidAnnotations
 }
 
 apply from: rootProject.file('gradle/gradle-maven-push.gradle')

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyModelClass.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyModelClass.java
@@ -1,16 +1,24 @@
 
 package com.airbnb.epoxy;
 
+import android.support.annotation.LayoutRes;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate EpoxyModel classes in order to generate a
- * subclass of that model with getters, setters, equals, and hashcode for the annotated fields.
+ * Used to annotate EpoxyModel classes in order to generate a subclass of that model with getters,
+ * setters, equals, and hashcode for the annotated fields, as well as other helper methods and
+ * boilerplate reduction.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
 public @interface EpoxyModelClass {
+  /**
+   * A layout resource that should be used as the default layout for the model. If you set this you
+   * don't have to implement `getDefaultLayout`; it will be generated for you.
+   */
+  @LayoutRes int value() default 0;
 }

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyModelClass.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyModelClass.java
@@ -20,5 +20,5 @@ public @interface EpoxyModelClass {
    * A layout resource that should be used as the default layout for the model. If you set this you
    * don't have to implement `getDefaultLayout`; it will be generated for you.
    */
-  @LayoutRes int value() default 0;
+  @LayoutRes int layout() default 0;
 }

--- a/epoxy-processor/build.gradle
+++ b/epoxy-processor/build.gradle
@@ -6,6 +6,17 @@ configurations.all { strategy ->
   strategy.resolutionStrategy.force rootProject.deps.assertj, rootProject.deps.googleTestingCompile
 }
 
+// Hack to allow us to use android support library annotations (@LayoutRes) in this project.
+// Since this isn't an android module normally we couldn't access them otherwise.
+// Taken from https://github.com/JakeWharton/butterknife/pull/380
+def logger = new com.android.build.gradle.internal.LoggerWrapper(project.logger)
+def sdkHandler = new com.android.build.gradle.internal.SdkHandler(project, logger)
+for (File file : sdkHandler.sdkLoader.repositories) {
+  repositories.maven {
+    url = file.toURI()
+  }
+}
+
 dependencies {
   compile deps.googleAutoService
   compile deps.squareJavaPoet

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -482,7 +482,7 @@ public class EpoxyProcessor extends AbstractProcessor {
           originalClassElement.getSimpleName());
     }
 
-    int layoutRes = annotation.value();
+    int layoutRes = annotation.layout();
     if (layoutRes == 0) {
       throwError("Model must specify a valid layout resource in the %s annotation. (class: %s)",
           EpoxyModelClass.class,

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -1,5 +1,7 @@
 package com.airbnb.epoxy;
 
+import android.support.annotation.LayoutRes;
+
 import com.airbnb.epoxy.ClassToGenerateInfo.ConstructorInfo;
 import com.airbnb.epoxy.ClassToGenerateInfo.MethodInfo;
 import com.google.auto.service.AutoService;
@@ -69,7 +71,9 @@ import static javax.lang.model.element.Modifier.STATIC;
 @AutoService(Processor.class)
 public class EpoxyProcessor extends AbstractProcessor {
 
-  public static final String CREATE_NEW_HOLDER_METHOD_NAME = "createNewHolder";
+  private static final String CREATE_NEW_HOLDER_METHOD_NAME = "createNewHolder";
+  private static final String GET_DEFAULT_LAYOUT_METHOD_NAME = "getDefaultLayout";
+
   private Filer filer;
   private Messager messager;
   private Elements elementUtils;
@@ -408,36 +412,88 @@ public class EpoxyProcessor extends AbstractProcessor {
    */
   private Iterable<MethodSpec> generateDefaultMethodImplementations(ClassToGenerateInfo info)
       throws EpoxyProcessorException {
+
     List<MethodSpec> methods = new ArrayList<>();
-
-    // If the model is a holder and doesn't implement the "createNewHolder" method we can
-    // generate a default implementation by getting the class type and creating a new instance
-    // of it.
     TypeElement originalClassElement = info.getOriginalClassElement();
-    if (isEpoxyModelWithHolder(originalClassElement)) {
 
-      MethodSpec createHolderMethod = MethodSpec.methodBuilder(CREATE_NEW_HOLDER_METHOD_NAME)
-          .addAnnotation(Override.class)
-          .addModifiers(Modifier.PROTECTED)
-          .build();
-
-      if (!implementsMethod(originalClassElement, createHolderMethod, typeUtils)) {
-        TypeMirror epoxyObjectType = getEpoxyObjectType(originalClassElement, typeUtils);
-
-        if (epoxyObjectType == null) {
-          throwError("Return type for createNewHolder method could not be found");
-        }
-
-        createHolderMethod = createHolderMethod.toBuilder()
-            .returns(TypeName.get(epoxyObjectType))
-            .addStatement("return new $T()", epoxyObjectType)
-            .build();
-
-        methods.add(createHolderMethod);
-      }
-    }
+    addCreateHolderMethodIfNeeded(originalClassElement, methods);
+    addDefaultLayoutMethodIfNeeded(originalClassElement, methods);
 
     return methods;
+  }
+
+  /**
+   * If the model is a holder and doesn't implement the "createNewHolder" method we can generate a
+   * default implementation by getting the class type and creating a new instance of it.
+   */
+  private void addCreateHolderMethodIfNeeded(TypeElement originalClassElement,
+      List<MethodSpec> methods) throws EpoxyProcessorException {
+
+    if (!isEpoxyModelWithHolder(originalClassElement)) {
+      return;
+    }
+
+    MethodSpec createHolderMethod = MethodSpec.methodBuilder(CREATE_NEW_HOLDER_METHOD_NAME)
+        .addAnnotation(Override.class)
+        .addModifiers(Modifier.PROTECTED)
+        .build();
+
+    if (implementsMethod(originalClassElement, createHolderMethod, typeUtils)) {
+      return;
+    }
+
+    TypeMirror epoxyObjectType = getEpoxyObjectType(originalClassElement, typeUtils);
+    if (epoxyObjectType == null) {
+      throwError("Return type for createNewHolder method could not be found. (class: %s)",
+          originalClassElement.getSimpleName());
+    }
+
+    createHolderMethod = createHolderMethod.toBuilder()
+        .returns(TypeName.get(epoxyObjectType))
+        .addStatement("return new $T()", epoxyObjectType)
+        .build();
+
+    methods.add(createHolderMethod);
+  }
+
+  /**
+   * If there is no existing implementation of getDefaultLayout we can generate an implementation.
+   * This relies on a layout res being set in the @EpoxyModelClass annotation.
+   */
+  private void addDefaultLayoutMethodIfNeeded(TypeElement originalClassElement,
+      List<MethodSpec> methods) throws EpoxyProcessorException {
+
+    MethodSpec getDefaultLayoutMethod = MethodSpec.methodBuilder(GET_DEFAULT_LAYOUT_METHOD_NAME)
+        .addAnnotation(Override.class)
+        .addAnnotation(LayoutRes.class)
+        .addModifiers(Modifier.PROTECTED)
+        .returns(TypeName.INT)
+        .build();
+
+    if (implementsMethod(originalClassElement, getDefaultLayoutMethod, typeUtils)) {
+      return;
+    }
+
+    EpoxyModelClass annotation = originalClassElement.getAnnotation(EpoxyModelClass.class);
+    if (annotation == null) {
+      throwError("Model must use %s annotation if it does not implement %s. (class: %s)",
+          EpoxyModelClass.class,
+          GET_DEFAULT_LAYOUT_METHOD_NAME,
+          originalClassElement.getSimpleName());
+    }
+
+    int layoutRes = annotation.value();
+    if (layoutRes == 0) {
+      throwError("Model must specify a valid layout resource in the %s annotation. (class: %s)",
+          EpoxyModelClass.class,
+          originalClassElement.getSimpleName());
+    }
+
+    getDefaultLayoutMethod = getDefaultLayoutMethod.toBuilder()
+        .addStatement("return $L", layoutRes)
+        .build();
+
+    methods.add(getDefaultLayoutMethod);
   }
 
   private void generateParams(StringBuilder statementBuilder, List<ParameterSpec> params) {

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
@@ -388,4 +388,20 @@ public class EpoxyProcessorTest {
         .and()
         .generatesSources(generatedModel);
   }
+
+  @Test
+  public void testGenerateDefaultLayoutMethod() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("GenerateDefaultLayoutMethod.java");
+
+    JavaFileObject generatedModel = JavaFileObjects
+        .forResource("GenerateDefaultLayoutMethod_.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
+  }
 }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyModelClass(1)
+@EpoxyModelClass(layout = 1)
 public abstract class GenerateDefaultLayoutMethod extends EpoxyModel<Object> {
   @EpoxyAttribute int value;
 }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod.java
@@ -1,0 +1,6 @@
+package com.airbnb.epoxy;
+
+@EpoxyModelClass(1)
+public abstract class GenerateDefaultLayoutMethod extends EpoxyModel<Object> {
+  @EpoxyAttribute int value;
+}

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
@@ -7,13 +7,14 @@ import java.lang.Override;
 import java.lang.String;
 
 /**
- * Generated file. Do not modify! */
-public class AbstractModelWithHolder_ extends AbstractModelWithHolder {
-  public AbstractModelWithHolder_() {
+ * Generated file. Do not modify!
+ */
+public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod {
+  public GenerateDefaultLayoutMethod_() {
     super();
   }
 
-  public AbstractModelWithHolder_ value(int value) {
+  public GenerateDefaultLayoutMethod_ value(int value) {
     this.value = value;
     return this;
   }
@@ -23,54 +24,55 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder {
   }
 
   @Override
-  public AbstractModelWithHolder_ id(long id) {
+  public GenerateDefaultLayoutMethod_ id(long id) {
     super.id(id);
     return this;
   }
 
   @Override
-  public AbstractModelWithHolder_ id(CharSequence key) {
+  public GenerateDefaultLayoutMethod_ id(CharSequence key) {
     super.id(key);
     return this;
   }
 
   @Override
-  public AbstractModelWithHolder_ id(CharSequence key, long id) {
+  public GenerateDefaultLayoutMethod_ id(CharSequence key, long id) {
     super.id(key, id);
     return this;
   }
 
   @Override
-  public AbstractModelWithHolder_ layout(@LayoutRes int arg0) {
+  public GenerateDefaultLayoutMethod_ layout(@LayoutRes int arg0) {
     super.layout(arg0);
     return this;
   }
 
   @Override
-  public AbstractModelWithHolder_ show() {
+  public GenerateDefaultLayoutMethod_ show() {
     super.show();
     return this;
   }
 
   @Override
-  public AbstractModelWithHolder_ show(boolean show) {
+  public GenerateDefaultLayoutMethod_ show(boolean show) {
     super.show(show);
     return this;
   }
 
   @Override
-  public AbstractModelWithHolder_ hide() {
+  public GenerateDefaultLayoutMethod_ hide() {
     super.hide();
     return this;
   }
 
   @Override
-  protected AbstractModelWithHolder.Holder createNewHolder() {
-    return new AbstractModelWithHolder.Holder();
+  @LayoutRes
+  protected int getDefaultLayout() {
+    return 1;
   }
 
   @Override
-  public AbstractModelWithHolder_ reset() {
+  public GenerateDefaultLayoutMethod_ reset() {
     this.value = 0;
     super.reset();
     return this;
@@ -81,13 +83,13 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder {
     if (o == this) {
       return true;
     }
-    if (!(o instanceof AbstractModelWithHolder_)) {
+    if (!(o instanceof GenerateDefaultLayoutMethod_)) {
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-    AbstractModelWithHolder_ that = (AbstractModelWithHolder_) o;
+    GenerateDefaultLayoutMethod_ that = (GenerateDefaultLayoutMethod_) o;
     if (value != that.value) {
       return false;
     }
@@ -103,7 +105,7 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder {
 
   @Override
   public String toString() {
-    return "AbstractModelWithHolder_{" +
+    return "GenerateDefaultLayoutMethod_{" +
         "value=" + value +
         "}" + super.toString();
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
@@ -1,13 +1,13 @@
 package com.airbnb.epoxy;
 
 import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 
 /**
- * Generated file. Do not modify!
- */
+ * Generated file. Do not modify! */
 public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClassAndAnnotation {
   public ModelWithAbstractClassAndAnnotation_() {
     super();
@@ -16,6 +16,18 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
   @Override
   public ModelWithAbstractClassAndAnnotation_ id(long id) {
     super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithAbstractClassAndAnnotation_ id(CharSequence key, long id) {
+    super.id(key, id);
     return this;
   }
 

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
@@ -13,7 +13,7 @@ import com.airbnb.epoxy.models.ButtonModel.ButtonHolder;
 import butterknife.BindView;
 
 /** This model class gives an example of how to use a view holder pattern with your models. */
-@EpoxyModelClass(R.layout.model_button)
+@EpoxyModelClass(layout = R.layout.model_button)
 public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
   @EpoxyAttribute @StringRes int text;
   @EpoxyAttribute OnClickListener clickListener;

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
@@ -13,15 +13,10 @@ import com.airbnb.epoxy.models.ButtonModel.ButtonHolder;
 import butterknife.BindView;
 
 /** This model class gives an example of how to use a view holder pattern with your models. */
-@EpoxyModelClass
+@EpoxyModelClass(R.layout.model_button)
 public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
   @EpoxyAttribute @StringRes int text;
   @EpoxyAttribute OnClickListener clickListener;
-
-  @Override
-  protected int getDefaultLayout() {
-    return R.layout.model_button;
-  }
 
   @Override
   public int getSpanSize(int totalSpanCount, int position, int itemCount) {

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/models/HeaderModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/models/HeaderModel.java
@@ -12,7 +12,7 @@ import com.airbnb.epoxy.views.HeaderView;
  * This model shows an example of binding to a specific view type. In this case it is a custom view
  * we made, but it could also be another single view, like an EditText or Button.
  */
-@EpoxyModelClass(R.layout.model_header)
+@EpoxyModelClass(layout = R.layout.model_header)
 public abstract class HeaderModel extends EpoxyModel<HeaderView> {
   @EpoxyAttribute @StringRes int title;
   @EpoxyAttribute @StringRes int caption;

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/models/HeaderModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/models/HeaderModel.java
@@ -4,6 +4,7 @@ import android.support.annotation.StringRes;
 
 import com.airbnb.epoxy.EpoxyAttribute;
 import com.airbnb.epoxy.EpoxyModel;
+import com.airbnb.epoxy.EpoxyModelClass;
 import com.airbnb.epoxy.R;
 import com.airbnb.epoxy.views.HeaderView;
 
@@ -11,14 +12,10 @@ import com.airbnb.epoxy.views.HeaderView;
  * This model shows an example of binding to a specific view type. In this case it is a custom view
  * we made, but it could also be another single view, like an EditText or Button.
  */
-public class HeaderModel extends EpoxyModel<HeaderView> {
+@EpoxyModelClass(R.layout.model_header)
+public abstract class HeaderModel extends EpoxyModel<HeaderView> {
   @EpoxyAttribute @StringRes int title;
   @EpoxyAttribute @StringRes int caption;
-
-  @Override
-  protected int getDefaultLayout() {
-    return R.layout.model_header;
-  }
 
   @Override
   public void bind(HeaderView view) {


### PR DESCRIPTION
This lets us get rid of even more boilerplate by not writing the `getDefaultLayout` method in models.