### PR TITLE
Add library config options

### DIFF
--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyConfig.java
@@ -1,0 +1,49 @@
+package com.airbnb.epoxy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation on any class in your project to specify default behavior for the Epoxy
+ * annotation processor for that project. You can only have one instance of this annotation per
+ * project.
+ * <p>
+ * If an instance of this annotation is not found in your project then the default values are used.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+public @interface EpoxyConfig {
+  boolean REQUIRE_HASHCODE_DEFAULT = false;
+  boolean REQUIRE_ABSTRACT_MODELS = false;
+  /**
+   * If true, all fields marked with {@link com.airbnb.epoxy.EpoxyAttribute} must have a type that
+   * implements hashCode, or the attribute must set hash=false.
+   * <p>
+   * Setting this to true is useful for ensuring that all model attributes correctly implement
+   * hashCode, or use hash=false (eg for click listeners). It is a common mistake to miss these,
+   * which leads to invalid model state and incorrect diffing.
+   * <p>
+   * The check is done at compile time and compilation will fail if a hashCode validation fails.
+   * <p>
+   * Since it is done at compile time this can only check the direct type of the field. Interfaces
+   * will fail the check even if an implementation of that interface which does implement hashCode
+   * is used at runtime.
+   * <p>
+   * If an attribute is an Iterable or Array then that collection type must implement hashCode.
+   * <p>
+   * If the attribute type is a class that uses Google AutoValue then the hashCode check will
+   * succeed, since it is assumed that a generated subclass of that type will be used.
+   */
+  boolean requireHashCode() default REQUIRE_HASHCODE_DEFAULT;
+  /**
+   * If true, all classes that contains {@link com.airbnb.epoxy.EpoxyAttribute} or {@link
+   * com.airbnb.epoxy.EpoxyModelClass} annotations in your project must be abstract. Otherwise
+   * compilation will fail.
+   * <p>
+   * Forcing models to be abstract can prevent the mistake of using the original model class instead
+   * of the generated class.
+   */
+  boolean requireAbstractModels() default REQUIRE_ABSTRACT_MODELS;
+}

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/ModuleEpoxyConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/ModuleEpoxyConfig.java
@@ -6,15 +6,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Use this annotation on any class in your project to specify default behavior for the Epoxy
- * annotation processor for that project. You can only have one instance of this annotation per
- * project.
+ * Use this annotation on any class in your module to specify default behavior for the Epoxy
+ * annotation processor for that module. You can only have one instance of this annotation per
+ * module.
  * <p>
