### PR TITLE
Change how model validation param is set

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -24,7 +24,7 @@ rootProject.ext.ASSERTJ_VERSION = "1.7.1"
 rootProject.ext.GOOGLE_TESTING_COMPILE_VERSION = "0.10"
 rootProject.ext.JUNIT_VERSION = "4.12"
 rootProject.ext.MOCKITO_VERSION = "2.7.7"
-rootProject.ext.ROBOLECTRIC_VERSION = "3.3"
+rootProject.ext.ROBOLECTRIC_VERSION = "3.3.1"
 
 rootProject.ext.deps = [
     androidSupportLibrary: "com.android.support:appcompat-v7:$ANDROID_SUPPORT_LIBS_VERSION",

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelper.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelper.java
@@ -16,7 +16,7 @@ public abstract class ControllerHelper<T extends EpoxyController> {
     for (int i = 0; i < currentModels.size(); i++) {
       EpoxyModel model = currentModels.get(i);
       model.validateStateHasNotChangedSinceAdded(
-          "Model has changed since it was added to the controller.");
+          "Model has changed since it was added to the controller.", i);
     }
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -28,7 +28,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     if (model instanceof GeneratedModel) {
       // The generated method will enforce that only a properly typed listener can be set
       //noinspection unchecked
-      ((GeneratedModel) model).handlePreBind(this, objectToBind());
+      ((GeneratedModel) model).handlePreBind(this, objectToBind(), position);
     }
 
     if (payloads.isEmpty()) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/GeneratedModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/GeneratedModel.java
@@ -8,7 +8,7 @@ public interface GeneratedModel<T> {
    * <p>
    * The ViewHolder is needed to get the model's adapter position when clicked.
    */
-  void handlePreBind(EpoxyViewHolder holder, T objectToBind);
+  void handlePreBind(EpoxyViewHolder holder, T objectToBind, int position);
   /**
    * Called on the generated model immediately after the main model onBind method has been called.
    * This let's the generated model handle binding of its own and dispatch calls to its onBind

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ImmutableModelException.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ImmutableModelException.java
@@ -13,33 +13,25 @@ class ImmutableModelException extends RuntimeException {
           + " is set on the adapter. If the model is already set on the adapter then you must"
           + " call `requestModelBuild` instead to recreate all models.";
 
-  ImmutableModelException(EpoxyController controller, EpoxyModel model) {
-    this(controller, model, "");
+  ImmutableModelException(EpoxyModel model, int modelPosition) {
+    this(model, "", modelPosition);
   }
 
-  ImmutableModelException(EpoxyController controller, EpoxyModel model,
-      String descriptionOfWhenChangeHappened) {
-    super(buildMessage(controller, model, descriptionOfWhenChangeHappened));
+  ImmutableModelException(EpoxyModel model,
+      String descriptionOfWhenChangeHappened, int modelPosition) {
+    super(buildMessage(model, descriptionOfWhenChangeHappened, modelPosition));
   }
 
   @NonNull
-  private static String buildMessage(EpoxyController controller, EpoxyModel model,
-      String descriptionOfWhenChangeHappened) {
+  private static String buildMessage(EpoxyModel model,
+      String descriptionOfWhenChangeHappened, int modelPosition) {
     return new StringBuilder(descriptionOfWhenChangeHappened)
         .append(" Position: ")
-        .append(getModelPosition(controller, model))
+        .append(modelPosition)
         .append(" Model: ")
         .append(model.toString())
         .append("\n\n")
         .append(MODEL_CANNOT_BE_CHANGED_MESSAGE)
         .toString();
-  }
-
-  private static int getModelPosition(EpoxyController controller, EpoxyModel model) {
-    if (controller.isBuildingModels()) {
-      return controller.getIndexOfModelInBuildingList(model);
-    }
-
-    return controller.getAdapter().getModelPosition(model);
   }
 }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/TestModel.java
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/TestModel.java
@@ -31,6 +31,11 @@ public class TestModel extends EpoxyModel<View> {
     return this;
   }
 
+  TestModel incrementValue() {
+    this.value++;
+    return this;
+  }
+
   int value() {
     return value;
   }

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
@@ -16,8 +16,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 public @interface PackageEpoxyConfig {
   boolean REQUIRE_HASHCODE_DEFAULT = false;
-  boolean REQUIRE_ABSTRACT_MODELS = false;
-  boolean VALIDATE_MODEL_USAGE = true;
+  boolean REQUIRE_ABSTRACT_MODELS_DEFAULT = false;
   /**
    * If true, all fields marked with {@link com.airbnb.epoxy.EpoxyAttribute} must have a type that
    * implements hashCode (besides the default Object implementation), or the attribute must set
@@ -47,22 +46,5 @@ public @interface PackageEpoxyConfig {
    * Forcing models to be abstract can prevent the mistake of using the original model class instead
    * of the generated class.
    */
-  boolean requireAbstractModels() default REQUIRE_ABSTRACT_MODELS;
-
-  /**
-   * If true, Epoxy models added to an EpoxyController will be
-   * validated at run time to make sure they are properly used.
-   * <p>
-   * By default this is true, and it is highly recommended to enable it to prevent accidental misuse
-   * of your models. However, you may want to disable this for production builds to avoid the
-   * overhead of the runtime validation code.
-   * <p>
-   * Using a debug build flag is a great way to do this. Unfortunately, BuildConfig.DEBUG is not
-   * considered a constant and cannot be used as an annotation param. However, you can define a
-   * custom BuildConfig field to use instead. See <a
-   * href="http://stackoverflow.com/questions/40721113/buildconfig-debug-or-equivalent-as-a
-   * -constant">this
-   * stack overflow post</a> for details.
-   */
-  boolean validateModelUsage() default VALIDATE_MODEL_USAGE;
+  boolean requireAbstractModels() default REQUIRE_ABSTRACT_MODELS_DEFAULT;
 }

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelValidationTest.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelValidationTest.java
@@ -337,62 +337,6 @@ public class EpoxyModelValidationTest {
   }
 
   @Test
-  public void hashChangeThrows_beforeUnbind() {
-    thrown.expect(ImmutableModelException.class);
-    thrown.expectMessage("A model cannot be changed");
-
-    final Model model = new Model_().id(1);
-    EpoxyController controller = new EpoxyController() {
-
-      @Override
-      protected void buildModels() {
-        add(model);
-      }
-    };
-
-    ControllerLifecycleHelper lifecycleHelper = new ControllerLifecycleHelper();
-    lifecycleHelper.buildModelsAndBind(controller);
-    model.value = 3;
-    lifecycleHelper.recycleLastBoundModel(controller);
-  }
-
-  static class ModelChangesDuringUnbind extends EpoxyModel<View> {
-    @EpoxyAttribute int value;
-
-    @Override
-    protected int getDefaultLayout() {
-      return R.layout.model_with_click_listener;
-    }
-
-    @Override
-    public void unbind(View view) {
-      super.unbind(view);
-      value = 3;
-    }
-  }
-
-  @Test
-  public void hashChangeThrows_duringUnbind() {
-    thrown.expect(ImmutableModelException.class);
-    thrown.expectMessage("A model cannot be changed");
-
-    final EpoxyModelValidationTest$ModelChangesDuringUnbind_ model =
-        new EpoxyModelValidationTest$ModelChangesDuringUnbind_().id(1);
-    EpoxyController controller = new EpoxyController() {
-
-      @Override
-      protected void buildModels() {
-        add(model);
-      }
-    };
-
-    ControllerLifecycleHelper lifecycleHelper = new ControllerLifecycleHelper();
-    lifecycleHelper.buildModelsAndBind(controller);
-    lifecycleHelper.recycleLastBoundModel(controller);
-  }
-
-
-  @Test
   public void hashChangeThrows_beforeNextModelBuild() {
     // This only works for controllers with AutoModels since only those have generated helpers
     thrown.expect(ImmutableModelException.class);

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
@@ -16,16 +16,50 @@ import static com.airbnb.epoxy.ProcessorUtils.buildEpoxyException;
 
 /** Manages configuration settings for different packages. */
 class ConfigManager {
+  static final String PROCESSOR_OPTION_VALIDATE_MODEL_USAGE = "validateEpoxyModelUsage";
+  static final String PROCESSOR_OPTION_REQUIRE_HASHCODE = "requireHashCodeInEpoxyModels";
+  static final String PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS = "requireAbstractEpoxyModels";
 
   private static final PackageConfigSettings
       DEFAULT_PACKAGE_CONFIG_SETTINGS = PackageConfigSettings.forDefaults();
   private final Map<String, PackageConfigSettings> configurationMap = new HashMap<>();
   private final Elements elementUtils;
+  private final boolean validateModelUsage;
+  private final boolean globalRequireHashCode;
+  private final boolean globalRequireAbstractModels;
 
-  ConfigManager(Elements elementUtils) {
+  ConfigManager(Map<String, String> options, Elements elementUtils) {
     this.elementUtils = elementUtils;
+    validateModelUsage = getBooleanOption(options, PROCESSOR_OPTION_VALIDATE_MODEL_USAGE, true);
+
+    globalRequireHashCode = getBooleanOption(options, PROCESSOR_OPTION_REQUIRE_HASHCODE,
+        PackageEpoxyConfig.REQUIRE_HASHCODE_DEFAULT);
+
+    globalRequireAbstractModels =
+        getBooleanOption(options, PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS,
+            PackageEpoxyConfig.REQUIRE_ABSTRACT_MODELS_DEFAULT);
   }
 
+  private static boolean getBooleanOption(Map<String, String> options, String option,
+      boolean defaultValue) {
+    String value = options.get(option);
+    if (value == null) {
+      return defaultValue;
+    }
+
+    return Boolean.valueOf(value);
+  }
+
+  /**
+   * If true, Epoxy models added to an EpoxyController will be
+   * validated at run time to make sure they are properly used.
+   * <p>
+   * By default this is true, and it is highly recommended to enable it to prevent accidental misuse
+   * of your models. However, you may want to disable this for production builds to avoid the
+   * overhead of the runtime validation code.
+   * <p>
+   * Using a debug build flag is a great way to do this.
+   */
   List<Exception> processConfigurations(RoundEnvironment roundEnv) {
     configurationMap.clear();
 
@@ -51,19 +85,17 @@ class ConfigManager {
   }
 
   boolean requiresHashCode(AttributeInfo attributeInfo) {
-    return getConfigurationForElement(attributeInfo.getClassElement()).requireHashCode;
+    return globalRequireHashCode
+        || getConfigurationForElement(attributeInfo.getClassElement()).requireHashCode;
   }
 
   boolean requiresAbstractModels(TypeElement classElement) {
-    return getConfigurationForElement(classElement).requireAbstractModels;
+    return globalRequireAbstractModels
+        || getConfigurationForElement(classElement).requireAbstractModels;
   }
 
-  boolean validateModelUsage(ControllerClassInfo classElement) {
-    return getConfigurationForElement(classElement.controllerClassElement).validateModelUsage;
-  }
-
-  boolean validateModelUsage(ClassToGenerateInfo epoxyClass) {
-    return getConfigurationForElement(epoxyClass.getOriginalClassElement()).validateModelUsage;
+  boolean shouldValidateModeUsage() {
+    return validateModelUsage;
   }
 
   private PackageConfigSettings getConfigurationForElement(Element element) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ControllerProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ControllerProcessor.java
@@ -202,7 +202,7 @@ class ControllerProcessor {
         .addMethod(buildConstructor(controllerInfo))
         .addMethod(buildResetModelsMethod(controllerInfo));
 
-    if (configManager.validateModelUsage(controllerInfo)) {
+    if (configManager.shouldValidateModeUsage()) {
       builder.addFields(buildFieldsToSaveModelsForValidation(controllerInfo))
           .addMethod(buildValidateModelsHaveNotChangedMethod(controllerInfo))
           .addMethod(buildValidateSameValueMethod())
@@ -301,7 +301,7 @@ class ControllerProcessor {
         .addAnnotation(Override.class)
         .addModifiers(Modifier.PUBLIC);
 
-    if (configManager.validateModelUsage(controllerInfo)) {
+    if (configManager.shouldValidateModeUsage()) {
       builder.addStatement("validateModelsHaveNotChanged()");
     }
 
@@ -311,7 +311,7 @@ class ControllerProcessor {
           .addStatement("controller.$L.id($L)", model.fieldName, id--);
     }
 
-    if (configManager.validateModelUsage(controllerInfo)) {
+    if (configManager.shouldValidateModeUsage()) {
       builder.addStatement("saveModelsForNextValidation()");
     }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -193,7 +193,7 @@ class GeneratedModelWriter {
 
   private void generateDebugAddToMethodIfNeeded(TypeSpec.Builder classBuilder,
       ClassToGenerateInfo info) {
-    if (!configManager.validateModelUsage(info)) {
+    if (!configManager.shouldValidateModeUsage()) {
       return;
     }
 
@@ -225,7 +225,8 @@ class GeneratedModelWriter {
         .addModifiers(PUBLIC)
         .addAnnotation(Override.class)
         .addParameter(viewHolderParam)
-        .addParameter(boundObjectParam);
+        .addParameter(boundObjectParam)
+        .addParameter(TypeName.INT, "position");
 
     addHashCodeValidationIfNecessary(preBindBuilder, classInfo,
         "The model was changed between being added to the controller and being bound.");
@@ -319,17 +320,11 @@ class GeneratedModelWriter {
         .addModifiers(PUBLIC)
         .addParameter(unbindObjectParam);
 
-    addHashCodeValidationIfNecessary(unbindBuilder, classInfo,
-        "The model was changed between being being bound to the recycler view and being unbound.");
-
     unbindBuilder
         .addStatement("super.unbind(object)")
         .beginControlFlow("if ($L != null)", modelUnbindListenerFieldName())
         .addStatement("$L.onModelUnbound(this, object)", modelUnbindListenerFieldName())
         .endControlFlow();
-
-    addHashCodeValidationIfNecessary(unbindBuilder, classInfo,
-        "The model was changed during the unbind method.");
 
     methods.add(unbindBuilder
         .build());
@@ -853,7 +848,7 @@ class GeneratedModelWriter {
 
   private MethodSpec.Builder addMutabilityValidationIfNecessary(MethodSpec.Builder method,
       ClassToGenerateInfo classInfo) {
-    if (configManager.validateModelUsage(classInfo)) {
+    if (configManager.shouldValidateModeUsage()) {
       method.addStatement("validateMutability()");
     }
 
@@ -862,8 +857,8 @@ class GeneratedModelWriter {
 
   private MethodSpec.Builder addHashCodeValidationIfNecessary(MethodSpec.Builder method,
       ClassToGenerateInfo classInfo, String message) {
-    if (configManager.validateModelUsage(classInfo)) {
-      method.addStatement("validateStateHasNotChangedSinceAdded($S)", message);
+    if (configManager.shouldValidateModeUsage()) {
+      method.addStatement("validateStateHasNotChangedSinceAdded($S, position)", message);
     }
 
     return method;

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
@@ -46,9 +46,15 @@ class HashCodeValidator {
       validateImplementsHashCode(attribute.getAttributeElement().asType());
     } catch (EpoxyProcessorException e) {
       // Append information about the attribute and class to the existing exception
-      throwError(e.getMessage() + " (Attribute: %s Class: %s)",
-          attribute.getName(),
-          attribute.getClassElement().getSimpleName().toString());
+      throwError(e.getMessage()
+              + " (%s#%s) Epoxy requires every field annotated with "
+              + "@EpoxyAttribute to implement hashCode so that the state of the model can be "
+              + "tracked. "
+              + "If you want the attribute to be excluded from the model's hashCode, use "
+              + "@EpoxyAttribute(DoNotHash). If you want to ignore this warning use "
+              + "@EpoxyAttribute(IgnoreRequireHashCode)",
+          attribute.getClassElement().getSimpleName().toString(),
+          attribute.getName());
     }
   }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/PackageConfigSettings.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/PackageConfigSettings.java
@@ -7,28 +7,23 @@ class PackageConfigSettings {
 
   final boolean requireHashCode;
   final boolean requireAbstractModels;
-  final boolean validateModelUsage;
 
-  private PackageConfigSettings(boolean requireHashCode, boolean requireAbstractModels,
-      boolean validateModelUsage) {
+  private PackageConfigSettings(boolean requireHashCode, boolean requireAbstractModels) {
     this.requireHashCode = requireHashCode;
     this.requireAbstractModels = requireAbstractModels;
-    this.validateModelUsage = validateModelUsage;
   }
 
   static PackageConfigSettings forDefaults() {
     return new PackageConfigSettings(
         PackageEpoxyConfig.REQUIRE_HASHCODE_DEFAULT,
-        PackageEpoxyConfig.REQUIRE_ABSTRACT_MODELS,
-        PackageEpoxyConfig.VALIDATE_MODEL_USAGE
+        PackageEpoxyConfig.REQUIRE_ABSTRACT_MODELS_DEFAULT
     );
   }
 
   static PackageConfigSettings create(PackageEpoxyConfig configAnnotation) {
     return new PackageConfigSettings(
         configAnnotation.requireHashCode(),
-        configAnnotation.requireAbstractModels(),
-        configAnnotation.validateModelUsage()
+        configAnnotation.requireAbstractModels()
     );
   }
 }

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
@@ -8,6 +8,7 @@ import javax.tools.JavaFileObject;
 
 import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaFileObjects.forResource;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static java.util.Arrays.asList;
 
@@ -254,23 +255,14 @@ public class ConfigTest {
 
   @Test
   public void testConfigNoModelValidation() {
-    JavaFileObject configNoModelValidation =
-        JavaFileObjects
-            .forSourceString("com.airbnb.epoxy.package-info", "@PackageEpoxyConfig(\n"
-                + "    validateModelUsage = false\n"
-                + ")\n"
-                + "package com.airbnb.epoxy;\n"
-                + "\n"
-                + "import com.airbnb.epoxy.PackageEpoxyConfig;");
-
     JavaFileObject model =
         forResource("ModelNoValidation.java");
 
     JavaFileObject generatedModel = JavaFileObjects.forResource("ModelNoValidation_.java");
 
-    assert_().about(javaSources())
-        .that(asList(configNoModelValidation, model))
-        .processedWith(new EpoxyProcessor())
+    assert_().about(javaSource())
+        .that(model)
+        .processedWith(EpoxyProcessor.withNoValidation())
         .compilesWithoutError()
         .and()
         .generatesSources(generatedModel);

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ControllerProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ControllerProcessorTest.java
@@ -40,21 +40,12 @@ public class ControllerProcessorTest {
     JavaFileObject controller = JavaFileObjects
         .forResource("ControllerWithAutoModelWithoutValidation.java");
 
-    // Config to turn validation off
-    JavaFileObject CONFIG = JavaFileObjects
-        .forSourceString("com.airbnb.epoxy.package-info", "@PackageEpoxyConfig(\n"
-            + "    validateModelUsage = false\n"
-            + ")\n"
-            + "package com.airbnb.epoxy;\n"
-            + "\n"
-            + "import com.airbnb.epoxy.PackageEpoxyConfig;");
-
     JavaFileObject generatedHelper = JavaFileObjects
         .forResource("ControllerWithAutoModelWithoutValidation_EpoxyHelper.java");
 
     assert_().about(javaSources())
-        .that(asList(model, controller, CONFIG))
-        .processedWith(new EpoxyProcessor())
+        .that(asList(model, controller))
+        .processedWith(EpoxyProcessor.withNoValidation())
         .compilesWithoutError()
         .and()
         .generatesSources(generatedHelper);

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
@@ -25,8 +25,8 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
 
   @Override
   public void handlePreBind(final EpoxyViewHolder holder,
-      final AbstractModelWithHolder.Holder object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+      final AbstractModelWithHolder.Holder object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -34,7 +34,7 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -52,12 +52,10 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
 
   @Override
   public void unbind(AbstractModelWithHolder.Holder object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
+++ b/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
@@ -24,8 +24,8 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
@@ -24,8 +24,8 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_.java
@@ -24,8 +24,8 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$WithLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$WithLayout_.java
@@ -24,8 +24,8 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
@@ -24,8 +24,8 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$WithLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$WithLayout_.java
@@ -24,8 +24,8 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
@@ -24,8 +24,8 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
@@ -24,8 +24,8 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
+++ b/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
@@ -24,8 +24,8 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
+++ b/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
@@ -25,8 +25,8 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -34,7 +34,7 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -52,12 +52,10 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelNoValidation_.java
+++ b/epoxy-processortest/src/test/resources/ModelNoValidation_.java
@@ -18,7 +18,7 @@ public class ModelNoValidation_ extends ModelNoValidation implements GeneratedMo
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
   }
 
   @Override

--- a/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
@@ -24,8 +24,8 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
@@ -25,8 +25,8 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -34,7 +34,7 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -52,12 +52,10 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
@@ -24,8 +24,8 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
@@ -34,8 +34,8 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -43,7 +43,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -61,12 +61,10 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
@@ -34,8 +34,8 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -43,7 +43,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -61,12 +61,10 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
@@ -24,8 +24,8 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
@@ -24,8 +24,8 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
@@ -24,8 +24,8 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
@@ -32,8 +32,8 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -41,7 +41,7 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -59,12 +59,10 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
@@ -25,8 +25,8 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -34,7 +34,7 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -52,12 +52,10 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
@@ -24,8 +24,8 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
@@ -29,8 +29,8 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -38,7 +38,7 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -56,12 +56,10 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
@@ -24,8 +24,8 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
@@ -27,8 +27,8 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
     if (clickListener_epoxyGeneratedModel != null) {
       super.setClickListener(new View.OnClickListener() {
               // Save the original click listener so if it gets changed on
@@ -53,7 +53,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -71,12 +71,10 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
@@ -24,8 +24,8 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
@@ -24,8 +24,8 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithSuper_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuper_.java
@@ -24,8 +24,8 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithType_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithType_.java
@@ -24,8 +24,8 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
@@ -29,8 +29,8 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -38,7 +38,7 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -56,12 +56,10 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -27,8 +27,8 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
     if (clickListener_epoxyGeneratedModel != null) {
       super.clickListener = new View.OnClickListener() {
               // Save the original click listener so if it gets changed on
@@ -53,7 +53,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -71,12 +71,10 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
@@ -24,8 +24,8 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
@@ -24,8 +24,8 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.");
+  public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
@@ -33,7 +33,7 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.");
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
   }
 
   /**
@@ -51,12 +51,10 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
 
   @Override
   public void unbind(Object object) {
-    validateStateHasNotChangedSinceAdded("The model was changed between being being bound to the recycler view and being unbound.");
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
     }
-    validateStateHasNotChangedSinceAdded("The model was changed during the unbind method.");
   }
 
   /**

--- a/epoxy-sample/build.gradle
+++ b/epoxy-sample/build.gradle
@@ -33,16 +33,14 @@ android {
     versionCode 1
     versionName "1.0"
   }
-
-  buildTypes {
-    debug {
-      buildConfigField "boolean", "VALIDATE_MODEL_USAGE", "true"
-    }
-
-    release {
-      buildConfigField "boolean", "VALIDATE_MODEL_USAGE", "false"
-    }
-  }
+}
+project.android.buildTypes.all { buildType ->
+  buildType.javaCompileOptions.annotationProcessorOptions.arguments =
+      [
+          validateEpoxyModelUsage     : String.valueOf(buildType.name == 'debug'),
+          requireHashCodeInEpoxyModels: "true",
+          requireAbstractEpoxyModels  : "true"
+      ]
 }
 
 /* Forces all transitive deps listed to our version. */

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/package-info.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/package-info.java
@@ -1,9 +1,0 @@
-@PackageEpoxyConfig(
-    requireAbstractModels = true,
-    requireHashCode = true,
-    validateModelUsage = BuildConfig.VALIDATE_MODEL_USAGE // This is defined in build.gradle
-)
-package com.airbnb.epoxy.sample;
-
-import com.airbnb.epoxy.BuildConfig;
-import com.airbnb.epoxy.PackageEpoxyConfig;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.0.0-RC1
+VERSION_NAME=2.0.0-RC2
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
This changes the options in the package annotation to instead be specified as annotation processor options in the build.gradle. This makes it easier to apply options, and gives us more flexibility in how we apply them.

It also optimizes the hash code validation since that was really slowing down dev builds.

lastly this bumps to rc2