### PR TITLE
Add interceptor to EpoxyController to allow for adjusting models

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerModelList.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerModelList.java
@@ -1,0 +1,35 @@
+package com.airbnb.epoxy;
+
+/**
+ * This ArrayList subclass enforces that no changes are made to the list after {@link #freeze()} is
+ * called. This prevents model interceptors from storing the list and trying to change it later. We
+ * could copy the list before diffing, but that would waste memory to make the copy for every
+ * buildModels cycle, plus the interceptors could still try to modify the list and be confused about
+ * why it doesn't do anything.
+ */
+class ControllerModelList extends ModelList {
+
+  private static final ModelListObserver OBSERVER = new ModelListObserver() {
+    @Override
+    public void onItemRangeInserted(int positionStart, int itemCount) {
+      throw new IllegalStateException(
+          "Models cannot be changed once they are added to the controller");
+    }
+
+    @Override
+    public void onItemRangeRemoved(int positionStart, int itemCount) {
+      throw new IllegalStateException(
+          "Models cannot be changed once they are added to the controller");
+    }
+  };
+
+  ControllerModelList(int expectedModelCount) {
+    super(expectedModelCount);
+    pauseNotifications();
+  }
+
+  void freeze() {
+    setObserver(OBSERVER);
+    resumeNotifications();
+  }
+}

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelList.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelList.java
@@ -18,6 +18,14 @@ import java.util.NoSuchElementException;
  */
 class ModelList extends ArrayList<EpoxyModel<?>> {
 
+  ModelList(int expectedModelCount) {
+    super(expectedModelCount);
+  }
+
+  ModelList() {
+
+  }
+
   interface ModelListObserver {
     void onItemRangeInserted(int positionStart, int itemCount);
     void onItemRangeRemoved(int positionStart, int itemCount);

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyControllerTest.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyControllerTest.java
@@ -1,0 +1,195 @@
+package com.airbnb.epoxy;
+
+import android.support.v7.widget.RecyclerView.AdapterDataObserver;
+
+import com.airbnb.epoxy.EpoxyController.Interceptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@Config(sdk = 21, manifest = TestRunner.MANIFEST_PATH)
+@RunWith(TestRunner.class)
+public class EpoxyControllerTest {
+
+  boolean noExceptionsDuringBasicBuildModels = true;
+
+  @Test
+  public void basicBuildModels() {
+    AdapterDataObserver observer = mock(AdapterDataObserver.class);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .addTo(this);
+      }
+
+      @Override
+      protected void onExceptionSwallowed(RuntimeException exception) {
+        noExceptionsDuringBasicBuildModels = false;
+      }
+    };
+
+    controller.getAdapter().registerAdapterDataObserver(observer);
+    controller.requestModelBuild();
+
+    assertTrue(noExceptionsDuringBasicBuildModels);
+    assertEquals(1, controller.getAdapter().getItemCount());
+    verify(observer).onItemRangeInserted(0, 1);
+    verifyNoMoreInteractions(observer);
+  }
+
+  @Test
+  public void filterDuplicates() {
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .id(1)
+            .addTo(this);
+
+        new TestModel()
+            .id(1)
+            .addTo(this);
+      }
+    };
+
+    controller.setFilterDuplicates(true);
+    controller.requestModelBuild();
+
+    assertEquals(1, controller.getAdapter().getItemCount());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void throwOnDuplicatesIfNotFiltering() {
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .id(1)
+            .addTo(this);
+
+        new TestModel()
+            .id(1)
+            .addTo(this);
+      }
+    };
+
+    controller.requestModelBuild();
+  }
+
+  boolean exceptionSwallowed;
+
+  @Test
+  public void exceptionSwallowedWhenDuplicateFiltered() {
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .id(1)
+            .addTo(this);
+
+        new TestModel()
+            .id(1)
+            .addTo(this);
+      }
+
+      @Override
+      protected void onExceptionSwallowed(RuntimeException exception) {
+        exceptionSwallowed = true;
+      }
+    };
+
+    controller.setFilterDuplicates(true);
+    controller.requestModelBuild();
+
+    assertTrue(exceptionSwallowed);
+  }
+
+  boolean interceptorCalled;
+
+  @Test
+  public void interceptorRunsAfterBuildModels() {
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .addTo(this);
+      }
+    };
+
+    controller.addInterceptor(new Interceptor() {
+      @Override
+      public void intercept(List<EpoxyModel<?>> models) {
+        assertEquals(1, models.size());
+        interceptorCalled = true;
+      }
+    });
+
+    controller.requestModelBuild();
+
+    assertTrue(interceptorCalled);
+    assertEquals(1, controller.getAdapter().getItemCount());
+  }
+
+  @Test
+  public void interceptorCanChangeModels() {
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .addTo(this);
+      }
+    };
+
+    controller.addInterceptor(new Interceptor() {
+      @Override
+      public void intercept(List<EpoxyModel<?>> models) {
+        models.add(new TestModel());
+      }
+    });
+
+    controller.requestModelBuild();
+
+    assertEquals(2, controller.getAdapter().getItemCount());
+  }
+
+  List<EpoxyModel<?>> savedModels;
+
+  @Test(expected = IllegalStateException.class)
+  public void interceptorCannotAddModelsLater() {
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .addTo(this);
+      }
+    };
+
+    controller.addInterceptor(new Interceptor() {
+      @Override
+      public void intercept(List<EpoxyModel<?>> models) {
+        savedModels = models;
+      }
+    });
+
+    controller.requestModelBuild();
+
+    savedModels.add(new TestModel());
+  }
+}

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyControllerTest.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyControllerTest.java
@@ -192,4 +192,36 @@ public class EpoxyControllerTest {
 
     savedModels.add(new TestModel());
   }
+
+  @Test
+  public void interceptorsRunInOrderAdded() {
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new TestModel()
+            .addTo(this);
+      }
+    };
+
+    controller.addInterceptor(new Interceptor() {
+      @Override
+      public void intercept(List<EpoxyModel<?>> models) {
+        assertEquals(1, models.size());
+        models.add(new TestModel());
+      }
+    });
+
+    controller.addInterceptor(new Interceptor() {
+      @Override
+      public void intercept(List<EpoxyModel<?>> models) {
+        assertEquals(2, models.size());
+        models.add(new TestModel());
+      }
+    });
+
+    controller.requestModelBuild();
+
+    assertEquals(3, controller.getAdapter().getItemCount());
+  }
 }


### PR DESCRIPTION
This interceptor will run after `buildModels` and before the models are diffed and set on the adapter. The use case is adjustments to the models that are best done when you have all the models in aggregate to work with, such as toggling divider logic or moving a model for an experiment.

@ngsilverman @gpeal 