### PR TITLE
Reduce duplication of private getter/setter code

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
@@ -279,12 +279,12 @@ class AttributeInfo {
     return isPrivate;
   }
 
-  String getter() {
-    return getter;
+  String getterCode() {
+    return isPrivate ? getter + "()" : name;
   }
 
-  String setter() {
-    return setter;
+  String setterCode() {
+    return isPrivate ? setter + "($L)" : name + " = $L";
   }
 
   @Override


### PR DESCRIPTION
@geralt-encore This lets us remove the `if (attribute is private) else...` code generation blocks by having a little method to generate the setter/getter code for each case. What do you think?