- * If an instance of this annotation is not found in your project then the default values are used.
+ * If an instance of this annotation is not found in a module then the default values are used.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
-public @interface EpoxyConfig {
+public @interface ModuleEpoxyConfig {
   boolean REQUIRE_HASHCODE_DEFAULT = false;
   boolean REQUIRE_ABSTRACT_MODELS = false;
   /**

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/Configuration.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/Configuration.java
@@ -8,7 +8,7 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 
 /**
- * Used to process {@link com.airbnb.epoxy.EpoxyConfig} annotations and specify configuration
+ * Used to process {@link ModuleEpoxyConfig} annotations and specify configuration
  * details to the annotation processor
  */
 class Configuration {
@@ -23,14 +23,14 @@ class Configuration {
 
   static Configuration forDefaults() {
     return new Configuration(
-        EpoxyConfig.REQUIRE_HASHCODE_DEFAULT,
-        EpoxyConfig.REQUIRE_ABSTRACT_MODELS
+        ModuleEpoxyConfig.REQUIRE_HASHCODE_DEFAULT,
+        ModuleEpoxyConfig.REQUIRE_ABSTRACT_MODELS
     );
   }
 
   static Configuration create(RoundEnvironment roundEnv) throws EpoxyProcessorException {
     Set<? extends Element> configElements =
-        roundEnv.getElementsAnnotatedWith(EpoxyConfig.class);
+        roundEnv.getElementsAnnotatedWith(ModuleEpoxyConfig.class);
 
     if (configElements.isEmpty()) {
       return forDefaults();
@@ -38,8 +38,8 @@ class Configuration {
 
     validateOnlyOneConfig(configElements);
 
-    EpoxyConfig configAnnotation =
-        configElements.iterator().next().getAnnotation(EpoxyConfig.class);
+    ModuleEpoxyConfig configAnnotation =
+        configElements.iterator().next().getAnnotation(ModuleEpoxyConfig.class);
 
     return new Configuration(
         configAnnotation.requireHashCode(),

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/Configuration.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/Configuration.java
@@ -1,0 +1,62 @@
+package com.airbnb.epoxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+
+/**
+ * Used to process {@link com.airbnb.epoxy.EpoxyConfig} annotations and specify configuration
+ * details to the annotation processor
+ */
+class Configuration {
+
+  final boolean requireHashCode;
+  final boolean requireAbstractModels;
+
+  private Configuration(boolean requireHashCode, boolean requireAbstractModels) {
+    this.requireHashCode = requireHashCode;
+    this.requireAbstractModels = requireAbstractModels;
+  }
+
+  static Configuration forDefaults() {
+    return new Configuration(
+        EpoxyConfig.REQUIRE_HASHCODE_DEFAULT,
+        EpoxyConfig.REQUIRE_ABSTRACT_MODELS
+    );
+  }
+
+  static Configuration create(RoundEnvironment roundEnv) throws EpoxyProcessorException {
+    Set<? extends Element> configElements =
+        roundEnv.getElementsAnnotatedWith(EpoxyConfig.class);
+
+    if (configElements.isEmpty()) {
+      return forDefaults();
+    }
+
+    validateOnlyOneConfig(configElements);
+
+    EpoxyConfig configAnnotation =
+        configElements.iterator().next().getAnnotation(EpoxyConfig.class);
+
+    return new Configuration(
+        configAnnotation.requireHashCode(),
+        configAnnotation.requireAbstractModels()
+    );
+  }
+
+  private static void validateOnlyOneConfig(Set<? extends Element> configElements)
+      throws EpoxyProcessorException {
+    if (configElements.size() > 1) {
+      List<String> classNamesWithConfigs = new ArrayList<>();
+      for (Element configElement : configElements) {
+        classNamesWithConfigs.add(configElement.getSimpleName().toString());
+      }
+
+      throw new EpoxyProcessorException(
+          "Epoxy config can only be used once per project. Exists in: " + classNamesWithConfigs);
+    }
+  }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -109,7 +109,7 @@ public class EpoxyProcessor extends AbstractProcessor {
 
     annotations.add(EpoxyModelClass.class);
     annotations.add(EpoxyAttribute.class);
-    annotations.add(EpoxyConfig.class);
+    annotations.add(ModuleEpoxyConfig.class);
 
     return annotations;
   }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
@@ -1,0 +1,111 @@
+package com.airbnb.epoxy;
+
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+
+import static com.airbnb.epoxy.ProcessorUtils.implementsMethod;
+import static com.airbnb.epoxy.ProcessorUtils.isIterableType;
+import static com.airbnb.epoxy.ProcessorUtils.isSubtypeOfType;
+import static com.airbnb.epoxy.ProcessorUtils.throwError;
+
+/** Validates that an attribute implements hashCode. */
+class HashCodeValidator {
+  private static final MethodSpec HASH_CODE_METHOD = MethodSpec.methodBuilder("hashCode")
+      .returns(TypeName.INT)
+      .build();
+
+  private final Types typeUtils;
+
+  HashCodeValidator(Types typeUtils) {
+    this.typeUtils = typeUtils;
+  }
+
+  void validate(AttributeInfo attribute) throws EpoxyProcessorException {
+    try {
+      validateImplementsHashCode(attribute.getAttributeElement().asType());
+    } catch (EpoxyProcessorException e) {
+      // Append information about the attribute and class to the existing exception
+      throwError(e.getMessage() + " (Attribute: %s Class: %s)",
+          attribute.getName(),
+          attribute.getClassElement().getSimpleName().toString());
+    }
+  }
+
+  private void validateImplementsHashCode(TypeMirror mirror) throws EpoxyProcessorException {
+    if (TypeName.get(mirror).isPrimitive()) {
+      return;
+    }
+
+    if (mirror.getKind() == TypeKind.ARRAY) {
+      validateArrayType((ArrayType) mirror);
+      return;
+    }
+
+    if (!(mirror instanceof DeclaredType)) {
+      return;
+    }
+
+    DeclaredType declaredType = (DeclaredType) mirror;
+    Element element = typeUtils.asElement(mirror);
+    TypeElement clazz = (TypeElement) element;
+
+    if (isIterableType(clazz)) {
+      validateIterableType(declaredType);
+      return;
+    }
+
+    if (isAutoValueType(element)) {
+      return;
+    }
+
+    if (!implementsMethod(clazz, HASH_CODE_METHOD, typeUtils)) {
+      throwError("Attribute does not implement hashCode");
+    }
+  }
+
+  private void validateArrayType(ArrayType mirror) throws EpoxyProcessorException {
+    // Check that the type of the array implements hashCode
+    TypeMirror arrayType = mirror.getComponentType();
+    try {
+      validateImplementsHashCode(arrayType);
+    } catch (EpoxyProcessorException e) {
+      throwError("Type in array does not implement hashCode. Type: %s",
+          arrayType.toString());
+    }
+  }
+
+  private void validateIterableType(DeclaredType declaredType) throws EpoxyProcessorException {
+    for (TypeMirror typeParameter : declaredType.getTypeArguments()) {
+      // check that the type implements hashCode
+      try {
+        validateImplementsHashCode(typeParameter);
+      } catch (EpoxyProcessorException e) {
+        throwError("Type in Iterable does not implement hashCode. Type: %s",
+            typeParameter.toString());
+      }
+    }
+
+    // Assume that the iterable class implements hashCode, so we can allow interfaces like List
+  }
+
+  private boolean isAutoValueType(Element element) {
+    for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+      DeclaredType annotationType = annotationMirror.getAnnotationType();
+      boolean isAutoValue = isSubtypeOfType(annotationType, "com.google.auto.value.AutoValue");
+      if (isAutoValue) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
@@ -23,6 +23,15 @@ class ProcessorUtils {
   static final String EPOXY_MODEL_TYPE = "com.airbnb.epoxy.EpoxyModel<?>";
   static final String EPOXY_MODEL_HOLDER_TYPE = "com.airbnb.epoxy.EpoxyModelWithHolder<?>";
 
+  static void throwError(String msg, Object... args)
+      throws EpoxyProcessorException {
+    throw new EpoxyProcessorException(String.format(msg, args));
+  }
+
+  static boolean isIterableType(TypeElement element) {
+    return isSubtypeOfType(element.asType(), "java.lang.Iterable<?>");
+  }
+
   static boolean isEpoxyModel(TypeMirror type) {
     return isSubtypeOfType(type, EPOXY_MODEL_TYPE);
   }
@@ -76,13 +85,19 @@ class ProcessorUtils {
   }
 
   /**
-   * @return True if the clazz (or one of its superclasses) implements the given method. Returns
-   * false if the method doesn't exist anywhere in the class hierarchy or it is abstract.
+   * @return True if the clazz (or one of its superclasses except for Object) implements the given
+   * method. Returns false if the method doesn't exist anywhere in the class hierarchy or it is
+   * abstract.
    */
   static boolean implementsMethod(TypeElement clazz, MethodSpec method, Types typeUtils) {
     ExecutableElement methodOnClass = getMethodOnClass(clazz, method, typeUtils);
-
     if (methodOnClass == null) {
+      return false;
+    }
+
+    Element implementingClass = methodOnClass.getEnclosingElement();
+    if (implementingClass.getSimpleName().toString().equals("Object")) {
+      // Don't count default implementations on Object class
       return false;
     }
 

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
@@ -483,7 +483,7 @@ public class EpoxyProcessorTest {
   @Test
   public void testConfigRequireHashCode() {
     JavaFileObject model = JavaFileObjects
-        .forResource("ModelWithAttributeWithoutHashCode.java");
+        .forResource("ModelRequiresHashCodeFailsBasicObject.java");
 
     assert_().about(javaSource())
         .that(model)

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/EpoxyProcessorTest.java
@@ -433,7 +433,6 @@ public class EpoxyProcessorTest {
         .compilesWithoutError()
         .and()
         .generatesSources(generatedNoLayoutModel, generatedWithLayoutModel);
-
   }
 
   @Test
@@ -467,5 +466,151 @@ public class EpoxyProcessorTest {
         .processedWith(new EpoxyProcessor())
         .failsToCompile()
         .withErrorContaining("Model must specify a valid layout resource");
+  }
+
+  @Test
+  public void testConfigDeclaredTwiceFails() {
+    JavaFileObject configClass = JavaFileObjects
+        .forResource("ClassWithTwoConfigs.java");
+
+    assert_().about(javaSource())
+        .that(configClass)
+        .processedWith(new EpoxyProcessor())
+        .failsToCompile()
+        .withErrorContaining("Epoxy config can only be used once per project");
+  }
+
+  @Test
+  public void testConfigRequireHashCode() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelWithAttributeWithoutHashCode.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .failsToCompile()
+        .withErrorContaining("Attribute does not implement hashCode");
+  }
+
+  @Test
+  public void testConfigRequireHashCodeIterableFails() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelRequiresHashCodeIterableFails.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .failsToCompile()
+        .withErrorContaining("Type in Iterable does not implement hashCode");
+  }
+
+  @Test
+  public void testConfigRequireHashCodeIterablePasses() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelRequiresHashCodeIterableSucceeds.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+  }
+
+  @Test
+  public void testConfigRequireHashCodeArrayFails() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelRequiresHashCodeArrayFails.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .failsToCompile()
+        .withErrorContaining("Type in array does not implement hashCode");
+  }
+
+  @Test
+  public void testConfigRequireHashCodeArrayPasses() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelRequiresHashCodeArraySucceeds.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+  }
+
+  @Test
+  public void testConfigRequireHashCodeEnumAttributePasses() {
+    // Verify that enum attributes pass the hashcode requirement
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelRequiresHashCodeEnumPasses.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+  }
+
+  @Test
+  public void testConfigRequireHashCodeAutoValueAttributePasses() {
+    // Verify that AutoValue class attributes pass the hashcode requirement
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelRequiresHashCodeAutoValueClassPasses.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+  }
+
+  @Test
+  public void testConfigRequireAbstractModelPassesClassWithAttribute() {
+    // Verify that AutoValue class attributes pass the hashcode requirement
+    JavaFileObject model = JavaFileObjects
+        .forResource("RequireAbstractModelPassesClassWithAttribute.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+  }
+
+  @Test
+  public void testConfigRequireAbstractModelFailsClassWithAttribute() {
+    // Verify that AutoValue class attributes pass the hashcode requirement
+    JavaFileObject model = JavaFileObjects
+        .forResource("RequireAbstractModelFailsClassWithAttribute.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "Epoxy model class must be abstract (RequireAbstractModelFailsClassWithAttribute)");
+  }
+
+  @Test
+  public void testConfigRequireAbstractModelPassesEpoxyModelClass() {
+    // Verify that AutoValue class attributes pass the hashcode requirement
+    JavaFileObject model = JavaFileObjects
+        .forResource("RequireAbstractModelPassesEpoxyModelClass.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+  }
+
+  @Test
+  public void testConfigRequireAbstractModelFailsEpoxyModelClass() {
+    // Verify that AutoValue class attributes pass the hashcode requirement
+    JavaFileObject model = JavaFileObjects
+        .forResource("RequireAbstractModelFailsEpoxyModelClass.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "Epoxy model class must be abstract (RequireAbstractModelFailsEpoxyModelClass)");
   }
 }

--- a/epoxy-processortest/src/test/resources/ClassWithTwoConfigs.java
+++ b/epoxy-processortest/src/test/resources/ClassWithTwoConfigs.java
@@ -1,0 +1,10 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig
+public class ClassWithTwoConfigs {
+
+  @EpoxyConfig
+  private static class SubClass {
+
+  }
+}

--- a/epoxy-processortest/src/test/resources/ClassWithTwoConfigs.java
+++ b/epoxy-processortest/src/test/resources/ClassWithTwoConfigs.java
@@ -1,9 +1,9 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig
+@ModuleEpoxyConfig
 public class ClassWithTwoConfigs {
 
-  @EpoxyConfig
+  @ModuleEpoxyConfig
   private static class SubClass {
 
   }

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArrayFails.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArrayFails.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireHashCode = true)
+@ModuleEpoxyConfig(requireHashCode = true)
 public class ModelRequiresHashCodeArrayFails extends EpoxyModel<Object> {
   @EpoxyAttribute Object[] clickListener;
 

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArrayFails.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArrayFails.java
@@ -1,0 +1,11 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireHashCode = true)
+public class ModelRequiresHashCodeArrayFails extends EpoxyModel<Object> {
+  @EpoxyAttribute Object[] clickListener;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArraySucceeds.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArraySucceeds.java
@@ -1,0 +1,11 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireHashCode = true)
+public class ModelRequiresHashCodeArraySucceeds extends EpoxyModel<Object> {
+  @EpoxyAttribute String[] clickListener;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArraySucceeds.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeArraySucceeds.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireHashCode = true)
+@ModuleEpoxyConfig(requireHashCode = true)
 public class ModelRequiresHashCodeArraySucceeds extends EpoxyModel<Object> {
   @EpoxyAttribute String[] clickListener;
 

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeAutoValueClassPasses.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeAutoValueClassPasses.java
@@ -2,7 +2,7 @@ package com.airbnb.epoxy;
 
 import com.google.auto.value.AutoValue;
 
-@EpoxyConfig(requireHashCode = true)
+@ModuleEpoxyConfig(requireHashCode = true)
 public class ModelRequiresHashCodeAutoValueClassPasses extends EpoxyModel<Object> {
 
   @AutoValue

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeAutoValueClassPasses.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeAutoValueClassPasses.java
@@ -1,0 +1,19 @@
+package com.airbnb.epoxy;
+
+import com.google.auto.value.AutoValue;
+
+@EpoxyConfig(requireHashCode = true)
+public class ModelRequiresHashCodeAutoValueClassPasses extends EpoxyModel<Object> {
+
+  @AutoValue
+  public static abstract class AutoValueClass {
+
+  }
+
+  @EpoxyAttribute AutoValueClass autoValueClass;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeEnumPasses.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeEnumPasses.java
@@ -1,0 +1,16 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireHashCode = true)
+public class ModelRequiresHashCodeEnumPasses extends EpoxyModel<Object> {
+
+  public enum MyEnum{
+    Value
+  }
+
+  @EpoxyAttribute MyEnum enumValue;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeEnumPasses.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeEnumPasses.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireHashCode = true)
+@ModuleEpoxyConfig(requireHashCode = true)
 public class ModelRequiresHashCodeEnumPasses extends EpoxyModel<Object> {
 
   public enum MyEnum{

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeFailsBasicObject.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeFailsBasicObject.java
@@ -1,7 +1,7 @@
 package com.airbnb.epoxy;
 
 @EpoxyConfig(requireHashCode = true)
-public class ModelWithAttributeWithoutHashCode extends EpoxyModel<Object> {
+public class ModelRequiresHashCodeFailsBasicObject extends EpoxyModel<Object> {
 
   public static class ClassWithoutHashCode {
 

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeFailsBasicObject.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeFailsBasicObject.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireHashCode = true)
+@ModuleEpoxyConfig(requireHashCode = true)
 public class ModelRequiresHashCodeFailsBasicObject extends EpoxyModel<Object> {
 
   public static class ClassWithoutHashCode {

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableFails.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableFails.java
@@ -3,7 +3,7 @@ package com.airbnb.epoxy;
 import java.util.List;
 
 
-@EpoxyConfig(requireHashCode = true)
+@ModuleEpoxyConfig(requireHashCode = true)
 public class ModelRequiresHashCodeIterableFails extends EpoxyModel<Object> {
   @EpoxyAttribute List<Object> clickListener;
 

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableFails.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableFails.java
@@ -1,0 +1,14 @@
+package com.airbnb.epoxy;
+
+import java.util.List;
+
+
+@EpoxyConfig(requireHashCode = true)
+public class ModelRequiresHashCodeIterableFails extends EpoxyModel<Object> {
+  @EpoxyAttribute List<Object> clickListener;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableSucceeds.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableSucceeds.java
@@ -1,0 +1,13 @@
+package com.airbnb.epoxy;
+
+import java.util.List;
+
+@EpoxyConfig(requireHashCode = true)
+public class ModelRequiresHashCodeIterableSucceeds extends EpoxyModel<Object> {
+  @EpoxyAttribute List<String> clickListener;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableSucceeds.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeIterableSucceeds.java
@@ -2,7 +2,7 @@ package com.airbnb.epoxy;
 
 import java.util.List;
 
-@EpoxyConfig(requireHashCode = true)
+@ModuleEpoxyConfig(requireHashCode = true)
 public class ModelRequiresHashCodeIterableSucceeds extends EpoxyModel<Object> {
   @EpoxyAttribute List<String> clickListener;
 

--- a/epoxy-processortest/src/test/resources/ModelWIthAttributeWithoutHashCode.java
+++ b/epoxy-processortest/src/test/resources/ModelWIthAttributeWithoutHashCode.java
@@ -1,0 +1,16 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireHashCode = true)
+public class ModelWithAttributeWithoutHashCode extends EpoxyModel<Object> {
+
+  public static class ClassWithoutHashCode {
+
+  }
+
+  @EpoxyAttribute ClassWithoutHashCode classWithoutHashCode;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelFailsClassWithAttribute.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelFailsClassWithAttribute.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireAbstractModels = true)
+@ModuleEpoxyConfig(requireAbstractModels = true)
 public class RequireAbstractModelFailsClassWithAttribute extends EpoxyModel<Object> {
 
   @EpoxyAttribute String value;

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelFailsClassWithAttribute.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelFailsClassWithAttribute.java
@@ -1,0 +1,12 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireAbstractModels = true)
+public class RequireAbstractModelFailsClassWithAttribute extends EpoxyModel<Object> {
+
+  @EpoxyAttribute String value;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelFailsEpoxyModelClass.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelFailsEpoxyModelClass.java
@@ -1,0 +1,11 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireAbstractModels = true)
+@EpoxyModelClass
+public class RequireAbstractModelFailsEpoxyModelClass extends EpoxyModel<Object> {
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelFailsEpoxyModelClass.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelFailsEpoxyModelClass.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireAbstractModels = true)
+@ModuleEpoxyConfig(requireAbstractModels = true)
 @EpoxyModelClass
 public class RequireAbstractModelFailsEpoxyModelClass extends EpoxyModel<Object> {
 

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelPassesClassWithAttribute.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelPassesClassWithAttribute.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireAbstractModels = true)
+@ModuleEpoxyConfig(requireAbstractModels = true)
 public abstract class RequireAbstractModelPassesClassWithAttribute extends EpoxyModel<Object> {
 
   @EpoxyAttribute String value;

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelPassesClassWithAttribute.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelPassesClassWithAttribute.java
@@ -1,0 +1,12 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireAbstractModels = true)
+public abstract class RequireAbstractModelPassesClassWithAttribute extends EpoxyModel<Object> {
+
+  @EpoxyAttribute String value;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelPassesEpoxyModelClass.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelPassesEpoxyModelClass.java
@@ -1,0 +1,11 @@
+package com.airbnb.epoxy;
+
+@EpoxyConfig(requireAbstractModels = true)
+@EpoxyModelClass
+public abstract class RequireAbstractModelPassesEpoxyModelClass extends EpoxyModel<Object> {
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/RequireAbstractModelPassesEpoxyModelClass.java
+++ b/epoxy-processortest/src/test/resources/RequireAbstractModelPassesEpoxyModelClass.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
-@EpoxyConfig(requireAbstractModels = true)
+@ModuleEpoxyConfig(requireAbstractModels = true)
 @EpoxyModelClass
 public abstract class RequireAbstractModelPassesEpoxyModelClass extends EpoxyModel<Object> {
 

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
@@ -16,7 +16,7 @@ import butterknife.BindView;
 @EpoxyModelClass(layout = R.layout.model_button)
 public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
   @EpoxyAttribute @StringRes int text;
-  @EpoxyAttribute OnClickListener clickListener;
+  @EpoxyAttribute(hash = false) OnClickListener clickListener;
 
   @Override
   public int getSpanSize(int totalSpanCount, int position, int itemCount) {


### PR DESCRIPTION
This adds support for optional library wide configuration options to the annotation processor. The two options available so far are requiring abstract model classes and requiring fields with @EpoxyAttribute to implement hashCode (or use hash=false).

This is done via a new @EpoxyConfig annotation that can be used anywhere in the project. My thinking is that an empty class could be created to do this. Something like
```
@EpoxyConfig(...)
final class EpoxyConfig {
  private EpoxyConfig(){}
}
```

I haven't seen any other ways for specifying options to an annotation processor, if someone has better ideas on how to do this let me know!

@felipecsl @seanabraham @gpeal @ngsilverman 