### PR TITLE
Change epoxy controller diffing to use equals instead of hashCode

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyAdapter.java
@@ -66,10 +66,10 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
    * previous so you don't have to micromanage notification calls yourself. This may be
    * prohibitively slow for large model lists (in the hundreds), in which case consider doing
    * notification calls yourself. If you use this, all your view models must implement {@link
-   * EpoxyModel#hashCode()} to completely identify their state, so that changes to a model's content
-   * can be detected. Before using this you must enable it with {@link #enableDiffing()}, since
-   * keeping track of the model state adds extra computation time to all other data change
-   * notifications.
+   * EpoxyModel#hashCode()} and {@link EpoxyModel#equals(Object)} to completely identify their
+   * state, so that changes to a model's content can be detected. Before using this you must enable
+   * it with {@link #enableDiffing()}, since keeping track of the model state adds extra computation
+   * time to all other data change notifications.
    *
    * @see #enableDiffing()
    */

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
@@ -379,7 +379,7 @@ public abstract class EpoxyController {
    * <p>
    * This is useful to verify that models are being diffed as expected, as well as to watch for
    * slowdowns in model building or diffing to indicate when you should optimize model building or
-   * model hashCode implementations (which can often slow down diffing).
+   * model hashCode/equals implementations (which can often slow down diffing).
    * <p>
    * This should only be used in debug builds to avoid a performance hit in prod.
    */

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyDiffLogger.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyDiffLogger.java
@@ -9,8 +9,8 @@ import android.util.Log;
  * events. This may be useful to use in debug builds in order to observe model updates and monitor
  * for issues.
  * <p>
- * You may want to look for unexpected item updates to catch improper hashCode implementations in
- * your models.
+ * You may want to look for unexpected item updates to catch improper hashCode/equals
+ * implementations in your models.
  * <p>
  * Additionally, you may want to look for frequent or unnecessary updates as an opportunity for
  * optimization.

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -362,6 +362,10 @@ public abstract class EpoxyModel<T> {
     }
   }
 
+  boolean isDebugValidationEnabled() {
+    return firstControllerAddedTo != null;
+  }
+
   /**
    * This is used internally by generated models to do validation checking when
    * "validateEpoxyModelUsage" is enabled and the model is used with an {@link EpoxyController}.
@@ -373,7 +377,7 @@ public abstract class EpoxyModel<T> {
     // The model may be added to multiple controllers, in which case if it was already diffed
     // and added to an adapter in one controller we don't want to even allow interceptors
     // from changing the model in a different controller
-    if (firstControllerAddedTo != null && !currentlyInInterceptors) {
+    if (isDebugValidationEnabled() && !currentlyInInterceptors) {
       throw new ImmutableModelException(this,
           getPosition(firstControllerAddedTo, this));
     }
@@ -401,7 +405,8 @@ public abstract class EpoxyModel<T> {
    */
   protected final void validateStateHasNotChangedSinceAdded(String descriptionOfChange,
       int modelPosition) {
-    if (firstControllerAddedTo != null && !currentlyInInterceptors
+    if (isDebugValidationEnabled()
+        && !currentlyInInterceptors
         && hashCodeWhenAdded != hashCode()) {
       throw new ImmutableModelException(this, descriptionOfChange, modelPosition);
     }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelState.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelState.java
@@ -24,15 +24,19 @@ class ModelState {
    */
   int lastMoveOp;
 
-  static ModelState build(EpoxyModel<?> model, int position) {
+  static ModelState build(EpoxyModel<?> model, int position, boolean immutableModel) {
     ModelState state = new ModelState();
 
     state.lastMoveOp = 0;
     state.pair = null;
     state.id = model.id();
-    state.hashCode = model.hashCode();
     state.position = position;
-    state.model = model;
+
+    if (immutableModel) {
+      state.model = model;
+    } else {
+      state.hashCode = model.hashCode();
+    }
 
     return state;
   }
@@ -59,6 +63,7 @@ class ModelState {
   public String toString() {
     return "ModelState{"
         + "id=" + id
+        + ", model=" + model
         + ", hashCode=" + hashCode
         + ", position=" + position
         + ", pair=" + pair

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/WrappedEpoxyModelClickListener.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/WrappedEpoxyModelClickListener.java
@@ -1,0 +1,46 @@
+package com.airbnb.epoxy;
+
+import android.view.View;
+import android.view.View.OnClickListener;
+
+/**
+ * Used in the generated models to transform normal view click listeners to model click
+ * listeners.
+ */
+public abstract class WrappedEpoxyModelClickListener implements OnClickListener {
+  // Save the original click listener so if it gets changed on
+  // the generated model this click listener won't be affected
+  // if it is still bound to a view. This also lets us call back to the original hashCode and
+  // equals methods
+  private final OnModelClickListener originalClickListener;
+
+  public WrappedEpoxyModelClickListener(OnModelClickListener originalClickListener) {
+    this.originalClickListener = originalClickListener;
+  }
+
+  @Override
+  public void onClick(View v) {
+    wrappedOnClick(v, originalClickListener);
+  }
+
+  protected abstract void wrappedOnClick(View v, OnModelClickListener originalClickListener);
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof WrappedEpoxyModelClickListener)) {
+      return false;
+    }
+
+    WrappedEpoxyModelClickListener that = (WrappedEpoxyModelClickListener) o;
+
+    return originalClickListener.equals(that.originalClickListener);
+  }
+
+  @Override
+  public int hashCode() {
+    return originalClickListener.hashCode();
+  }
+}

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyAttribute.java
@@ -29,8 +29,9 @@ public @interface EpoxyAttribute {
      */
     NoSetter,
     /**
-     * By default every attribute's hashCode method is called when determining the model's state.
-     * This option can be used to exclude an attribute's hashCode from contributing to the state.
+     * By default every attribute's hashCode and equals method is called when determining the
+     * model's state. This option can be used to exclude an attribute's hashCode/equals from
+     * contributing to the state.
      * <p>
      * This is useful for objects that may change without actually changing the model's state. A
      * common case is an anonymous click listener that gets recreated with every bind call.
@@ -41,17 +42,17 @@ public @interface EpoxyAttribute {
     DoNotHash,
     /**
      * This is meant to be used in conjunction with {@link PackageEpoxyConfig#requireHashCode()}.
-     * When that is enabled every attribute must implement hashCode. However, there are some valid
-     * cases where the attribute type does not implement hashCode, but it should still be hashed at
-     * runtime and contribute to the model's state. Use this option on an attribute in that case to
-     * tell the processor to let it pass the hashCode validation.
+     * When that is enabled every attribute must implement hashCode/equals. However, there are some
+     * valid cases where the attribute type does not implement hashCode/equals, but it should still
+     * be hashed at runtime and contribute to the model's state. Use this option on an attribute in
+     * that case to tell the processor to let it pass the hashCode/equals validation.
      * <p>
-     * An example case is AutoValue classes, where the generated class correctly implements hashCode
-     * at runtime.
+     * An example case is AutoValue classes, where the generated class correctly implements
+     * hashCode/equals at runtime.
      * <p>
      * If you use this it is your responsibility to ensure that the object assigned to the attribute
-     * at runtime correctly implements hashCode. If you don't want the attribute to contribute to
-     * model state you should use {@link Option#DoNotHash} instead.
+     * at runtime correctly implements hashCode/equals. If you don't want the attribute to
+     * contribute to model state you should use {@link Option#DoNotHash} instead.
      */
     IgnoreRequireHashCode
   }

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
@@ -19,22 +19,22 @@ public @interface PackageEpoxyConfig {
   boolean REQUIRE_ABSTRACT_MODELS_DEFAULT = false;
   /**
    * If true, all fields marked with {@link com.airbnb.epoxy.EpoxyAttribute} must have a type that
-   * implements hashCode (besides the default Object implementation), or the attribute must set
-   * hash=false.
+   * implements hashCode and equals (besides the default Object implementation), or the attribute
+   * must set DoNotHash as an option.
    * <p>
    * Setting this to true is useful for ensuring that all model attributes correctly implement
-   * hashCode, or use hash=false (eg for click listeners). It is a common mistake to miss these,
-   * which leads to invalid model state and incorrect diffing.
+   * hashCode and equals, or use DoNotHash (eg for click listeners). It is a common mistake to miss
+   * these, which leads to invalid model state and incorrect diffing.
    * <p>
    * The check is done at compile time and compilation will fail if a hashCode validation fails.
    * <p>
    * Since it is done at compile time this can only check the direct type of the field. Interfaces
-   * or classes will pass the check if they either have an abstract hashCode method (since it is
-   * assumed that the object at runtime will implement it) or their class hierarchy must have an
-   * implementation of hashCode besides the default Object implementation.
+   * or classes will pass the check if they either have an abstract hashCode/equals method (since it
+   * is assumed that the object at runtime will implement it) or their class hierarchy must have an
+   * implementation of hashCode/equals besides the default Object implementation.
    * <p>
    * If an attribute is an Iterable or Array then the type of object in that collection must
-   * implement hashCode.
+   * implement hashCode/equals.
    */
   boolean requireHashCode() default REQUIRE_HASHCODE_DEFAULT;
 

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelClickListenerTest.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelClickListenerTest.java
@@ -142,7 +142,7 @@ public class ModelClickListenerTest {
   }
 
   @Test
-  public void modelClickListenerIsHashed() {
+  public void modelClickListenerIsDiffed() {
     // Internally we wrap the model click listener with an anonymous click listener. We can't hash
     // the anonymous click listener since that changes the model state, instead our anonymous
     // click listener should use the hashCode of the user's click listener
@@ -169,7 +169,6 @@ public class ModelClickListenerTest {
     model = new ModelWithClickListener_();
     model.clickListener(modelClickListener);
     controller.setModel(model);
-    model.clickListener(modelClickListener);
     controller.requestModelBuild();
 
     model = new ModelWithClickListener_();
@@ -182,7 +181,7 @@ public class ModelClickListenerTest {
   }
 
   @Test
-  public void viewClickListenerIsHashed() {
+  public void viewClickListenerIsDiffed() {
     TestController controller = new TestController();
 
     AdapterDataObserver observerMock = mock(AdapterDataObserver.class);

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
@@ -35,6 +35,7 @@ class ProcessorUtils {
   static final String MODEL_CLICK_LISTENER_TYPE = "com.airbnb.epoxy.OnModelClickListener";
   static final String ON_BIND_MODEL_LISTENER_TYPE = "com.airbnb.epoxy.OnModelBoundListener";
   static final String ON_UNBIND_MODEL_LISTENER_TYPE = "com.airbnb.epoxy.OnModelUnboundListener";
+  static final String WRAPPED_LISTENER_TYPE = "com.airbnb.epoxy.WrappedEpoxyModelClickListener";
 
   static void throwError(String msg, Object... args)
       throws EpoxyProcessorException {

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ConfigTest.java
@@ -94,6 +94,18 @@ public class ConfigTest {
   }
 
   @Test
+  public void testConfigRequireEquals() {
+    JavaFileObject model =
+        forResource("ModelRequiresEqualsFailsBasicObject.java");
+
+    assert_().about(javaSources())
+        .that(asList(CONFIG_CLASS_REQUIRE_HASH, model))
+        .processedWith(new EpoxyProcessor())
+        .failsToCompile()
+        .withErrorContaining("Attribute does not implement equals");
+  }
+
+  @Test
   public void testConfigRequireHashCodeIterableFails() {
     JavaFileObject model =
         forResource("ModelRequiresHashCodeIterableFails.java");

--- a/epoxy-processortest/src/test/resources/ModelRequiresEqualsFailsBasicObject.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresEqualsFailsBasicObject.java
@@ -1,0 +1,22 @@
+package com.airbnb.epoxy.configtest;
+
+import com.airbnb.epoxy.EpoxyAttribute;
+import com.airbnb.epoxy.EpoxyModel;
+
+public class ModelRequiresEqualsFailsBasicObject extends EpoxyModel<Object> {
+
+  public static class ClassWithHashCodeAndNotEquals {
+
+    @Override
+    public int hashCode() {
+      return super.hashCode();
+    }
+  }
+
+  @EpoxyAttribute ClassWithHashCodeAndNotEquals classWithoutHashCode;
+
+  @Override
+  protected int getDefaultLayout() {
+    return 0;
+  }
+}

--- a/epoxy-processortest/src/test/resources/ModelRequiresHashCodeFailsBasicObject.java
+++ b/epoxy-processortest/src/test/resources/ModelRequiresHashCodeFailsBasicObject.java
@@ -7,6 +7,10 @@ public class ModelRequiresHashCodeFailsBasicObject extends EpoxyModel<Object> {
 
   public static class ClassWithoutHashCode {
 
+    @Override
+    public boolean equals(Object obj) {
+      return super.equals(obj);
+    }
   }
 
   @EpoxyAttribute ClassWithoutHashCode classWithoutHashCode;

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
@@ -31,21 +31,13 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
     if (clickListener_epoxyGeneratedModel != null) {
-      super.setClickListener(new View.OnClickListener() {
-              // Save the original click listener so if it gets changed on
-              // the generated model this click listener won't be affected
-              // if it is still bound to a view.
-              private final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithPrivateViewClickListener_.this.clickListener_epoxyGeneratedModel;
-              public void onClick(View v) {
-              clickListener_epoxyGeneratedModel.onClick(ModelWithPrivateViewClickListener_.this, object, v,
-                  holder.getAdapterPosition());
-              }
-              public int hashCode() {
-                 // Use the hash of the original click listener so we don't change the
-                 // value by wrapping it with this anonymous click listener
-                 return clickListener_epoxyGeneratedModel.hashCode();
-              }
-            });
+      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener_epoxyGeneratedModel) {
+              @Override
+              protected void wrappedOnClick(View v, OnModelClickListener originalClickListener) {
+                 originalClickListener.onClick(com.airbnb.epoxy.ModelWithPrivateViewClickListener_.this, object, v,
+                        holder.getAdapterPosition());
+                 }
+              });
     }
   }
 
@@ -96,19 +88,17 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   public ModelWithPrivateViewClickListener_ clickListener(final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener) {
     validateMutability();
     this.clickListener_epoxyGeneratedModel = clickListener;
-    super.setClickListener(new View.OnClickListener() {
-            // Save the original click listener so if it gets changed on
-            // the generated model this click listener won't be affected
-            // if it is still bound to a view.
-            private final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithPrivateViewClickListener_.this.clickListener_epoxyGeneratedModel;
-            public void onClick(View v) { }
-            
-            public int hashCode() {
-               // Use the hash of the original click listener so we don't change the
-               // value by wrapping it with this anonymous click listener
-               return clickListener_epoxyGeneratedModel.hashCode();
-            }
-          });
+    if (clickListener == null) {
+      super.setClickListener(null);
+    }
+    else {
+      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener)  {
+                  @Override
+                  protected void wrappedOnClick(View v, OnModelClickListener originalClickListener) {
+                    
+                  }
+                });
+    }
     return this;
   }
 

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -31,21 +31,13 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
     if (clickListener_epoxyGeneratedModel != null) {
-      super.clickListener = new View.OnClickListener() {
-              // Save the original click listener so if it gets changed on
-              // the generated model this click listener won't be affected
-              // if it is still bound to a view.
-              private final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithViewClickListener_.this.clickListener_epoxyGeneratedModel;
-              public void onClick(View v) {
-              clickListener_epoxyGeneratedModel.onClick(ModelWithViewClickListener_.this, object, v,
-                  holder.getAdapterPosition());
-              }
-              public int hashCode() {
-                 // Use the hash of the original click listener so we don't change the
-                 // value by wrapping it with this anonymous click listener
-                 return clickListener_epoxyGeneratedModel.hashCode();
-              }
-            };
+      super.clickListener = new WrappedEpoxyModelClickListener(clickListener_epoxyGeneratedModel) {
+              @Override
+              protected void wrappedOnClick(View v, OnModelClickListener originalClickListener) {
+                 originalClickListener.onClick(com.airbnb.epoxy.ModelWithViewClickListener_.this, object, v,
+                        holder.getAdapterPosition());
+                 }
+              };
     }
   }
 
@@ -96,19 +88,17 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   public ModelWithViewClickListener_ clickListener(final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener) {
     validateMutability();
     this.clickListener_epoxyGeneratedModel = clickListener;
-    super.clickListener = new View.OnClickListener() {
-            // Save the original click listener so if it gets changed on
-            // the generated model this click listener won't be affected
-            // if it is still bound to a view.
-            private final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener_epoxyGeneratedModel = ModelWithViewClickListener_.this.clickListener_epoxyGeneratedModel;
-            public void onClick(View v) { }
-            
-            public int hashCode() {
-               // Use the hash of the original click listener so we don't change the
-               // value by wrapping it with this anonymous click listener
-               return clickListener_epoxyGeneratedModel.hashCode();
-            }
-          };
+    if (clickListener == null) {
+      super.clickListener = null;
+    }
+    else {
+      super.clickListener = new WrappedEpoxyModelClickListener(clickListener)  {
+                  @Override
+                  protected void wrappedOnClick(View v, OnModelClickListener originalClickListener) {
+                    
+                  }
+                };
+    }
     return this;
   }
 

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/ColorModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/ColorModel.java
@@ -4,7 +4,6 @@ import android.support.annotation.ColorInt;
 import android.view.View;
 
 import com.airbnb.epoxy.EpoxyAttribute;
-import com.airbnb.epoxy.EpoxyAttribute.Option;
 import com.airbnb.epoxy.EpoxyModel;
 import com.airbnb.epoxy.EpoxyModelClass;
 import com.airbnb.epoxy.R;


### PR DESCRIPTION
We can do this now since we force models to be immutable and we can keep the previous model around. 

Pros: 
1. equals is more accurate since it's possible to have hashCode collisions.
2. Equals can fail early as soon as a difference is found, so it could be faster. 
3. We have to calculate all model hashCodes when the models are first added to the adapter - this is unnecessary work if the models won’t be diffed again or will be removed, and using equals avoids this

 Cons: 
1. Changing documentation and education to say that diffing uses both hashCode and equals. 
2. Possible bugs if people only implemented hashCode.

I've updated all the places I found that mention hashCode, and I also changed the hashcode requirement validation to also include equals and updated tests.