### PR TITLE
Option to delay model build by arbitrary amount

### DIFF
--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/ColorModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/ColorModel.java
@@ -4,7 +4,6 @@ import android.support.annotation.ColorInt;
 import android.view.View;
 
 import com.airbnb.epoxy.EpoxyAttribute;
-import com.airbnb.epoxy.EpoxyAttribute.Option;
 import com.airbnb.epoxy.EpoxyModel;
 import com.airbnb.epoxy.EpoxyModelClass;
 import com.airbnb.epoxy.R;


### PR DESCRIPTION
Using this to delay a model update may be helpful in cases where user input is causing many
rapid changes in the models, such as typing. In that case, the view is already updated on
screen and constantly rebuilding models is potentially slow and unnecessary. The downside to
delaying the model build too long is that models will not be in sync with the data or view, and
scrolling the view offscreen and back onscreen will cause the model to bind old data.