### PR TITLE
Fix model callbacks to use holder for EpoxyModelWithHolder

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyAdapter.java
@@ -211,21 +211,21 @@ public abstract class EpoxyAdapter extends RecyclerView.Adapter<EpoxyViewHolder>
   @Override
   public boolean onFailedToRecycleView(EpoxyViewHolder holder) {
     //noinspection unchecked,rawtypes
-    return ((EpoxyModel) holder.getModel()).onFailedToRecycleView(holder.itemView);
+    return ((EpoxyModel) holder.getModel()).onFailedToRecycleView(holder.objectToBind());
   }
 
   @CallSuper
   @Override
   public void onViewAttachedToWindow(EpoxyViewHolder holder) {
     //noinspection unchecked,rawtypes
-    ((EpoxyModel) holder.getModel()).onViewAttachedToWindow(holder.itemView);
+    ((EpoxyModel) holder.getModel()).onViewAttachedToWindow(holder.objectToBind());
   }
 
   @CallSuper
   @Override
   public void onViewDetachedFromWindow(EpoxyViewHolder holder) {
     //noinspection unchecked,rawtypes
-    ((EpoxyModel) holder.getModel()).onViewDetachedFromWindow(holder.itemView);
+    ((EpoxyModel) holder.getModel()).onViewDetachedFromWindow(holder.objectToBind());
   }
 
   public void onSaveInstanceState(Bundle outState) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -37,7 +37,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     epoxyModel = model;
   }
 
-  private Object objectToBind() {
+  Object objectToBind() {
     return epoxyHolder != null ? epoxyHolder : itemView;
   }
 


### PR DESCRIPTION
The holder class was being pass the view, which caused a crash. This will use the correct object depending on the model