### PR TITLE
Fix Kotlin corner case with propery named is%s

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
@@ -261,4 +261,9 @@ class ProcessorUtils {
     }
     return original.substring(0, 1).toUpperCase() + original.substring(1);
   }
+
+  static boolean startsWithIs(String original) {
+    return original.startsWith("is") && original.length() > 2
+        && Character.isUpperCase(original.charAt(2));
+  }
 }

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ModelProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ModelProcessorTest.java
@@ -652,7 +652,7 @@ public class ModelProcessorTest {
     JavaFileObject model = JavaFileObjects
         .forResource("ModelWithPrivateViewClickListener.java");
 
-    JavaFileObject generatedNoLayoutModel = JavaFileObjects
+    JavaFileObject generatedModel = JavaFileObjects
         .forResource("ModelWithPrivateViewClickListener_.java");
 
     assert_().about(javaSource())
@@ -660,6 +660,22 @@ public class ModelProcessorTest {
         .processedWith(new EpoxyProcessor())
         .compilesWithoutError()
         .and()
-        .generatesSources(generatedNoLayoutModel);
+        .generatesSources(generatedModel);
+  }
+
+  @Test
+  public void modelWithPrivateFieldWithSameAsFieldGetterAndSetterName() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName.java");
+
+    JavaFileObject generatedModel = JavaFileObjects
+        .forResource("ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java");
+
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
   }
 }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName.java
@@ -1,0 +1,18 @@
+package com.airbnb.epoxy;
+
+public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName extends EpoxyModel<Object> {
+  @EpoxyAttribute private boolean isValue;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+
+  public boolean isValue() {
+    return isValue;
+  }
+
+  public void setValue(boolean isValue) {
+    this.isValue = isValue;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
@@ -1,0 +1,162 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import java.lang.CharSequence;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+
+/**
+ * Generated file. Do not modify! */
+public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName implements GeneratedModel<Object> {
+  private OnModelBoundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> onModelBoundListener_epoxyGeneratedModel;
+
+  private OnModelUnboundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> onModelUnboundListener_epoxyGeneratedModel;
+
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_() {
+    super();
+  }
+
+  @Override
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+  }
+
+  @Override
+  public void handlePostBind(final Object object, int position) {
+    if (onModelBoundListener_epoxyGeneratedModel != null) {
+      onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
+    }
+  }
+
+  /**
+   * Register a listener that will be called when this model is bound to a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ onBind(OnModelBoundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> listener) {
+    this.onModelBoundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  @Override
+  public void unbind(Object object) {
+    super.unbind(object);
+    if (onModelUnboundListener_epoxyGeneratedModel != null) {
+      onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
+    }
+  }
+
+  /**
+   * Register a listener that will be called when this model is unbound from a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ onUnbind(OnModelUnboundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> listener) {
+    this.onModelUnboundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ isValue(boolean isValue) {
+    this.setValue(isValue);
+    return this;
+  }
+
+  public boolean isValue() {
+    return isValue();
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ id(CharSequence key, long id) {
+    super.id(key, id);
+    return this;
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
+    return this;
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ reset() {
+    onModelBoundListener_epoxyGeneratedModel = null;
+    onModelUnboundListener_epoxyGeneratedModel = null;
+    this.setValue(false);
+    super.reset();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ that = (ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_) o;
+    if ((onModelBoundListener_epoxyGeneratedModel == null) != (that.onModelBoundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if ((onModelUnboundListener_epoxyGeneratedModel == null) != (that.onModelUnboundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if (isValue() != that.isValue()) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (onModelBoundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + (onModelUnboundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + (isValue() ? 1 : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_{" +
+        "isValue=" + isValue() +
+        "}" + super.toString();
+  }
+}


### PR DESCRIPTION
I've found a corner case with an integration of models written in Kotlin with Epoxy.
So originally we were checking property name and converting it into getter or setter by adding a `get` or `set` prefix. This is how Kotlin properties are backed with getters/setters for Java compatibility in most cases. But there is an exception. If your property named like `isProperty` then getter for it will have the same name as a property itself. And for this case, we won't be able to generate a model since we are looking for a getter with `getIsProperty` name which doesn't exist.
