### PR TITLE
Override EpoxyModelWithHolder callbacks to change param name

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -92,8 +92,8 @@ public abstract class EpoxyModel<T> {
    * is preferable to using {@link String#hashCode()} because that is a 32 bit hash and this is a 64
    * bit hash, giving better spread and less chance of collision with other ids.
    * <p>
-   * Since this uses a hashcode method to convert the String to a long there is a very small
-   * chance that you may have a collision with another id. Assuming an even spread of hashcodes, and
+   * Since this uses a hashcode method to convert the String to a long there is a very small chance
+   * that you may have a collision with another id. Assuming an even spread of hashcodes, and
    * several hundred models in the adapter, there would be roughly 1 in 100 trillion chance of a
    * collision. (http://preshing.com/20110504/hash-collision-probabilities/)
    *
@@ -287,11 +287,11 @@ public abstract class EpoxyModel<T> {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "{" +
-        "id=" + id +
-        ", layout=" + getLayout() +
-        ", shown=" + shown +
-        ", addedToAdapter=" + addedToAdapter +
-        '}';
+    return getClass().getSimpleName() + "{"
+        + "id=" + id
+        + ", layout=" + getLayout()
+        + ", shown=" + shown
+        + ", addedToAdapter=" + addedToAdapter
+        + '}';
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithHolder.java
@@ -32,4 +32,19 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   public void unbind(T holder) {
     super.unbind(holder);
   }
+
+  @Override
+  public boolean onFailedToRecycleView(T holder) {
+    return super.onFailedToRecycleView(holder);
+  }
+
+  @Override
+  public void onViewAttachedToWindow(T holder) {
+    super.onViewAttachedToWindow(holder);
+  }
+
+  @Override
+  public void onViewDetachedFromWindow(T holder) {
+    super.onViewDetachedFromWindow(holder);
+  }
 }


### PR DESCRIPTION
This is done so that subclasses overriding these methods see the param as `holder` instead of `view`. This was already done for the bind/unbind methods, and now this does it for the newer callbacks as well.