### PR TITLE
Add model usage validation in generated code

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelper.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelper.java
@@ -1,5 +1,7 @@
 package com.airbnb.epoxy;
 
+import java.util.List;
+
 /**
  * A helper class for {@link EpoxyController} to handle {@link
  * com.airbnb.epoxy.AutoModel} models. This is only implemented by the generated classes created the
@@ -7,4 +9,14 @@ package com.airbnb.epoxy;
  */
 public abstract class ControllerHelper<T extends EpoxyController> {
   public abstract void resetAutoModels();
+
+  protected void validateModelHashCodesHaveNotChanged(EpoxyController controller) {
+    List<EpoxyModel<?>> currentModels = controller.getAdapter().getCopyOfModels();
+
+    for (int i = 0; i < currentModels.size(); i++) {
+      EpoxyModel model = currentModels.get(i);
+      model.validateStateHasNotChangedSinceAdded(
+          "Model has changed since it was added to the controller.");
+    }
+  }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -12,6 +12,7 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter {
   private final EpoxyController epoxyController;
   private List<EpoxyModel<?>> currentModels = Collections.emptyList();
   private List<EpoxyModel<?>> copyOfCurrentModels;
+  private int itemCount;
 
   EpoxyControllerAdapter(EpoxyController epoxyController) {
     this.epoxyController = epoxyController;
@@ -28,7 +29,16 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter {
     return currentModels;
   }
 
+  @Override
+  public int getItemCount() {
+    // RecyclerView calls this A LOT. The base class implementation does
+    // getCurrentModels().size() which adds some overhead because of the method calls.
+    // We can easily memoize this, which seems to help when there are lots of models.
+    return itemCount;
+  }
+
   void setModels(List<EpoxyModel<?>> models) {
+    itemCount = models.size();
     copyOfCurrentModels = null;
     this.currentModels = models;
     notifyBlocker.allowChanges();

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/IllegalEpoxyUsage.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/IllegalEpoxyUsage.java
@@ -1,0 +1,7 @@
+package com.airbnb.epoxy;
+
+public class IllegalEpoxyUsage extends RuntimeException {
+  public IllegalEpoxyUsage(String message) {
+    super(message);
+  }
+}

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ImmutableModelException.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ImmutableModelException.java
@@ -1,0 +1,45 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Thrown if a model is changed after it is added to an {@link com.airbnb.epoxy.EpoxyController}.
+ */
+class ImmutableModelException extends RuntimeException {
+  private static final String MODEL_CANNOT_BE_CHANGED_MESSAGE =
+      "A model cannot be changed once it is added to a controller. The only exception is if "
+          + "the change is made inside an Interceptor callback. Consider using an interceptor"
+          + " if you need to change a model after it is added to the controller and before it"
+          + " is set on the adapter. If the model is already set on the adapter then you must"
+          + " call `requestModelBuild` instead to recreate all models.";
+
+  ImmutableModelException(EpoxyController controller, EpoxyModel model) {
+    this(controller, model, "");
+  }
+
+  ImmutableModelException(EpoxyController controller, EpoxyModel model,
+      String descriptionOfWhenChangeHappened) {
+    super(buildMessage(controller, model, descriptionOfWhenChangeHappened));
+  }
+
+  @NonNull
+  private static String buildMessage(EpoxyController controller, EpoxyModel model,
+      String descriptionOfWhenChangeHappened) {
+    return new StringBuilder(descriptionOfWhenChangeHappened)
+        .append(" Position: ")
+        .append(getModelPosition(controller, model))
+        .append(" Model: ")
+        .append(model.toString())
+        .append("\n\n")
+        .append(MODEL_CANNOT_BE_CHANGED_MESSAGE)
+        .toString();
+  }
+
+  private static int getModelPosition(EpoxyController controller, EpoxyModel model) {
+    if (controller.isBuildingModels()) {
+      return controller.getIndexOfModelInBuildingList(model);
+    }
+
+    return controller.getAdapter().getModelPosition(model);
+  }
+}

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyAdapterTest.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyAdapterTest.java
@@ -382,7 +382,7 @@ public class EpoxyAdapterTest {
 
     testAdapter.addModel(testModel);
 
-    thrown.expect(IllegalStateException.class);
+    thrown.expect(IllegalEpoxyUsage.class);
     thrown.expectMessage("Cannot change a model's id after it has been added to the adapter");
     testModel.id(200);
   }
@@ -404,7 +404,7 @@ public class EpoxyAdapterTest {
     testAdapter.models.add(testModel);
     testAdapter.notifyModelsChanged();
 
-    thrown.expect(IllegalStateException.class);
+    thrown.expect(IllegalEpoxyUsage.class);
     thrown.expectMessage("Cannot change a model's id after it has been added to the adapter");
     testModel.id(200);
   }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/TestModel.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/TestModel.java
@@ -31,6 +31,10 @@ public class TestModel extends EpoxyModel<View> {
     return this;
   }
 
+  int value() {
+    return value;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
 public @interface PackageEpoxyConfig {
   boolean REQUIRE_HASHCODE_DEFAULT = false;
   boolean REQUIRE_ABSTRACT_MODELS = false;
-  boolean VALIDATE_AUTO_MODEL_USAGE = true;
+  boolean VALIDATE_MODEL_USAGE = true;
   /**
    * If true, all fields marked with {@link com.airbnb.epoxy.EpoxyAttribute} must have a type that
    * implements hashCode (besides the default Object implementation), or the attribute must set
@@ -50,12 +50,12 @@ public @interface PackageEpoxyConfig {
   boolean requireAbstractModels() default REQUIRE_ABSTRACT_MODELS;
 
   /**
-   * If true, fields annotated with {@link com.airbnb.epoxy.AutoModel} in an adapter will be
+   * If true, Epoxy models added to an EpoxyController will be
    * validated at run time to make sure they are properly used.
    * <p>
    * By default this is true, and it is highly recommended to enable it to prevent accidental misuse
-   * of your models. However, you may want to disable this for production builds to avoid the slight
-   * performance hit of the runtime validation code.
+   * of your models. However, you may want to disable this for production builds to avoid the
+   * overhead of the runtime validation code.
    * <p>
    * Using a debug build flag is a great way to do this. Unfortunately, BuildConfig.DEBUG is not
    * considered a constant and cannot be used as an annotation param. However, you can define a
@@ -64,5 +64,5 @@ public @interface PackageEpoxyConfig {
    * -constant">this
    * stack overflow post</a> for details.
    */
-  boolean validateAutoModelUsage() default VALIDATE_AUTO_MODEL_USAGE;
+  boolean validateModelUsage() default VALIDATE_MODEL_USAGE;
 }

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ControllerLifecycleHelper.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ControllerLifecycleHelper.java
@@ -1,0 +1,36 @@
+package com.airbnb.epoxy;
+
+import android.widget.FrameLayout;
+
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.List;
+
+class ControllerLifecycleHelper {
+  private EpoxyViewHolder viewHolder;
+
+  void buildModelsAndBind(EpoxyController controller) {
+    controller.requestModelBuild();
+    bindModels(controller);
+  }
+
+  void bindModels(EpoxyController controller) {
+    EpoxyControllerAdapter adapter = controller.getAdapter();
+
+    List<EpoxyModel<?>> models = adapter.getCopyOfModels();
+    for (int i = 0; i < models.size(); i++) {
+      EpoxyModel<?> model = models.get(i);
+      viewHolder =
+          adapter.onCreateViewHolder(
+              new FrameLayout(RuntimeEnvironment.application),
+              model.getLayout()
+          );
+
+      adapter.onBindViewHolder(viewHolder, i);
+    }
+  }
+
+  void recycleLastBoundModel(EpoxyController controller) {
+    controller.getAdapter().onViewRecycled(viewHolder);
+  }
+}

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ControllerWithAutoModel.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ControllerWithAutoModel.java
@@ -1,0 +1,11 @@
+package com.airbnb.epoxy;
+
+public class ControllerWithAutoModel extends EpoxyController {
+
+  @AutoModel Model_ model;
+
+  @Override
+  protected void buildModels() {
+    add(model);
+  }
+}

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelValidationTest.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelValidationTest.java
@@ -1,0 +1,430 @@
+package com.airbnb.epoxy;
+
+import android.view.View;
+
+import com.airbnb.epoxy.EpoxyController.Interceptor;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
+public class EpoxyModelValidationTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  static class Controller extends EpoxyController {
+
+    @Override
+    protected void buildModels() {
+
+    }
+  }
+
+  @Test
+  public void testModelCannotBeAddedTwice() {
+    thrown.expect(IllegalEpoxyUsage.class);
+    thrown.expectMessage("This model was already added to the controller at position 0");
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        Model model = new Model_().id(1);
+        model.addTo(this);
+        model.addTo(this);
+      }
+    };
+
+    controller.requestModelBuild();
+  }
+
+  @Test
+  public void addToOnlyValidInsideBuildModels() {
+    thrown.expect(IllegalEpoxyUsage.class);
+    thrown.expectMessage("You can only add models inside the `buildModels` methods");
+
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+      }
+    };
+
+    new Model_()
+        .id(1)
+        .addTo(controller);
+  }
+
+  @Test
+  public void addModelOnlyValidInsideBuildModels() {
+    thrown.expect(IllegalEpoxyUsage.class);
+    thrown.expectMessage("You can only add models inside the `buildModels` methods");
+
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+      }
+    };
+
+    controller.add(new Model_().id(1));
+  }
+
+  @Test
+  public void cannotCallBuildModelsDirectly() {
+    thrown.expect(IllegalEpoxyUsage.class);
+    thrown.expectMessage("Call `requestModelBuild` instead");
+
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new Model_()
+            .id(1)
+            .addTo(this);
+      }
+    };
+
+    controller.buildModels();
+  }
+
+  @Test
+  public void mustSpecifyModelIdInController() {
+    thrown.expect(IllegalEpoxyUsage.class);
+    thrown.expectMessage("You must set an id on a model");
+
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new Model_()
+            .addTo(this);
+      }
+    };
+
+    controller.requestModelBuild();
+  }
+
+  @Test
+  public void hideModelNotAllowedInController() {
+    thrown.expect(IllegalEpoxyUsage.class);
+    thrown.expectMessage("You cannot hide a model");
+
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        new Model_()
+            .id(1)
+            .hide()
+            .addTo(this);
+      }
+    };
+
+    controller.requestModelBuild();
+  }
+
+  @Test
+  public void cannotChangeIdAfterAddingModelToController() {
+    thrown.expect(IllegalEpoxyUsage.class);
+    thrown.expectMessage("Cannot change a model's id");
+
+    final Model model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+
+    model.id(2);
+  }
+
+  @Test
+  public void mutationNotAllowedAfterModelIsAdded_reset() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+
+    model.reset();
+  }
+
+  @Test
+  public void mutationNotAllowedAfterModelIsAdded_bindListener() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model_ model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+
+    model.onBind(null);
+  }
+
+  @Test
+  public void mutationNotAllowedAfterModelIsAdded_unbindListener() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model_ model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+
+    model.onUnbind(null);
+  }
+
+  @Test
+  public void mutationNotAllowedAfterModelIsAdded_setter() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model_ model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+
+    model.value(2);
+  }
+
+  @Test
+  public void mutationNotAllowedAfterModelIsAdded_layout() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+
+    model.layout(R.layout.view_holder_empty_view);
+  }
+
+  @Test
+  public void mutationNotAllowedAfterModelIsAdded_hide() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+
+    model.hide();
+  }
+
+  @Test
+  public void mutationAllowedDuringInterceptorCall() {
+    final Model model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.addInterceptor(new Interceptor() {
+      @Override
+      public void intercept(List<EpoxyModel<?>> models) {
+        model.reset();
+      }
+    });
+
+    controller.requestModelBuild();
+  }
+
+  @Test
+  public void hashChangeThrows_beforeBind() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.requestModelBuild();
+    model.value = 3;
+    new ControllerLifecycleHelper().bindModels(controller);
+  }
+
+  static class ModelChangesDuringBind extends EpoxyModel<View> {
+    @EpoxyAttribute int value;
+
+    @Override
+    protected int getDefaultLayout() {
+      return R.layout.model_with_click_listener;
+    }
+
+    @Override
+    public void bind(View view) {
+      super.bind(view);
+      value = 3;
+    }
+  }
+
+  @Test
+  public void hashChangeThrows_duringBind() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final EpoxyModelValidationTest$ModelChangesDuringBind_ model =
+        new EpoxyModelValidationTest$ModelChangesDuringBind_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    new ControllerLifecycleHelper().buildModelsAndBind(controller);
+  }
+
+  @Test
+  public void hashChangeThrows_beforeUnbind() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final Model model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    ControllerLifecycleHelper lifecycleHelper = new ControllerLifecycleHelper();
+    lifecycleHelper.buildModelsAndBind(controller);
+    model.value = 3;
+    lifecycleHelper.recycleLastBoundModel(controller);
+  }
+
+  static class ModelChangesDuringUnbind extends EpoxyModel<View> {
+    @EpoxyAttribute int value;
+
+    @Override
+    protected int getDefaultLayout() {
+      return R.layout.model_with_click_listener;
+    }
+
+    @Override
+    public void unbind(View view) {
+      super.unbind(view);
+      value = 3;
+    }
+  }
+
+  @Test
+  public void hashChangeThrows_duringUnbind() {
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    final EpoxyModelValidationTest$ModelChangesDuringUnbind_ model =
+        new EpoxyModelValidationTest$ModelChangesDuringUnbind_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    ControllerLifecycleHelper lifecycleHelper = new ControllerLifecycleHelper();
+    lifecycleHelper.buildModelsAndBind(controller);
+    lifecycleHelper.recycleLastBoundModel(controller);
+  }
+
+
+  @Test
+  public void hashChangeThrows_beforeNextModelBuild() {
+    // This only works for controllers with AutoModels since only those have generated helpers
+    thrown.expect(ImmutableModelException.class);
+    thrown.expectMessage("A model cannot be changed");
+
+    ControllerWithAutoModel controller = new ControllerWithAutoModel();
+
+    controller.requestModelBuild();
+    Model model = (Model) controller.getAdapter().getCopyOfModels().get(0);
+    model.value = 3;
+
+    controller.requestModelBuild();
+  }
+
+  @Test
+  public void hashChangeDuringInterceptorIsAllowed() {
+    final Model_ model = new Model_().id(1);
+    EpoxyController controller = new EpoxyController() {
+
+      @Override
+      protected void buildModels() {
+        add(model);
+      }
+    };
+
+    controller.addInterceptor(new Interceptor() {
+      @Override
+      public void intercept(List<EpoxyModel<?>> models) {
+        model.value(3);
+      }
+    });
+
+    controller.requestModelBuild();
+  }
+}

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/Model.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/Model.java
@@ -1,0 +1,13 @@
+package com.airbnb.epoxy;
+
+import android.view.View;
+
+@EpoxyModelClass
+abstract class Model extends EpoxyModel<View> {
+  @EpoxyAttribute int value;
+
+  @Override
+  protected int getDefaultLayout() {
+    return R.layout.model_with_click_listener;
+  }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
@@ -58,8 +58,12 @@ class ConfigManager {
     return getConfigurationForElement(classElement).requireAbstractModels;
   }
 
-  boolean validateAutoModelUsage(ControllerClassInfo classElement) {
-    return getConfigurationForElement(classElement.controllerClassElement).validateAutoModelUsage;
+  boolean validateModelUsage(ControllerClassInfo classElement) {
+    return getConfigurationForElement(classElement.controllerClassElement).validateModelUsage;
+  }
+
+  boolean validateModelUsage(ClassToGenerateInfo epoxyClass) {
+    return getConfigurationForElement(epoxyClass.getOriginalClassElement()).validateModelUsage;
   }
 
   private PackageConfigSettings getConfigurationForElement(Element element) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
@@ -53,6 +53,13 @@ class HashCodeValidator {
   }
 
   private void validateImplementsHashCode(TypeMirror mirror) throws EpoxyProcessorException {
+    if (mirror.getKind() == TypeKind.ERROR) {
+      // The class type cannot be resolved. This may be because it is a generated epoxy model and
+      // the class hasn't been built yet.
+      // We just assume that the class will implement hashCode at runtime.
+      return;
+    }
+
     if (TypeName.get(mirror).isPrimitive()) {
       return;
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
@@ -44,7 +44,8 @@ class ModelProcessor {
     this.typeUtils = typeUtils;
     this.configManager = configManager;
     this.errorLogger = errorLogger;
-    modelWriter = new GeneratedModelWriter(filer, typeUtils, errorLogger, layoutProcessor);
+    modelWriter =
+        new GeneratedModelWriter(filer, typeUtils, errorLogger, layoutProcessor, configManager);
   }
 
   List<ClassToGenerateInfo> getGeneratedModels() {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/PackageConfigSettings.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/PackageConfigSettings.java
@@ -7,20 +7,20 @@ class PackageConfigSettings {
 
   final boolean requireHashCode;
   final boolean requireAbstractModels;
-  final boolean validateAutoModelUsage;
+  final boolean validateModelUsage;
 
   private PackageConfigSettings(boolean requireHashCode, boolean requireAbstractModels,
-      boolean validateAutoModelUsage) {
+      boolean validateModelUsage) {
     this.requireHashCode = requireHashCode;
     this.requireAbstractModels = requireAbstractModels;
-    this.validateAutoModelUsage = validateAutoModelUsage;
+    this.validateModelUsage = validateModelUsage;
   }
 
   static PackageConfigSettings forDefaults() {
     return new PackageConfigSettings(
         PackageEpoxyConfig.REQUIRE_HASHCODE_DEFAULT,
         PackageEpoxyConfig.REQUIRE_ABSTRACT_MODELS,
-        PackageEpoxyConfig.VALIDATE_AUTO_MODEL_USAGE
+        PackageEpoxyConfig.VALIDATE_MODEL_USAGE
     );
   }
 
@@ -28,7 +28,7 @@ class PackageConfigSettings {
     return new PackageConfigSettings(
         configAnnotation.requireHashCode(),
         configAnnotation.requireAbstractModels(),
-        configAnnotation.validateAutoModelUsage()
+        configAnnotation.validateModelUsage()
     );
   }
 }

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
@@ -251,4 +251,28 @@ public class ConfigTest {
         .withErrorContaining(
             "Epoxy model class must be abstract (RequireAbstractModelFailsEpoxyModelClass)");
   }
+
+  @Test
+  public void testConfigNoModelValidation() {
+    JavaFileObject configNoModelValidation =
+        JavaFileObjects
+            .forSourceString("com.airbnb.epoxy.package-info", "@PackageEpoxyConfig(\n"
+                + "    validateModelUsage = false\n"
+                + ")\n"
+                + "package com.airbnb.epoxy;\n"
+                + "\n"
+                + "import com.airbnb.epoxy.PackageEpoxyConfig;");
+
+    JavaFileObject model =
+        forResource("ModelNoValidation.java");
+
+    JavaFileObject generatedModel = JavaFileObjects.forResource("ModelNoValidation_.java");
+
+    assert_().about(javaSources())
+        .that(asList(configNoModelValidation, model))
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
+  }
 }

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ControllerProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ControllerProcessorTest.java
@@ -43,7 +43,7 @@ public class ControllerProcessorTest {
     // Config to turn validation off
     JavaFileObject CONFIG = JavaFileObjects
         .forSourceString("com.airbnb.epoxy.package-info", "@PackageEpoxyConfig(\n"
-            + "    validateAutoModelUsage = false\n"
+            + "    validateModelUsage = false\n"
             + ")\n"
             + "package com.airbnb.epoxy;\n"
             + "\n"

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
@@ -18,8 +18,15 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder,
       final AbstractModelWithHolder.Holder object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -27,6 +34,7 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -37,16 +45,19 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public AbstractModelWithHolder_ onBind(OnModelBoundListener<AbstractModelWithHolder_, AbstractModelWithHolder.Holder> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(AbstractModelWithHolder.Holder object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -57,11 +68,13 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public AbstractModelWithHolder_ onUnbind(OnModelUnboundListener<AbstractModelWithHolder_, AbstractModelWithHolder.Holder> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public AbstractModelWithHolder_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
+++ b/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
@@ -18,7 +18,14 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public BasicModelWithAttribute_ onBind(OnModelBoundListener<BasicModelWithAttribute_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public BasicModelWithAttribute_ onUnbind(OnModelUnboundListener<BasicModelWithAttribute_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public BasicModelWithAttribute_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ControllerWithAutoModel_EpoxyHelper.java
+++ b/epoxy-processortest/src/test/resources/ControllerWithAutoModel_EpoxyHelper.java
@@ -33,6 +33,7 @@ public class ControllerWithAutoModel_EpoxyHelper extends ControllerHelper<Contro
   private void validateModelsHaveNotChanged() {
     validateSameModel(modelWithAttribute1, controller.modelWithAttribute1, "modelWithAttribute1", -1);
     validateSameModel(modelWithAttribute2, controller.modelWithAttribute2, "modelWithAttribute2", -2);
+    validateModelHashCodesHaveNotChanged(controller);
   }
 
   private void validateSameModel(EpoxyModel expectedObject, EpoxyModel actualObject,

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
@@ -18,7 +18,14 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodNextParentLayout$NoLayout_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodNextParentLayout$NoLayout_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_.java
@@ -18,7 +18,14 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,6 +67,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$WithLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$WithLayout_.java
@@ -18,7 +18,14 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodNextParentLayout$WithLayout_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,6 +67,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodNextParentLayout$WithLayout_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
@@ -18,7 +18,14 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodParentLayout$NoLayout_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodParentLayout$NoLayout_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$WithLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$WithLayout_.java
@@ -18,7 +18,14 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$WithLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodParentLayout$WithLayout_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,6 +67,7 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$WithLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodParentLayout$WithLayout_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
@@ -18,7 +18,14 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethod_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethod_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethod_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethod_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public GenerateDefaultLayoutMethod_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
@@ -18,7 +18,14 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelDoNotHash_ onBind(OnModelBoundListener<ModelDoNotHash_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelDoNotHash_ onUnbind(OnModelUnboundListener<ModelDoNotHash_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelDoNotHash_ value2(int value2) {
+    validateMutability();
     this.value2 = value2;
     return this;
   }
@@ -70,6 +83,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
   }
 
   public ModelDoNotHash_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }
@@ -79,6 +93,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
   }
 
   public ModelDoNotHash_ value3(String value3) {
+    validateMutability();
     this.value3 = value3;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
+++ b/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
@@ -18,7 +18,14 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForRProcessingTest_ onBind(OnModelBoundListener<ModelForRProcessingTest_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForRProcessingTest_ onUnbind(OnModelUnboundListener<ModelForRProcessingTest_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelForRProcessingTest_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
+++ b/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
@@ -19,7 +19,14 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -27,6 +34,7 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -37,16 +45,19 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForTestingDuplicateRValues_ onBind(OnModelBoundListener<ModelForTestingDuplicateRValues_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -57,11 +68,13 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForTestingDuplicateRValues_ onUnbind(OnModelUnboundListener<ModelForTestingDuplicateRValues_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelForTestingDuplicateRValues_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelNoValidation.java
+++ b/epoxy-processortest/src/test/resources/ModelNoValidation.java
@@ -1,0 +1,10 @@
+package com.airbnb.epoxy;
+
+public class ModelNoValidation extends EpoxyModel<Object> {
+  @EpoxyAttribute int value;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelNoValidation_.java
+++ b/epoxy-processortest/src/test/resources/ModelNoValidation_.java
@@ -8,24 +8,17 @@ import java.lang.String;
 
 /**
  * Generated file. Do not modify! */
-public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassTypeWithVarargs implements GeneratedModel<Object> {
-  private OnModelBoundListener<ModelReturningClassTypeWithVarargs_, Object> onModelBoundListener_epoxyGeneratedModel;
+public class ModelNoValidation_ extends ModelNoValidation implements GeneratedModel<Object> {
+  private OnModelBoundListener<ModelNoValidation_, Object> onModelBoundListener_epoxyGeneratedModel;
 
-  private OnModelUnboundListener<ModelReturningClassTypeWithVarargs_, Object> onModelUnboundListener_epoxyGeneratedModel;
+  private OnModelUnboundListener<ModelNoValidation_, Object> onModelUnboundListener_epoxyGeneratedModel;
 
-  public ModelReturningClassTypeWithVarargs_() {
+  public ModelNoValidation_() {
     super();
   }
 
   @Override
-  public void addTo(EpoxyController controller) {
-    super.addTo(controller);
-    addWithDebugValidation(controller);
-  }
-
-  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -33,7 +26,6 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -43,20 +35,17 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
    * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
-  public ModelReturningClassTypeWithVarargs_ onBind(OnModelBoundListener<ModelReturningClassTypeWithVarargs_, Object> listener) {
-    validateMutability();
+  public ModelNoValidation_ onBind(OnModelBoundListener<ModelNoValidation_, Object> listener) {
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -66,14 +55,12 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
    * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
-  public ModelReturningClassTypeWithVarargs_ onUnbind(OnModelUnboundListener<ModelReturningClassTypeWithVarargs_, Object> listener) {
-    validateMutability();
+  public ModelNoValidation_ onUnbind(OnModelUnboundListener<ModelNoValidation_, Object> listener) {
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
-  public ModelReturningClassTypeWithVarargs_ value(int value) {
-    validateMutability();
+  public ModelNoValidation_ value(int value) {
     this.value = value;
     return this;
   }
@@ -83,61 +70,49 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ classType(String... varargs) {
-    super.classType(varargs);
-    return this;
-  }
-
-  @Override
-  public ModelReturningClassTypeWithVarargs_ classType(String first, String... varargs) {
-    super.classType(first, varargs);
-    return this;
-  }
-
-  @Override
-  public ModelReturningClassTypeWithVarargs_ id(long id) {
+  public ModelNoValidation_ id(long id) {
     super.id(id);
     return this;
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ id(CharSequence key) {
+  public ModelNoValidation_ id(CharSequence key) {
     super.id(key);
     return this;
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ id(CharSequence key, long id) {
+  public ModelNoValidation_ id(CharSequence key, long id) {
     super.id(key, id);
     return this;
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ layout(@LayoutRes int arg0) {
+  public ModelNoValidation_ layout(@LayoutRes int arg0) {
     super.layout(arg0);
     return this;
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ show() {
+  public ModelNoValidation_ show() {
     super.show();
     return this;
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ show(boolean show) {
+  public ModelNoValidation_ show(boolean show) {
     super.show(show);
     return this;
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ hide() {
+  public ModelNoValidation_ hide() {
     super.hide();
     return this;
   }
 
   @Override
-  public ModelReturningClassTypeWithVarargs_ reset() {
+  public ModelNoValidation_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
     this.value = 0;
@@ -150,13 +125,13 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
     if (o == this) {
       return true;
     }
-    if (!(o instanceof ModelReturningClassTypeWithVarargs_)) {
+    if (!(o instanceof ModelNoValidation_)) {
       return false;
     }
     if (!super.equals(o)) {
       return false;
     }
-    ModelReturningClassTypeWithVarargs_ that = (ModelReturningClassTypeWithVarargs_) o;
+    ModelNoValidation_ that = (ModelNoValidation_) o;
     if ((onModelBoundListener_epoxyGeneratedModel == null) != (that.onModelBoundListener_epoxyGeneratedModel == null)) {
       return false;
     }
@@ -180,7 +155,7 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
 
   @Override
   public String toString() {
-    return "ModelReturningClassTypeWithVarargs_{" +
+    return "ModelNoValidation_{" +
         "value=" + value +
         "}" + super.toString();
   }

--- a/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
@@ -19,7 +19,14 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -27,6 +34,7 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -37,16 +45,19 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelReturningClassType_ onBind(OnModelBoundListener<ModelReturningClassType_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -57,11 +68,13 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelReturningClassType_ onUnbind(OnModelUnboundListener<ModelReturningClassType_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelReturningClassType_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
@@ -18,7 +18,14 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAbstractClassAndAnnotation_ onBind(OnModelBoundListener<ModelWithAbstractClassAndAnnotation_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,6 +67,7 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAbstractClassAndAnnotation_ onUnbind(OnModelUnboundListener<ModelWithAbstractClassAndAnnotation_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
@@ -28,7 +28,14 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -36,6 +43,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -46,16 +54,19 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllFieldTypes_ onBind(OnModelBoundListener<ModelWithAllFieldTypes_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -66,11 +77,13 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllFieldTypes_ onUnbind(OnModelUnboundListener<ModelWithAllFieldTypes_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAllFieldTypes_ valueInteger(Integer valueInteger) {
+    validateMutability();
     this.valueInteger = valueInteger;
     return this;
   }
@@ -80,6 +93,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueShort(short valueShort) {
+    validateMutability();
     this.valueShort = valueShort;
     return this;
   }
@@ -89,6 +103,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueLong(long valueLong) {
+    validateMutability();
     this.valueLong = valueLong;
     return this;
   }
@@ -98,6 +113,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueList(List<String> valueList) {
+    validateMutability();
     this.valueList = valueList;
     return this;
   }
@@ -107,6 +123,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
+    validateMutability();
     this.valueShortWrapper = valueShortWrapper;
     return this;
   }
@@ -116,6 +133,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueDouble(double valueDouble) {
+    validateMutability();
     this.valueDouble = valueDouble;
     return this;
   }
@@ -125,6 +143,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueChar(char valueChar) {
+    validateMutability();
     this.valueChar = valueChar;
     return this;
   }
@@ -134,6 +153,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueInt(int valueInt) {
+    validateMutability();
     this.valueInt = valueInt;
     return this;
   }
@@ -143,6 +163,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
+    validateMutability();
     this.valueDoubleWrapper = valueDoubleWrapper;
     return this;
   }
@@ -152,6 +173,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
+    validateMutability();
     this.valueFloatWrapper = valueFloatWrapper;
     return this;
   }
@@ -161,6 +183,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
+    validateMutability();
     this.valueBooleanWrapper = valueBooleanWrapper;
     return this;
   }
@@ -170,6 +193,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
+    validateMutability();
     this.valueByteWrapper = valueByteWrapper;
     return this;
   }
@@ -179,6 +203,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valuebByte(byte valuebByte) {
+    validateMutability();
     this.valuebByte = valuebByte;
     return this;
   }
@@ -188,6 +213,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
+    validateMutability();
     this.valueLongWrapper = valueLongWrapper;
     return this;
   }
@@ -197,6 +223,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueCharacter(Character valueCharacter) {
+    validateMutability();
     this.valueCharacter = valueCharacter;
     return this;
   }
@@ -206,6 +233,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueString(String valueString) {
+    validateMutability();
     this.valueString = valueString;
     return this;
   }
@@ -215,6 +243,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueFloat(float valueFloat) {
+    validateMutability();
     this.valueFloat = valueFloat;
     return this;
   }
@@ -224,6 +253,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueBoolean(boolean valueBoolean) {
+    validateMutability();
     this.valueBoolean = valueBoolean;
     return this;
   }
@@ -233,6 +263,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
+    validateMutability();
     this.valueObjectArray = valueObjectArray;
     return this;
   }
@@ -242,6 +273,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueObject(Object valueObject) {
+    validateMutability();
     this.valueObject = valueObject;
     return this;
   }
@@ -251,6 +283,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueIntArray(int[] valueIntArray) {
+    validateMutability();
     this.valueIntArray = valueIntArray;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
@@ -28,7 +28,14 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -36,6 +43,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -46,16 +54,19 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllPrivateFieldTypes_ onBind(OnModelBoundListener<ModelWithAllPrivateFieldTypes_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -66,11 +77,13 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllPrivateFieldTypes_ onUnbind(OnModelUnboundListener<ModelWithAllPrivateFieldTypes_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAllPrivateFieldTypes_ valueInteger(Integer valueInteger) {
+    validateMutability();
     this.setValueInteger(valueInteger);
     return this;
   }
@@ -80,6 +93,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueShort(short valueShort) {
+    validateMutability();
     this.setValueShort(valueShort);
     return this;
   }
@@ -89,6 +103,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueLong(long valueLong) {
+    validateMutability();
     this.setValueLong(valueLong);
     return this;
   }
@@ -98,6 +113,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueList(List<String> valueList) {
+    validateMutability();
     this.setValueList(valueList);
     return this;
   }
@@ -107,6 +123,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
+    validateMutability();
     this.setValueShortWrapper(valueShortWrapper);
     return this;
   }
@@ -116,6 +133,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueDouble(double valueDouble) {
+    validateMutability();
     this.setValueDouble(valueDouble);
     return this;
   }
@@ -125,6 +143,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueChar(char valueChar) {
+    validateMutability();
     this.setValueChar(valueChar);
     return this;
   }
@@ -134,6 +153,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueInt(int valueInt) {
+    validateMutability();
     this.setValueInt(valueInt);
     return this;
   }
@@ -143,6 +163,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
+    validateMutability();
     this.setValueDoubleWrapper(valueDoubleWrapper);
     return this;
   }
@@ -152,6 +173,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
+    validateMutability();
     this.setValueFloatWrapper(valueFloatWrapper);
     return this;
   }
@@ -161,6 +183,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
+    validateMutability();
     this.setValueBooleanWrapper(valueBooleanWrapper);
     return this;
   }
@@ -170,6 +193,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
+    validateMutability();
     this.setValueByteWrapper(valueByteWrapper);
     return this;
   }
@@ -179,6 +203,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valuebByte(byte valuebByte) {
+    validateMutability();
     this.setValuebByte(valuebByte);
     return this;
   }
@@ -188,6 +213,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
+    validateMutability();
     this.setValueLongWrapper(valueLongWrapper);
     return this;
   }
@@ -197,6 +223,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueCharacter(Character valueCharacter) {
+    validateMutability();
     this.setValueCharacter(valueCharacter);
     return this;
   }
@@ -206,6 +233,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueString(String valueString) {
+    validateMutability();
     this.setValueString(valueString);
     return this;
   }
@@ -215,6 +243,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueFloat(float valueFloat) {
+    validateMutability();
     this.setValueFloat(valueFloat);
     return this;
   }
@@ -224,6 +253,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueBoolean(boolean valueBoolean) {
+    validateMutability();
     this.setValueBoolean(valueBoolean);
     return this;
   }
@@ -233,6 +263,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
+    validateMutability();
     this.setValueObjectArray(valueObjectArray);
     return this;
   }
@@ -242,6 +273,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueObject(Object valueObject) {
+    validateMutability();
     this.setValueObject(valueObject);
     return this;
   }
@@ -251,6 +283,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueIntArray(int[] valueIntArray) {
+    validateMutability();
     this.setValueIntArray(valueIntArray);
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
@@ -18,7 +18,14 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ onBind(OnModelBoundListener<ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ superValue(int superValue) {
+    validateMutability();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
@@ -18,7 +18,14 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes_ onBind(OnModelBoundListener<ModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAnnotatedClassAndSuperAttributes_ superValue(int superValue) {
+    validateMutability();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
@@ -18,7 +18,14 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClass_ onBind(OnModelBoundListener<ModelWithAnnotatedClass_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,6 +67,7 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClass_ onUnbind(OnModelUnboundListener<ModelWithAnnotatedClass_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
@@ -26,7 +26,14 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -34,6 +41,7 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -44,16 +52,19 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithConstructors_ onBind(OnModelBoundListener<ModelWithConstructors_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -64,11 +75,13 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithConstructors_ onUnbind(OnModelUnboundListener<ModelWithConstructors_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithConstructors_ valueInt(int valueInt) {
+    validateMutability();
     this.valueInt = valueInt;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
@@ -19,7 +19,14 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -27,6 +34,7 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -37,16 +45,19 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFieldAnnotation_ onBind(OnModelBoundListener<ModelWithFieldAnnotation_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -57,11 +68,13 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFieldAnnotation_ onUnbind(OnModelUnboundListener<ModelWithFieldAnnotation_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithFieldAnnotation_ title(@Nullable String title) {
+    validateMutability();
     this.title = title;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
@@ -18,7 +18,14 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFinalField_ onBind(OnModelBoundListener<ModelWithFinalField_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,6 +67,7 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFinalField_ onUnbind(OnModelUnboundListener<ModelWithFinalField_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy.models;
 
 import android.support.annotation.LayoutRes;
+import com.airbnb.epoxy.EpoxyController;
 import com.airbnb.epoxy.EpoxyViewHolder;
 import com.airbnb.epoxy.GeneratedModel;
 import com.airbnb.epoxy.OnModelBoundListener;
@@ -22,7 +23,14 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -30,6 +38,7 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -40,16 +49,19 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithIntDef_ onBind(OnModelBoundListener<ModelWithIntDef_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -60,11 +72,13 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithIntDef_ onUnbind(OnModelUnboundListener<ModelWithIntDef_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithIntDef_ type(@ModelWithIntDef.MyType int type) {
+    validateMutability();
     this.type = type;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
@@ -18,7 +18,14 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ onBind(OnModelBoundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ onUnbind(OnModelUnboundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ isValue(boolean isValue) {
+    validateMutability();
     this.setValue(isValue);
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
@@ -21,23 +21,30 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
     if (clickListener_epoxyGeneratedModel != null) {
       super.setClickListener(new View.OnClickListener() {
-          // Save the original click listener so if it gets changed on
-          // the generated model this click listener won't be affected
-          // if it is still bound to a view.
-          private final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithPrivateViewClickListener_.this.clickListener_epoxyGeneratedModel;
-          public void onClick(View v) {
-          clickListener_epoxyGeneratedModel.onClick(ModelWithPrivateViewClickListener_.this, object, v,
-              holder.getAdapterPosition());
-          }
-          public int hashCode() {
-             // Use the hash of the original click listener so we don't change the
-             // value by wrapping it with this anonymous click listener
-             return clickListener_epoxyGeneratedModel.hashCode();
-          }
-        });
+              // Save the original click listener so if it gets changed on
+              // the generated model this click listener won't be affected
+              // if it is still bound to a view.
+              private final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithPrivateViewClickListener_.this.clickListener_epoxyGeneratedModel;
+              public void onClick(View v) {
+              clickListener_epoxyGeneratedModel.onClick(ModelWithPrivateViewClickListener_.this, object, v,
+                  holder.getAdapterPosition());
+              }
+              public int hashCode() {
+                 // Use the hash of the original click listener so we don't change the
+                 // value by wrapping it with this anonymous click listener
+                 return clickListener_epoxyGeneratedModel.hashCode();
+              }
+            });
     }
   }
 
@@ -46,6 +53,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -56,16 +64,19 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateViewClickListener_ onBind(OnModelBoundListener<ModelWithPrivateViewClickListener_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -76,6 +87,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateViewClickListener_ onUnbind(OnModelUnboundListener<ModelWithPrivateViewClickListener_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -83,12 +95,26 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public ModelWithPrivateViewClickListener_ clickListener(final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener) {
-    super.setClickListener(null);
+    validateMutability();
     this.clickListener_epoxyGeneratedModel = clickListener;
+    super.setClickListener(new View.OnClickListener() {
+            // Save the original click listener so if it gets changed on
+            // the generated model this click listener won't be affected
+            // if it is still bound to a view.
+            private final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithPrivateViewClickListener_.this.clickListener_epoxyGeneratedModel;
+            public void onClick(View v) { }
+            
+            public int hashCode() {
+               // Use the hash of the original click listener so we don't change the
+               // value by wrapping it with this anonymous click listener
+               return clickListener_epoxyGeneratedModel.hashCode();
+            }
+          });
     return this;
   }
 
   public ModelWithPrivateViewClickListener_ clickListener(View.OnClickListener clickListener) {
+    validateMutability();
     this.setClickListener(clickListener);
     this.clickListener_epoxyGeneratedModel = null;
     return this;
@@ -171,9 +197,6 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
     if ((getClickListener() == null) != (that.getClickListener() == null)) {
       return false;
     }
-    if ((clickListener_epoxyGeneratedModel == null) != (that.clickListener_epoxyGeneratedModel == null)) {
-      return false;
-    }
     return true;
   }
 
@@ -183,7 +206,6 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
     result = 31 * result + (onModelBoundListener_epoxyGeneratedModel != null ? 1 : 0);
     result = 31 * result + (onModelUnboundListener_epoxyGeneratedModel != null ? 1 : 0);
     result = 31 * result + (getClickListener() != null ? 1 : 0);
-    result = 31 * result + (clickListener_epoxyGeneratedModel != null ? 1 : 0);
     return result;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
@@ -18,7 +18,14 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ onBind(OnModelBoundListener<ModelWithSuperAttributes$SubModelWithSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithSuperAttributes$SubModelWithSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ subValue(int subValue) {
+    validateMutability();
     this.subValue = subValue;
     return this;
   }
@@ -70,6 +83,7 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
   }
 
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ superValue(int superValue) {
+    validateMutability();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
@@ -18,7 +18,14 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes_ onBind(OnModelBoundListener<ModelWithSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithSuperAttributes_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithSuperAttributes_ superValue(int superValue) {
+    validateMutability();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithSuper_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuper_.java
@@ -18,7 +18,14 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuper_ onBind(OnModelBoundListener<ModelWithSuper_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuper_ onUnbind(OnModelUnboundListener<ModelWithSuper_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithSuper_ valueInt(int valueInt) {
+    validateMutability();
     this.valueInt = valueInt;
     super.valueInt(valueInt);
     return this;

--- a/epoxy-processortest/src/test/resources/ModelWithType_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithType_.java
@@ -18,7 +18,14 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithType_<T> onBind(OnModelBoundListener<ModelWithType_<T>, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithType_<T> onUnbind(OnModelUnboundListener<ModelWithType_<T>, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithType_<T> value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
@@ -23,7 +23,14 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -31,6 +38,7 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -41,16 +49,19 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithVarargsConstructors_ onBind(OnModelBoundListener<ModelWithVarargsConstructors_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -61,11 +72,13 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithVarargsConstructors_ onUnbind(OnModelUnboundListener<ModelWithVarargsConstructors_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithVarargsConstructors_ varargs(String[] varargs) {
+    validateMutability();
     this.varargs = varargs;
     return this;
   }
@@ -75,6 +88,7 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
   }
 
   public ModelWithVarargsConstructors_ valueInt(int valueInt) {
+    validateMutability();
     this.valueInt = valueInt;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -21,23 +21,30 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
     if (clickListener_epoxyGeneratedModel != null) {
       super.clickListener = new View.OnClickListener() {
-          // Save the original click listener so if it gets changed on
-          // the generated model this click listener won't be affected
-          // if it is still bound to a view.
-          private final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithViewClickListener_.this.clickListener_epoxyGeneratedModel;
-          public void onClick(View v) {
-          clickListener_epoxyGeneratedModel.onClick(ModelWithViewClickListener_.this, object, v,
-              holder.getAdapterPosition());
-          }
-          public int hashCode() {
-             // Use the hash of the original click listener so we don't change the
-             // value by wrapping it with this anonymous click listener
-             return clickListener_epoxyGeneratedModel.hashCode();
-          }
-        };
+              // Save the original click listener so if it gets changed on
+              // the generated model this click listener won't be affected
+              // if it is still bound to a view.
+              private final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithViewClickListener_.this.clickListener_epoxyGeneratedModel;
+              public void onClick(View v) {
+              clickListener_epoxyGeneratedModel.onClick(ModelWithViewClickListener_.this, object, v,
+                  holder.getAdapterPosition());
+              }
+              public int hashCode() {
+                 // Use the hash of the original click listener so we don't change the
+                 // value by wrapping it with this anonymous click listener
+                 return clickListener_epoxyGeneratedModel.hashCode();
+              }
+            };
     }
   }
 
@@ -46,6 +53,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -56,16 +64,19 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithViewClickListener_ onBind(OnModelBoundListener<ModelWithViewClickListener_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -76,6 +87,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithViewClickListener_ onUnbind(OnModelUnboundListener<ModelWithViewClickListener_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -83,12 +95,26 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public ModelWithViewClickListener_ clickListener(final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener) {
-    super.clickListener = null;
+    validateMutability();
     this.clickListener_epoxyGeneratedModel = clickListener;
+    super.clickListener = new View.OnClickListener() {
+            // Save the original click listener so if it gets changed on
+            // the generated model this click listener won't be affected
+            // if it is still bound to a view.
+            private final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithViewClickListener_.this.clickListener_epoxyGeneratedModel;
+            public void onClick(View v) { }
+            
+            public int hashCode() {
+               // Use the hash of the original click listener so we don't change the
+               // value by wrapping it with this anonymous click listener
+               return clickListener_epoxyGeneratedModel.hashCode();
+            }
+          };
     return this;
   }
 
   public ModelWithViewClickListener_ clickListener(View.OnClickListener clickListener) {
+    validateMutability();
     this.clickListener = clickListener;
     this.clickListener_epoxyGeneratedModel = null;
     return this;
@@ -171,9 +197,6 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
     if ((clickListener == null) != (that.clickListener == null)) {
       return false;
     }
-    if ((clickListener_epoxyGeneratedModel == null) != (that.clickListener_epoxyGeneratedModel == null)) {
-      return false;
-    }
     return true;
   }
 
@@ -183,7 +206,6 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
     result = 31 * result + (onModelBoundListener_epoxyGeneratedModel != null ? 1 : 0);
     result = 31 * result + (onModelUnboundListener_epoxyGeneratedModel != null ? 1 : 0);
     result = 31 * result + (clickListener != null ? 1 : 0);
-    result = 31 * result + (clickListener_epoxyGeneratedModel != null ? 1 : 0);
     return result;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
@@ -18,7 +18,14 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutHash_ onBind(OnModelBoundListener<ModelWithoutHash_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,11 +67,13 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutHash_ onUnbind(OnModelUnboundListener<ModelWithoutHash_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithoutHash_ value2(int value2) {
+    validateMutability();
     this.value2 = value2;
     return this;
   }
@@ -70,6 +83,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
   }
 
   public ModelWithoutHash_ value(int value) {
+    validateMutability();
     this.value = value;
     return this;
   }
@@ -79,6 +93,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
   }
 
   public ModelWithoutHash_ value3(String value3) {
+    validateMutability();
     this.value3 = value3;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
@@ -18,7 +18,14 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
   }
 
   @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
   }
 
   @Override
@@ -26,6 +33,7 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
   }
 
   /**
@@ -36,16 +44,19 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutSetter_ onBind(OnModelBoundListener<ModelWithoutSetter_, Object> listener) {
+    validateMutability();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
   public void unbind(Object object) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
+    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**
@@ -56,6 +67,7 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutSetter_ onUnbind(OnModelUnboundListener<ModelWithoutSetter_, Object> listener) {
+    validateMutability();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-sample/build.gradle
+++ b/epoxy-sample/build.gradle
@@ -36,11 +36,11 @@ android {
 
   buildTypes {
     debug {
-      buildConfigField "boolean", "VALIDATE_AUTO_MODEL_USAGE", "true"
+      buildConfigField "boolean", "VALIDATE_MODEL_USAGE", "true"
     }
 
     release {
-      buildConfigField "boolean", "VALIDATE_AUTO_MODEL_USAGE", "false"
+      buildConfigField "boolean", "VALIDATE_MODEL_USAGE", "false"
     }
   }
 }

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/package-info.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/package-info.java
@@ -1,7 +1,7 @@
 @PackageEpoxyConfig(
     requireAbstractModels = true,
     requireHashCode = true,
-    validateAutoModelUsage = BuildConfig.VALIDATE_AUTO_MODEL_USAGE
+    validateModelUsage = BuildConfig.VALIDATE_MODEL_USAGE
 )
 package com.airbnb.epoxy;
 

--- a/update_processor_test_resources.rb
+++ b/update_processor_test_resources.rb
@@ -56,6 +56,6 @@ def updateTestClass(test_class_result)
 end
 
 # Looks through each module's build folder for debug test results
-Dir.glob("*/build/reports/tests/debug/classes/*.html") do |test_class_result|
+Dir.glob("*/build/reports/tests/testDebugUnitTest/classes/*.html") do |test_class_result|
   updateTestClass(test_class_result)
 end


### PR DESCRIPTION
This adds validations to the generated models that enforce immutability after the model is added to the controller. This will help enforce the pattern that models must be recreated when changes are needed, instead of modifying existing models. I tried to make the error messages as helpful and descriptive as possible to teach users how to use the EpoxyController correctly.

@ngsilverman @geralt-encore 