### PR TITLE
Automatically assign view types for models with view

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelperLookup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelperLookup.java
@@ -1,5 +1,7 @@
 package com.airbnb.epoxy;
 
+import android.support.annotation.Nullable;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.LinkedHashMap;
@@ -39,10 +41,11 @@ class ControllerHelperLookup {
     }
   }
 
+  @Nullable
   private static Constructor<?> findConstructorForClass(Class<?> controllerClass) {
-    Constructor<?> bindingCtor = BINDINGS.get(controllerClass);
-    if (bindingCtor != null) {
-      return bindingCtor;
+    Constructor<?> helperCtor = BINDINGS.get(controllerClass);
+    if (helperCtor != null || BINDINGS.containsKey(controllerClass)) {
+      return helperCtor;
     }
 
     String clsName = controllerClass.getName();
@@ -53,13 +56,13 @@ class ControllerHelperLookup {
     try {
       Class<?> bindingClass = Class.forName(clsName + GENERATED_HELPER_CLASS_SUFFIX);
       //noinspection unchecked
-      bindingCtor = bindingClass.getConstructor(controllerClass);
+      helperCtor = bindingClass.getConstructor(controllerClass);
     } catch (ClassNotFoundException e) {
-      bindingCtor = findConstructorForClass(controllerClass.getSuperclass());
+      helperCtor = findConstructorForClass(controllerClass.getSuperclass());
     } catch (NoSuchMethodException e) {
       throw new RuntimeException("Unable to find Epoxy Helper constructor for " + clsName, e);
     }
-    BINDINGS.put(controllerClass, bindingCtor);
-    return bindingCtor;
+    BINDINGS.put(controllerClass, helperCtor);
+    return helperCtor;
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
@@ -43,7 +43,9 @@ public abstract class EpoxyController {
   private boolean hasBuiltModelsEver;
 
   // TODO: (eli_hart 3/8/17) Don't always delay first build?
-  // TODO: (eli_hart 3/9/17) Validate newly added model does not exist on current adapter models
+  // TODO: (eli_hart 3/9/17) Validate newly added model does not exist on current adapter models???
+  // TODO: (eli_hart 3/9/17) validate addTo doesn't add a model that == a model already added
+  // TODO: (eli_hart 3/9/17) hook after build models before diffing (eg to toggle dividers)
 
   // Readme items:
   // hidden models breaking for pull to refresh or multiple items in a row on grid
@@ -61,6 +63,10 @@ public abstract class EpoxyController {
    * #buildModels()} so that models can be rebuilt for the current data.
    */
   public void requestModelBuild() {
+    if (isBuildingModels()) {
+      throw new IllegalStateException("Cannot call `requestBuildModels` from inside `buildModels`");
+    }
+
     handler.removeCallbacks(buildModelsRunnable);
     handler.post(buildModelsRunnable);
   }
@@ -303,6 +309,13 @@ public abstract class EpoxyController {
     return adapter.isMultiSpan();
   }
 
+  /**
+   * This is called when recoverable exceptions happen at runtime. They can be ignored and Epoxy
+   * will recover, but you can override this to be aware of when they happen.
+   */
+  protected void onExceptionSwallowed(RuntimeException exception) {
+  }
+
   /** Called when the controller's adapter is attach to a recyclerview. */
   protected void onAttachedToRecyclerView(RecyclerView recyclerView) {
 
@@ -314,9 +327,40 @@ public abstract class EpoxyController {
   }
 
   /**
-   * This is called when recoverable exceptions happen at runtime. They can be ignored and Epoxy
-   * will recover, but you can override this to be aware of when they happen.
+   * Called immediately after a model is bound to a view holder. Subclasses can override this if
+   * they want alerts on when a model is bound. Alternatively you may attach a listener directly to
+   * a generated model with model.onBind(...)
    */
-  protected void onExceptionSwallowed(RuntimeException exception) {
+  protected void onModelBound(EpoxyViewHolder holder, EpoxyModel<?> model, int position,
+      @Nullable List<Object> payloads) {
+  }
+
+  /**
+   * Called immediately after a model is unbound from a view holder. Subclasses can override this if
+   * they want alerts on when a model is unbound. Alternatively you may attach a listener directly
+   * to a generated model with model.onUnbind(...)
+   */
+  protected void onModelUnbound(EpoxyViewHolder holder, EpoxyModel<?> model) {
+
+  }
+
+  /**
+   * Called when the given viewholder is attached to the window, along with the model it is bound
+   * to.
+   *
+   * @see BaseEpoxyAdapter#onViewAttachedToWindow(EpoxyViewHolder)
+   */
+  protected void onViewAttachedToWindow(EpoxyViewHolder holder, EpoxyModel<?> model) {
+
+  }
+
+  /**
+   * Called when the given viewholder is detechaed from the window, along with the model it is bound
+   * to.
+   *
+   * @see BaseEpoxyAdapter#onViewDetachedFromWindow(EpoxyViewHolder)
+   */
+  protected void onViewDetachedFromWindow(EpoxyViewHolder holder, EpoxyModel<?> model) {
+
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -46,6 +46,29 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter {
     epoxyController.onDetachedFromRecyclerView(recyclerView);
   }
 
+  @Override
+  public void onViewAttachedToWindow(EpoxyViewHolder holder) {
+    super.onViewAttachedToWindow(holder);
+    epoxyController.onViewAttachedToWindow(holder, holder.getModel());
+  }
+
+  @Override
+  public void onViewDetachedFromWindow(EpoxyViewHolder holder) {
+    super.onViewDetachedFromWindow(holder);
+    epoxyController.onViewDetachedFromWindow(holder, holder.getModel());
+  }
+
+  @Override
+  protected void onModelBound(EpoxyViewHolder holder, EpoxyModel<?> model, int position,
+      @Nullable List<Object> payloads) {
+    epoxyController.onModelBound(holder, model, position, payloads);
+  }
+
+  @Override
+  protected void onModelUnbound(EpoxyViewHolder holder, EpoxyModel<?> model) {
+    epoxyController.onModelUnbound(holder, model);
+  }
+
   /** Get an unmodifiable copy of the current models set on the adapter. */
   public List<EpoxyModel<?>> getCopyOfModels() {
     if (copyOfCurrentModels == null) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithView.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithView.java
@@ -9,18 +9,16 @@ import android.view.ViewGroup;
  * resource. Just implement {@link #buildView} so the adapter can create a new view for this model
  * when needed.
  * <p>
- * {@link #getViewType()} is used by the adapter to know how to reuse views for this model. If it is
- * left unimplemented then the generated model will include an implementation which returns a value
- * based on the generated model's name. This means that all models of that type should be able to
- * share the same view, but the view won't be shared with models of any other type.
+ * {@link #getViewType()} is used by the adapter to know how to reuse views for this model. This
+ * means that all models that return the same type should be able to share the same view, and the
+ * view won't be shared with models of any other type.
  * <p>
- * The generated view type will be negative so that it cannot collide with values from layout
- * resources, which are used in normal Epoxy models. However, it is possible for generated view
- * types to collide if models from different libraries are used together, since the model processor
- * can only guarantee that view types are unique within a library. If you need to use {@link
- * EpoxyModelWithView} models from different libraries or modules together you can define a view
- * type manually to avoid this small collision chance. A good way to manually create value is by
- * creating an R.id. value in an ids resource while, which will guarantee a unique value.
+ * If it is left unimplemented then at runtime a unique view type will be created to use for all
+ * models of that class. The generated view type will be negative so that it cannot collide with
+ * values from resource files, which are used in normal Epoxy models. If you would like to share
+ * the same view between models of different classes you can have those classes return the same view
+ * type. A good way to manually create a view type value is by creating an R.id. value in an ids
+ * resource file.
  */
 public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
 
@@ -31,7 +29,9 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
    * @see android.support.v7.widget.RecyclerView.Adapter#getItemViewType(int)
    */
   @Override
-  protected abstract int getViewType();
+  protected int getViewType() {
+    return 0;
+  }
 
   /**
    * Create and return a new instance of a view for this model. If no layout params are set on the

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ViewTypeManager.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ViewTypeManager.java
@@ -1,0 +1,92 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.VisibleForTesting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class ViewTypeManager {
+  private static Map<Class, Integer> viewTypeMap;
+  /**
+   * The last model that had its view type looked up. This is stored so in most cases we can quickly
+   * look up what view type belongs to which model.
+   */
+  private EpoxyModel<?> lastModelForViewTypeLookup;
+
+  /**
+   * The type map is static so that models of the same class share the same views across different
+   * adapters. This is useful for view recycling when the adapter instance changes, or when there
+   * are multiple adapters. For testing purposes though it is good to be able to clear the map so we
+   * don't carry over values across tests.
+   */
+  @VisibleForTesting
+  void resetMapForTesting() {
+    if (viewTypeMap != null) {
+      viewTypeMap.clear();
+    }
+  }
+
+  int getViewType(EpoxyModel<?> model) {
+    lastModelForViewTypeLookup = model;
+    return getViewTypeInternal(model);
+  }
+
+  private static int getViewTypeInternal(EpoxyModel<?> model) {
+    int defaultViewType = model.getViewType();
+    if (defaultViewType != 0) {
+      return defaultViewType;
+    }
+
+    // If a model does not specify a view type then we generate a value to use for models of that
+    // class.
+    Class modelClass = model.getClass();
+    if (viewTypeMap == null) {
+      viewTypeMap = new HashMap<>();
+    }
+
+    Integer viewType = viewTypeMap.get(modelClass);
+
+    if (viewType == null) {
+      viewType = -viewTypeMap.size() - 1;
+      viewTypeMap.put(modelClass, viewType);
+    }
+
+    return viewType;
+  }
+
+  /**
+   * Find the model that has the given view type so we can create a view for that model. In most
+   * cases this value is a layout resource and we could simply inflate it, but to support {@link
+   * EpoxyModelWithView} we can't assume the view type is a layout. In that case we need to lookup
+   * the model so we can ask it to create a new view for itself.
+   * <p>
+   * To make this efficient, we rely on the RecyclerView implementation detail that {@link
+   * BaseEpoxyAdapter#getItemViewType(int)} is called immediately before {@link
+   * BaseEpoxyAdapter#onCreateViewHolder(android.view.
+   *, int)}. We cache the last model that
+   * had its view type looked up, and unless that implementation changes we expect to have a very
+   * fast lookup for the correct model.
+   * <p>
+   * To be safe, we fallback to searching through all models for a view type match. This is slow and
+   * shouldn't be needed, but is a guard against recyclerview behavior changing.
+   */
+  EpoxyModel<?> getModelForViewType(BaseEpoxyAdapter adapter, int viewType) {
+    if (lastModelForViewTypeLookup != null
+        && getViewTypeInternal(lastModelForViewTypeLookup) == viewType) {
+      // We expect this to be a hit 100% of the time
+      return lastModelForViewTypeLookup;
+    }
+
+    adapter.onExceptionSwallowed(
+        new IllegalStateException("Last model did not match expected view type"));
+
+    // To be extra safe in case RecyclerView implementation details change...
+    for (EpoxyModel<?> model : adapter.getCurrentModels()) {
+      if (model.getViewType() == viewType) {
+        return model;
+      }
+    }
+
+    throw new IllegalStateException("Could not find model for view type: " + viewType);
+  }
+}

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/ViewTypeManagerIntegrationTest.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/ViewTypeManagerIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.airbnb.epoxy;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@Config(sdk = 21, manifest = TestRunner.MANIFEST_PATH)
+@RunWith(TestRunner.class)
+public class ViewTypeManagerIntegrationTest {
+
+  @Before
+  public void resetViewTypeMap() {
+    new ViewTypeManager().resetMapForTesting();
+  }
+
+  static class TestModel extends EpoxyModelWithView<View> {
+    @Override
+    protected View buildView(ViewGroup parent) {
+      return new FrameLayout(RuntimeEnvironment.application);
+    }
+  }
+
+  static class ModelWithViewType extends TestModel {
+
+    @Override
+    protected int getViewType() {
+      return 1;
+    }
+  }
+
+  static class ModelWithViewType2 extends TestModel {
+
+    @Override
+    protected int getViewType() {
+      return 2;
+    }
+  }
+
+  @Test
+  public void modelWithLayout() {
+    SimpleEpoxyAdapter adapter = new SimpleEpoxyAdapter();
+    adapter.addModel(new ModelWithViewType());
+    adapter.addModel(new ModelWithViewType2());
+
+    // The view type should be the value declared in the model
+    assertEquals(1, adapter.getItemViewType(0));
+    assertEquals(2, adapter.getItemViewType(1));
+  }
+
+  static class ModelWithoutViewType extends TestModel {}
+
+  static class ModelWithoutViewType2 extends TestModel {}
+
+  static class ModelWithoutViewType3 extends TestModel {}
+
+  @Test
+  public void modelsWithoutLayoutHaveViewTypesGenerated() {
+    SimpleEpoxyAdapter adapter = new SimpleEpoxyAdapter();
+
+    adapter.addModel(new ModelWithoutViewType());
+    adapter.addModel(new ModelWithoutViewType2());
+    adapter.addModel(new ModelWithoutViewType3());
+
+    adapter.addModel(new ModelWithoutViewType());
+    adapter.addModel(new ModelWithoutViewType2());
+    adapter.addModel(new ModelWithoutViewType3());
+
+    // Models with view type 0 should have a view type generated for them
+    assertEquals(-1, adapter.getItemViewType(0));
+    assertEquals(-2, adapter.getItemViewType(1));
+    assertEquals(-3, adapter.getItemViewType(2));
+    // Models of same class should share the same generated view type
+    assertEquals(-1, adapter.getItemViewType(3));
+    assertEquals(-2, adapter.getItemViewType(4));
+    assertEquals(-3, adapter.getItemViewType(5));
+  }
+
+  @Test
+  public void fastModelLookupOfLastModel() {
+    SimpleEpoxyAdapter adapter = spy(new SimpleEpoxyAdapter());
+    TestModel modelToAdd = spy(new ModelWithoutViewType());
+    adapter.addModel(modelToAdd);
+
+    int itemViewType = adapter.getItemViewType(0);
+
+    adapter.onCreateViewHolder(null, itemViewType);
+
+    // onExceptionSwallowed is called if the fast model look up failed
+    verify(adapter, never()).onExceptionSwallowed(any(RuntimeException.class));
+    verify(modelToAdd).buildView(null);
+  }
+
+  @Test
+  public void fallbackLookupOfUnknownModel() {
+    SimpleEpoxyAdapter adapter = spy(new SimpleEpoxyAdapter());
+    TestModel modelToAdd = spy(new ModelWithViewType());
+    adapter.addModel(modelToAdd);
+
+    // If we pass a view type that hasn't been looked up recently it should fallback to searching
+    // through all models to find a match.
+    adapter.onCreateViewHolder(null, 1);
+
+    // onExceptionSwallowed is called when the fast model look up fails
+    verify(adapter).onExceptionSwallowed(any(RuntimeException.class));
+    verify(modelToAdd).buildView(null);
+  }
+
+  @Test
+  public void viewTypesSharedAcrossAdapters() {
+    SimpleEpoxyAdapter adapter1 = new SimpleEpoxyAdapter();
+    SimpleEpoxyAdapter adapter2 = new SimpleEpoxyAdapter();
+
+    adapter1.addModel(new ModelWithoutViewType());
+    adapter1.addModel(new ModelWithoutViewType2());
+
+    adapter2.addModel(new ModelWithoutViewType());
+    adapter2.addModel(new ModelWithoutViewType2());
+
+    assertEquals(adapter1.getItemViewType(0), adapter2.getItemViewType(0));
+    assertEquals(adapter1.getItemViewType(1), adapter2.getItemViewType(1));
+  }
+}


### PR DESCRIPTION
Finishes support for https://github.com/airbnb/epoxy/issues/86

This allows models with programmatic views to not specify a custom view type (leaving a default of 0) and at runtime the adapter will create a view type to use with models of that class.

@niccorder This is MUCH simpler than trying to generate a value at compile time in the processor, and this seems to work nicely. Hope you didn't spend too much time on the gradle plugin approach. Personally I was too focused on the idea of solving this in the annotation processor. Thankfully my teammate realized it could be done this way instead.

I included some other clean up and feature work for the 2.0 branch too, but the applicable change is the `ViewTypeManager` class and it's usage in BaseEpoxyAdapter. EpoxyModelWithView was also updated to support this.

@ngsilverman Thanks for the idea! It is awesome.