### PR TITLE
Allow canceling pending build model on EpoxyController

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
@@ -78,11 +78,19 @@ public abstract class EpoxyController {
     // so that they are debounced, and so any updates to data can be completely finished before
     // the models are built.
     if (hasBuiltModelsEver) {
-      handler.removeCallbacks(buildModelsRunnable);
+      cancelPendingModelBuild();
       handler.post(buildModelsRunnable);
     } else {
       dispatchModelBuild();
     }
+  }
+
+  /**
+   * Cancels a pending call to {@link #buildModels()} if one has been queued by {@link
+   * #requestModelBuild()}.
+   */
+  public void cancelPendingModelBuild() {
+    handler.removeCallbacks(buildModelsRunnable);
   }
 
   private final Runnable buildModelsRunnable = new Runnable() {


### PR DESCRIPTION
If a call to buildModels is posted but the screen is destroyed before the callback happens the user may want to cancel it.

I noticed I had a case where buildModels crashed because I cleared out an interface when my fragment was destroyed.