### PR TITLE
Better approach to model grouping

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithView.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithView.java
@@ -35,10 +35,9 @@ public abstract class EpoxyModelWithView<T extends View> extends EpoxyModel<T> {
 
   /**
    * Create and return a new instance of a view for this model. If no layout params are set on the
-   * returned view then the RecyclerView will set default layout params on it, which set the size to
-   * wrap_content.
+   * returned view then default layout params will be used.
    *
-   * @param parent The parent viewgroup that the returned view will be added to. It can be used to
+   * @param parent The parent ViewGroup that the returned view will be added to. It can be used to
    *               create layout params for the new view.
    */
   @Override

--- a/epoxy-adapter/src/main/res/layout/epoxy_model_group_horizontal.xml
+++ b/epoxy-adapter/src/main/res/layout/epoxy_model_group_horizontal.xml
@@ -1,32 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!-- A sample layout to use with EpoxyModelGroup to group up to 5 models horizontally. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_1"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_2"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_3"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_4"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_5"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/epoxy-adapter/src/main/res/layout/epoxy_model_group_vertical.xml
+++ b/epoxy-adapter/src/main/res/layout/epoxy_model_group_vertical.xml
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!-- A sample layout to use with EpoxyModelGroup to group up to 5 models vertically. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_3"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_4"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <ViewStub
-        android:id="@id/epoxy_model_group_view_stub_5"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/epoxy-adapter/src/main/res/values/ids.xml
+++ b/epoxy-adapter/src/main/res/values/ids.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="view_model_state_saving_id" type="id" />
-
-    <!-- Used by the model group class -->
-    <item name="epoxy_model_group_view_stub_1" type="id" />
-    <item name="epoxy_model_group_view_stub_2" type="id" />
-    <item name="epoxy_model_group_view_stub_3" type="id" />
-    <item name="epoxy_model_group_view_stub_4" type="id" />
-    <item name="epoxy_model_group_view_stub_5" type="id" />
 </resources>

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
@@ -58,7 +58,6 @@ class ModelProcessor {
     modelClassMap = new LinkedHashMap<>();
 
     for (Element attribute : roundEnv.getElementsAnnotatedWith(EpoxyAttribute.class)) {
-      messager.printMessage(Kind.NOTE, "field typename: " + TypeName.get(attribute.asType()));
       try {
         addAttributeToGeneratedClass(attribute, modelClassMap);
       } catch (Exception e) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
@@ -1,7 +1,5 @@
 package com.airbnb.epoxy;
 
-import com.squareup.javapoet.TypeName;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -21,7 +19,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import javax.tools.Diagnostic.Kind;
 
 import static com.airbnb.epoxy.ProcessorUtils.EPOXY_MODEL_TYPE;
 import static com.airbnb.epoxy.ProcessorUtils.isEpoxyModel;


### PR DESCRIPTION
This changes the EpoxyModelGroup from needing a specific id on a viewstub to recognize model it belongs to, to instead just using the view stubs in their child order in the view group. This should be more flexible and easier to understand since we don't have to force arbitrary id usage. It also lifts the arbitrary 5 model limit. I also fixed support and added documentation for EpoxyModelWithView inside the group model