### PR TITLE
Add options array to EpoxyAttribute annotation

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -195,6 +195,10 @@ abstract class BaseEpoxyAdapter extends RecyclerView.Adapter<EpoxyViewHolder> {
 
     if (inState != null) {
       viewHolderState = inState.getParcelable(SAVED_STATE_ARG_VIEW_HOLDERS);
+      if (viewHolderState == null) {
+        throw new IllegalStateException(
+            "Tried to restore instance state, but onSaveInstanceState was never called.");
+      }
     }
   }
 

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
@@ -7,25 +7,77 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate fields on EpoxyModel classes in order to generate a
- * subclass of that model with getters, setters, equals, and hashcode for the annotated fields.
+ * Used to annotate fields on EpoxyModel classes in order to generate a subclass of that model with
+ * getters, setters, equals, and hashcode for the annotated fields.
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.CLASS)
 public @interface EpoxyAttribute {
   /**
+   * Options that can be included on the attribute to affect how the model's generated class is
+   * created.
+   */
+  enum Option {
+    /**
+     * A getter is generated for this attribute by default. Add this option to prevent a getter from
+     * being generated.
+     */
+    NoGetter,
+    /**
+     * A setter is generated for this attribute by default. Add this option to prevent a setter from
+     * being generated.
+     */
+    NoSetter,
+    /**
+     * By default every attribute's hashCode method is called when determining the model's state.
+     * This option can be used to exclude an attribute's hashCode from contributing to the state.
+     * <p>
+     * This is useful for objects that may change without actually changing the model's state. A
+     * common case is an anonymous click listener that gets recreated with every bind call.
+     * <p>
+     * When this is used, the attribute will affect the model state solely based on whether it is
+     * null or non null.
+     */
+    DoNotHash,
+    /**
+     * This is meant to be used in conjunction with {@link PackageEpoxyConfig#requireHashCode()}.
+     * When that is enabled every attribute must implement hashCode. However, there are some valid
+     * cases where the attribute type does not implement hashCode, but it should still be hashed at
+     * runtime and contribute to the model's state. Use this option on an attribute in that case to
+     * tell the processor to let it pass the hashCode validation.
+     * <p>
+     * An example case is AutoValue classes, where the generated class correctly implements hashCode
+     * at runtime.
+     * <p>
+     * If you use this it is your responsibility to ensure that the object assigned to the attribute
+     * at runtime correctly implements hashCode. If you don't want the attribute to contribute to
+     * model state you should use {@link Option#DoNotHash} instead.
+     */
+    AllowMissingHash
+  }
+
+  /** Specify any {@link Option} values that should be used when generating the model class. */
+  Option[] value() default {};
+
+  /**
    * Whether or not to include this attribute in equals and hashCode calculations.
-   *
+   * <p>
    * It may be useful to disable this for objects that get recreated without the underlying data
    * changing such as a click listener that gets created inline in every bind call.
+   *
+   * @deprecated Use {@link Option#DoNotHash} instead.
    */
+  @Deprecated
   boolean hash() default true;
 
   /**
    * Whether or not to generate setter for this attribute.
-   *
+   * <p>
    * It may be useful to disable this for attribute which can be immutable and doesn't require
    * setter.
+   *
+   * @deprecated Use {@link Option#NoSetter} instead.
    */
+  @Deprecated
   boolean setter() default true;
 }

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
@@ -53,7 +53,7 @@ public @interface EpoxyAttribute {
      * at runtime correctly implements hashCode. If you don't want the attribute to contribute to
      * model state you should use {@link Option#DoNotHash} instead.
      */
-    AllowMissingHash
+    IgnoreRequireHashCode
   }
 
   /** Specify any {@link Option} values that should be used when generating the model class. */

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
@@ -34,7 +34,7 @@ class AttributeInfo {
   private final String name;
   private final TypeName type;
   private final boolean useInHash;
-  private final boolean allowMissingHash;
+  private final boolean ignoreRequireHashCode;
   private final boolean generateSetter;
   private final boolean generateGetter;
   private final boolean hasFinalModifier;
@@ -65,7 +65,7 @@ class AttributeInfo {
     validateAnnotationOptions(errorLogger, annotation, options);
 
     useInHash = annotation.hash() && !options.contains(Option.DoNotHash);
-    allowMissingHash = options.contains(Option.AllowMissingHash);
+    ignoreRequireHashCode = options.contains(Option.IgnoreRequireHashCode);
 
     generateSetter = annotation.setter() && !options.contains(Option.NoSetter);
     generateGetter = !options.contains(Option.NoGetter);
@@ -75,11 +75,11 @@ class AttributeInfo {
   private void validateAnnotationOptions(ErrorLogger errorLogger, EpoxyAttribute annotation,
       Set<Option> options) {
 
-    if (options.contains(Option.AllowMissingHash) && options.contains(Option.DoNotHash)) {
+    if (options.contains(Option.IgnoreRequireHashCode) && options.contains(Option.DoNotHash)) {
       errorLogger
           .logError("Illegal to use both %s and %s options in an %s annotation. (%s#%s)",
               Option.DoNotHash,
-              Option.AllowMissingHash,
+              Option.IgnoreRequireHashCode,
               EpoxyAttribute.class.getSimpleName(),
               classElement.getSimpleName(),
               name);
@@ -192,8 +192,8 @@ class AttributeInfo {
     return useInHash;
   }
 
-  public boolean allowMissingHash() {
-    return allowMissingHash;
+  boolean ignoreRequireHashCode() {
+    return ignoreRequireHashCode;
   }
 
   boolean generateSetter() {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
@@ -145,7 +145,7 @@ class ModelProcessor {
       for (AttributeInfo attributeInfo : generatedClass.getAttributeInfo()) {
         if (configManager.requiresHashCode(attributeInfo)
             && attributeInfo.useInHash()
-            && !attributeInfo.allowMissingHash()) {
+            && !attributeInfo.ignoreRequireHashCode()) {
 
           try {
             hashCodeValidator.validate(attributeInfo);

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
@@ -662,14 +662,9 @@ class ModelProcessor {
                 + "            boundEpoxyViewHolder.getAdapterPosition());\n"
                 + "      }\n"
                 + "    }\n"
-                + "    public int hashCode() {\n"
-                + "      // Hash the original click listener to avoid changing model state\n"
-                + "      return $L.hashCode();\n"
-                + "    }\n"
                 + "  };\n"
                 + "}\n", attributeName, attributeName, attributeName,
-            viewClickListenerType, viewType, attributeName, helperClass.getGeneratedName(),
-            attributeName));
+            viewClickListenerType, viewType, attributeName, helperClass.getGeneratedName()));
 
     return builder
         .addStatement("return this")

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
@@ -187,6 +187,18 @@ public class ConfigTest {
   }
 
   @Test
+  public void testConfigRequireHashCodeAllowsMarkedAttributes() {
+    // Verify that AutoValue class attributes pass the hashcode requirement
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelConfigRequireHashCodeAllowsMarkedAttributes.java");
+
+    assert_().about(javaSources())
+        .that(asList(CONFIG_CLASS_REQUIRE_HASH, model))
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError();
+  }
+
+  @Test
   public void testConfigRequireAbstractModelPassesClassWithAttribute() {
     // Verify that AutoValue class attributes pass the hashcode requirement. Only works for
     // classes in the module since AutoValue has a retention of Source so it is discarded after

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ModelProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ModelProcessorTest.java
@@ -139,6 +139,21 @@ public class ModelProcessorTest {
   }
 
   @Test
+  public void testDoNotHashModel() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelDoNotHash.java");
+
+    JavaFileObject generatedModel = JavaFileObjects.forResource("ModelDoNotHash_.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
+  }
+
+  @Test
   public void testModelWithFinalAttribute() {
     JavaFileObject model = JavaFileObjects
         .forResource("ModelWithFinalField.java");

--- a/epoxy-processortest/src/test/resources/ModelConfigRequireHashCodeAllowsMarkedAttributes.java
+++ b/epoxy-processortest/src/test/resources/ModelConfigRequireHashCodeAllowsMarkedAttributes.java
@@ -1,0 +1,19 @@
+package com.airbnb.epoxy.configtest;
+
+import com.airbnb.epoxy.EpoxyAttribute;
+import com.airbnb.epoxy.EpoxyAttribute.Option;
+import com.airbnb.epoxy.EpoxyModel;
+
+public class ModelConfigRequireHashCodeAllowsMarkedAttributes extends EpoxyModel<Object> {
+
+  public static class ClassWithoutHashCode {
+
+  }
+
+  @EpoxyAttribute({Option.AllowMissingHash}) ClassWithoutHashCode classWithoutHashCode;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelConfigRequireHashCodeAllowsMarkedAttributes.java
+++ b/epoxy-processortest/src/test/resources/ModelConfigRequireHashCodeAllowsMarkedAttributes.java
@@ -10,7 +10,7 @@ public class ModelConfigRequireHashCodeAllowsMarkedAttributes extends EpoxyModel
 
   }
 
-  @EpoxyAttribute({Option.AllowMissingHash}) ClassWithoutHashCode classWithoutHashCode;
+  @EpoxyAttribute(Option.IgnoreRequireHashCode) ClassWithoutHashCode classWithoutHashCode;
 
   @Override
   protected int getDefaultLayout() {

--- a/epoxy-processortest/src/test/resources/ModelDoNotHash.java
+++ b/epoxy-processortest/src/test/resources/ModelDoNotHash.java
@@ -1,0 +1,14 @@
+package com.airbnb.epoxy;
+
+import com.airbnb.epoxy.EpoxyAttribute.Option;
+
+public class ModelDoNotHash extends EpoxyModel<Object> {
+  @EpoxyAttribute int value;
+  @EpoxyAttribute({Option.DoNotHash}) int value2;
+  @EpoxyAttribute({Option.DoNotHash}) String value3;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
@@ -1,0 +1,131 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+
+/**
+ * Generated file. Do not modify! */
+public class ModelDoNotHash_ extends ModelDoNotHash {
+  public ModelDoNotHash_() {
+    super();
+  }
+
+  public ModelDoNotHash_ value2(int value2) {
+    this.value2 = value2;
+    return this;
+  }
+
+  public int value2() {
+    return value2;
+  }
+
+  public ModelDoNotHash_ value(int value) {
+    this.value = value;
+    return this;
+  }
+
+  public int value() {
+    return value;
+  }
+
+  public ModelDoNotHash_ value3(String value3) {
+    this.value3 = value3;
+    return this;
+  }
+
+  public String value3() {
+    return value3;
+  }
+
+  @Override
+  public ModelDoNotHash_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelDoNotHash_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelDoNotHash_ id(CharSequence key, long id) {
+    super.id(key, id);
+    return this;
+  }
+
+  @Override
+  public ModelDoNotHash_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
+    return this;
+  }
+
+  @Override
+  public ModelDoNotHash_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public ModelDoNotHash_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public ModelDoNotHash_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  public ModelDoNotHash_ reset() {
+    this.value2 = 0;
+    this.value = 0;
+    this.value3 = null;
+    super.reset();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof ModelDoNotHash_)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    ModelDoNotHash_ that = (ModelDoNotHash_) o;
+    if (value != that.value) {
+      return false;
+    }
+    if (value3 != null && that.value3 == null || value3 == null && that.value3 != null) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + value;
+    result = 31 * result + (value3 != null ? 1 : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ModelDoNotHash_{" +
+        "value2=" + value2 +
+        ", value=" + value +
+        ", value3=" + value3 +
+        "}" + super.toString();
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener.java
@@ -2,8 +2,12 @@ package com.airbnb.epoxy;
 
 import android.view.View;
 
+import com.airbnb.epoxy.EpoxyAttribute.Option;
+
+import static com.airbnb.epoxy.EpoxyAttribute.Option.DoNotHash;
+
 public class ModelWithViewClickListener extends EpoxyModel<Object> {
-  @EpoxyAttribute View.OnClickListener clickListener;
+  @EpoxyAttribute(DoNotHash) View.OnClickListener clickListener;
 
   @Override
   protected int getDefaultLayout() {

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -55,6 +55,10 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
                 boundEpoxyViewHolder.getAdapterPosition());
           }
         }
+        public int hashCode() {
+          // Hash the original click listener to avoid changing model state
+          return clickListener.hashCode();
+        }
       };
     }
     return this;

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/SampleAdapter.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/SampleAdapter.java
@@ -34,6 +34,8 @@ class SampleAdapter extends TypedAutoEpoxyAdapter<List<ColorData>> {
   // TODO: (eli_hart 2/27/17) typed adapter integration test
   // TODO: (eli_hart 2/27/17) Consider adding span/position/count to getDefaultLayout
   // TODO: (eli_hart 2/27/17) consider removing equals and renaming hashcode to epoxyHash
+  // TODO: (eli_hart 2/28/17) Null out automodels after building models?
+  // TODO: (eli_hart 2/28/17) Change buildModels name to render?
 
   @Override
   protected void buildModels(List<ColorData> colors) {

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/models/ButtonModel.java
@@ -12,11 +12,13 @@ import com.airbnb.epoxy.models.ButtonModel.ButtonHolder;
 
 import butterknife.BindView;
 
+import static com.airbnb.epoxy.EpoxyAttribute.Option.DoNotHash;
+
 /** This model class gives an example of how to use a view holder pattern with your models. */
 @EpoxyModelClass(layout = R.layout.model_button)
 public abstract class ButtonModel extends EpoxyModelWithHolder<ButtonHolder> {
   @EpoxyAttribute @StringRes int text;
-  @EpoxyAttribute(hash = false) OnClickListener clickListener;
+  @EpoxyAttribute(DoNotHash) OnClickListener clickListener;
 
   @Override
   public int getSpanSize(int totalSpanCount, int position, int itemCount) {


### PR DESCRIPTION
This introduces a set of options that can be set as an array on an EpoxyAttribute. It deprecates and replaces the use of hash=false. Instead you would now say `@EpoxyAttribute({DoNotHash})`. it also introduces two new options. AllowMissingHash and NoGetter. These are detailed in the code comments.

There were a few reasons for this. Importantly, something like `AllowMissingHash` needed to be added for the special case of ignoring the package config of failing on attributes without hashcode (like the AutoValue case). `hash=true` does not work in that case because it is the default, and it isn't possible to use Boolean as an annotation param. This options approach makes it easy to add support for this.

Another, I want to allow for other adding more params to the annotation without having a long list -> `EpoxyAttribute(hash = false, setter = false, getter = false)` etc.

I also think this reads a bit nicer.

@gpeal @felipecsl @seanabraham @ngsilverman 