### PR TITLE
Modify layout resource processing to support databinding layouts

### DIFF
--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyDataBindingLayouts.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/EpoxyDataBindingLayouts.java
@@ -1,0 +1,23 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to specify a list of databinding layout resources that you want EpoxyModels generated for.
+ * The models will be generated in the same package as this annotation. Every layout must be a valid
+ * databinding layout. The name of the generated model will be based on the layout resource name.
+ * <p>
+ * The layouts must not specify a custom databinding class name or package via the
+ * class="com.example.CustomClassName" override in the layout xml.
+ */
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.CLASS)
+public @interface EpoxyDataBindingLayouts {
+  /** A list of databinding layout resources that should have EpoxyModel's generated for them. */
+  @LayoutRes int[] value();
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModuleLookup.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModuleLookup.java
@@ -1,0 +1,122 @@
+package com.airbnb.epoxy;
+
+import com.squareup.javapoet.ClassName;
+
+import java.util.List;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+class DataBindingModuleLookup {
+
+  private final Elements elements;
+  private final Types types;
+  private final ErrorLogger errorLogger;
+  private final LayoutResourceProcessor resourceProcessor;
+
+  DataBindingModuleLookup(Elements elements, Types types, ErrorLogger errorLogger,
+      LayoutResourceProcessor resourceProcessor) {
+
+    this.elements = elements;
+    this.types = types;
+    this.errorLogger = errorLogger;
+    this.resourceProcessor = resourceProcessor;
+  }
+
+  String getModuleName(Element element) {
+    PackageElement packageOf = elements.getPackageOf(element);
+    String packageName = packageOf.getQualifiedName().toString();
+
+    // First we try to get the module name by looking at what R classes were found when processing
+    // layout annotations. This may find nothing if no layouts were given as annotation params
+    String moduleName = getModuleNameViaResources(packageName);
+
+    if (moduleName == null) {
+      // If the first approach fails, we try to guess at the R class for the module and look up
+      // the class to see if it exists. This can fail if this model's package name does not
+      // include the module name as a prefix (convention makes this unlikely.)
+      moduleName = getModuleNameViaGuessing(packageName);
+    }
+
+    if (moduleName == null) {
+      errorLogger.logError("Could not find module name for DataBinding BR class.");
+      // Fallback to using the package name so we can at least try to generate and compile something
+      moduleName = packageName;
+    }
+
+    return moduleName;
+  }
+
+  /**
+   * Attempts to get the module name of the given package. We can do this because the package name
+   * of an R class is the module. Generally only one R class is used and we can just use that module
+   * name, but it is possible to have multiple R classes. In that case we compare the package names
+   * to find what is the most similar.
+   * <p>
+   * We need to get the module name to know the path of the BR class for data binding.
+   */
+  private String getModuleNameViaResources(String packageName) {
+    List<ClassName> rClasses = resourceProcessor.getRClassNames();
+    if (rClasses.isEmpty()) {
+      return packageName;
+    }
+
+    if (rClasses.size() == 1) {
+      // Common case
+      return rClasses.get(0).packageName();
+    }
+
+    // Generally the only R class used should be the app's. It is possible to use other R classes
+    // though, like Android's. In that case we figure out the most likely match by comparing the
+    // package name.
+    //  For example we might have "com.airbnb.epoxy.R" and "android.R"
+    String[] packageNames = packageName.split("\\.");
+
+    ClassName bestMatch = null;
+    int bestNumMatches = -1;
+
+    for (ClassName rClass : rClasses) {
+      String[] rModuleNames = rClass.packageName().split("\\.");
+      int numNameMatches = 0;
+      for (int i = 0; i < Math.min(packageNames.length, rModuleNames.length); i++) {
+        if (packageNames[i].equals(rModuleNames[i])) {
+          numNameMatches++;
+        } else {
+          break;
+        }
+      }
+
+      if (numNameMatches > bestNumMatches) {
+        bestMatch = rClass;
+      }
+    }
+
+    return bestMatch.packageName();
+  }
+
+  /**
+   * Attempts to get the android module that is currently being processed.. We can do this because
+   * the package name of an R class is the module name. So, we take any element in the module,
+   * <p>
+   * We need to get the module name to know the path of the BR class for data binding.
+   */
+  private String getModuleNameViaGuessing(String packageName) {
+    String[] packageNameParts = packageName.split("\\.");
+
+    String moduleName = "";
+    for (int i = 0; i < packageNameParts.length; i++) {
+      moduleName += packageNameParts[i];
+
+      Element rClass = ProcessorUtils.getElementByName(moduleName + ".R", elements, types);
+      if (rClass != null) {
+        return moduleName;
+      } else {
+        moduleName += ".";
+      }
+    }
+
+    return null;
+  }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.java
@@ -1,0 +1,79 @@
+package com.airbnb.epoxy;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+class DataBindingProcessor {
+  private final Filer filer;
+  private final Elements elementUtils;
+  private final Types typeUtils;
+  private final ErrorLogger errorLogger;
+  private final ConfigManager configManager;
+  private final LayoutResourceProcessor layoutResourceProcessor;
+  private final DataBindingModuleLookup dataBindingModuleLookup;
+
+  DataBindingProcessor(Filer filer, Elements elementUtils, Types typeUtils, ErrorLogger errorLogger,
+      ConfigManager configManager, LayoutResourceProcessor layoutResourceProcessor,
+      DataBindingModuleLookup dataBindingModuleLookup) {
+
+    this.filer = filer;
+    this.elementUtils = elementUtils;
+    this.typeUtils = typeUtils;
+    this.errorLogger = errorLogger;
+    this.configManager = configManager;
+    this.layoutResourceProcessor = layoutResourceProcessor;
+    this.dataBindingModuleLookup = dataBindingModuleLookup;
+  }
+
+  void process(RoundEnvironment roundEnv) {
+    Set<? extends Element> dataBindingLayoutPackageElements =
+        roundEnv.getElementsAnnotatedWith(EpoxyDataBindingLayouts.class);
+
+    for (Element packageElement : dataBindingLayoutPackageElements) {
+      List<LayoutResource> layoutResources = layoutResourceProcessor
+          .getLayoutsInAnnotation(packageElement, EpoxyDataBindingLayouts.class);
+
+      // Get the module name after parsing resources so we can use the resource classes to figure
+      // out the module name
+      String moduleName = dataBindingModuleLookup.getModuleName(packageElement);
+
+      for (LayoutResource layoutResource : layoutResources) {
+        generateDataBindingModel(layoutResource, moduleName);
+      }
+    }
+  }
+
+  private void generateDataBindingModel(LayoutResource layoutResource, String moduleName) {
+    String dataBindingClassName = getDataBindingClassNameForResource(layoutResource, moduleName);
+
+    // This databinding class won't exist until the second round of annotation processing since
+    // it is generated in the first round. If it doesn't exist we need to hold onto it until the
+    // next round and then try again.
+    Element dataBindingClass =
+        ProcessorUtils.getElementByName(dataBindingClassName, elementUtils, typeUtils);
+
+    // TODO: Inspect the methods enclosed in the binding class to find setters. Use those setters
+    // to get the variable names and types. Then generate an EpoxyModel with those variables
+
+  }
+
+  private String getDataBindingClassNameForResource(LayoutResource layoutResource,
+      String moduleName) {
+    // TODO
+
+    // From https://developer.android.com/topic/libraries/data-binding/index.html
+    // By default, a Binding class will be generated based on the name of the layout file,
+    // converting it to Pascal case and suffixing "Binding" to it. The above layout file was
+    // main_activity.xml so the generate class was MainActivityBinding.
+
+    // We don't support custom class names via <data class="com.example.CustomClassName">
+
+    return "";
+  }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LayoutResource.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LayoutResource.java
@@ -8,20 +8,26 @@ import com.squareup.javapoet.CodeBlock;
  * <p>
  * Inpspired by Butterknife. https://github.com/JakeWharton/butterknife/pull/613
  */
-final class ModelLayoutResource {
+final class LayoutResource {
   private static final ClassName ANDROID_R = ClassName.get("android", "R");
 
+  final ClassName className;
+  final String resourceName;
   final int value;
   final CodeBlock code;
   final boolean qualifed;
 
-  ModelLayoutResource(int value) {
+  LayoutResource(int value) {
     this.value = value;
     this.code = CodeBlock.of("$L", value);
     this.qualifed = false;
+    resourceName = null;
+    className = null;
   }
 
-  ModelLayoutResource(ClassName className, String resourceName, int value) {
+  LayoutResource(ClassName className, String resourceName, int value) {
+    this.className = className;
+    this.resourceName = resourceName;
     this.value = value;
     this.code = className.topLevelClassName().equals(ANDROID_R)
         ? CodeBlock.of("$L.$N", className, resourceName)
@@ -34,11 +40,11 @@ final class ModelLayoutResource {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ModelLayoutResource)) {
+    if (!(o instanceof LayoutResource)) {
       return false;
     }
 
-    ModelLayoutResource that = (ModelLayoutResource) o;
+    LayoutResource that = (LayoutResource) o;
 
     if (value != that.value) {
       return false;

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LayoutResourceProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LayoutResourceProcessor.java
@@ -7,13 +7,13 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeScanner;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
@@ -29,19 +29,14 @@ import javax.lang.model.util.Types;
  * This is adapted from Butterknife. https://github.com/JakeWharton/butterknife/pull/613
  */
 class LayoutResourceProcessor {
-  private static final String CLASS_ANNOTATION_CANONICAL_NAME =
-      EpoxyModelClass.class.getCanonicalName();
 
   private final ErrorLogger errorLogger;
   private final Elements elementUtils;
   private final Types typeUtils;
-  /**
-   * Map of fully qualified model name to layout resource for the EpoxyModelClass annotation on that
-   * model.
-   */
-  private final Map<String, ModelLayoutResource> modelLayoutMap = new HashMap<>();
+
   private Trees trees;
   private final Map<String, ClassName> rClassNameMap = new HashMap<>();
+  private final AnnotationLayoutParamScanner scanner = new AnnotationLayoutParamScanner();
 
   LayoutResourceProcessor(ProcessingEnvironment processingEnv, ErrorLogger errorLogger,
       Elements elementUtils, Types typeUtils) {
@@ -56,161 +51,130 @@ class LayoutResourceProcessor {
     }
   }
 
-  /**
-   * Looks up the layout resource used in the {@link EpoxyModelClass} annotation on this model. The
-   * given element is expected to be an EpoxyModel that is annotated with {@link EpoxyModelClass}
-   */
-  ModelLayoutResource getLayoutForModel(TypeElement modelClassElement) {
-    String modelName = getModelNameFromElement(modelClassElement);
-    ModelLayoutResource modelLayout = modelLayoutMap.get(modelName);
+  LayoutResource getLayoutInAnnotation(TypeElement element, Class annotationClass) {
+    List<LayoutResource> layouts = getLayoutsInAnnotation(element, annotationClass);
+    if (layouts.size() != 1) {
+      errorLogger.logError(
+          "Expected exactly 1 layout resource in the %s annotation but received %s. Annotated "
+              + "element is %s",
+          annotationClass.getSimpleName(), layouts.size(), element.getSimpleName());
 
-    if (modelLayout == null) {
-      // If a value was hardcoded, instead of an R.layout value, then there won't be a match.
-      // We just use the hardcoded value directly in this case.
-      EpoxyModelClass annotation = modelClassElement.getAnnotation(EpoxyModelClass.class);
-      modelLayout = new ModelLayoutResource(annotation.layout());
-      modelLayoutMap.put(modelName, modelLayout);
+      if (layouts.isEmpty()) {
+        // Just pass back something so the code can compile before the error logger prints
+        return new LayoutResource(0);
+      }
     }
 
-    return modelLayout;
+    return layouts.get(0);
   }
 
   /**
-   * Attempts to get the module name of the given package. We can do this because the package name
-   * of an R class is the module. Generally only one R class is used and we can just use that module
-   * name, but it is possible to have multiple R classes. In that case we compare the package names
-   * to find what is the most similar.
-   * <p>
-   * We need to get the module name to know the path of the BR class for data binding.
+   * Get detailed information about the layout resources that are parameters to the given
+   * annotation.
    */
-  String getModuleName(String packageName) {
-    List<ClassName> rClasses = new ArrayList<>(rClassNameMap.values());
-    if (rClasses.isEmpty()) {
-      return packageName;
+  List<LayoutResource> getLayoutsInAnnotation(Element element, Class annotationClass) {
+    List<Integer> layoutValues = getLayoutValues(element, annotationClass);
+    List<LayoutResource> resources = new ArrayList<>(layoutValues.size());
+
+    JCTree tree = (JCTree) trees.getTree(element, getAnnotationMirror(element, annotationClass));
+    // tree can be null if the references are compiled types and not source
+    if (tree != null) {
+      // Collects details about the layout resource used for the annotation parameter
+      scanner.clearResults();
+      scanner.setCurrentAnnotationDetails(element, annotationClass);
+      tree.accept(scanner);
+      List<ScannerResult> scannerResults = scanner.getResults();
+
+      for (ScannerResult scannerResult : scannerResults) {
+        resources.add(new LayoutResource(
+            getClassName(scannerResult.rClass),
+            scannerResult.resourceName,
+            scannerResult.resourceValue
+        ));
+      }
     }
 
-    if (rClasses.size() == 1) {
-      // Common case
-      return rClasses.get(0).packageName();
-    }
-
-    // Generally the only R class used should be the app's. It is possible to use other R classes
-    // though, like Android's. In that case we figure out the most likely match by comparing the
-    // package name.
-    //  For example we might have "com.airbnb.epoxy.R" and "android.R"
-    String[] packageNames = packageName.split("\\.");
-
-    ClassName bestMatch = null;
-    int bestNumMatches = -1;
-
-    for (ClassName rClass : rClasses) {
-      String[] rModuleNames = rClass.packageName().split("\\.");
-      int numNameMatches = 0;
-      for (int i = 0; i < Math.min(packageNames.length, rModuleNames.length); i++) {
-        if (packageNames[i].equals(rModuleNames[i])) {
-          numNameMatches++;
-        } else {
-          break;
+    // Layout values may not have been picked up by the scanner if they are hardcoded.
+    // In that case we just use the hardcoded value without an R class
+    if (resources.size() != layoutValues.size()) {
+      for (int layoutValue : layoutValues) {
+        if (!isLayoutValueInResources(resources, layoutValue)) {
+          resources.add(new LayoutResource(layoutValue));
         }
       }
+    }
 
-      if (numNameMatches > bestNumMatches) {
-        bestMatch = rClass;
+    return resources;
+  }
+
+  private boolean isLayoutValueInResources(List<LayoutResource> resources, int layoutValue) {
+    for (LayoutResource resource : resources) {
+      if (resource.value == layoutValue) {
+        return true;
       }
     }
 
-    return bestMatch.packageName();
+    return false;
   }
 
-  private String getModelNameFromElement(TypeElement modelClassElement) {
-    return modelClassElement.getQualifiedName().toString();
-  }
+  private static List<Integer> getLayoutValues(Element element, Class annotationClass) {
+    Annotation annotation = element.getAnnotation(annotationClass);
 
-  /**
-   * Processes details about the layout resources used in {@link EpoxyModelClass} annotations
-   * across all Epoxy models. Details for each model layout is stored in a map so they can be looked
-   * up with the model name via {@link #getLayoutForModel(TypeElement)}
-   */
-  void processResources(RoundEnvironment env) {
-    modelLayoutMap.clear();
-
-    if (trees == null) {
-      return;
+    // We could do this in a more generic way if we ever need to support more annotation types
+    List<Integer> layoutResources = new ArrayList<>();
+    if (annotation instanceof EpoxyModelClass) {
+      layoutResources.add(((EpoxyModelClass) annotation).layout());
+    } else if (annotation instanceof EpoxyDataBindingLayouts) {
+      for (int layoutRes : ((EpoxyDataBindingLayouts) annotation).value()) {
+        layoutResources.add(layoutRes);
+      }
     }
 
-    ModelLayoutScanner scanner = new ModelLayoutScanner();
-
-    for (Element modelElement : env.getElementsAnnotatedWith(EpoxyModelClass.class)) {
-      EpoxyModelClass modelAnnotation = modelElement.getAnnotation(EpoxyModelClass.class);
-      int layoutValue = modelAnnotation.layout();
-
-      if (layoutValue == 0) {
-        // A layout value was not provided in this annotation
-        continue;
-      }
-
-      JCTree tree = (JCTree) trees.getTree(modelElement, getAnnotationMirror(modelElement));
-      if (tree == null) {
-        // tree can be null if the references are compiled types and not source
-        continue;
-      }
-
-      // Collects details about the layout resource used for the annotation parameter
-      tree.accept(scanner);
-      ScannerResult result = scanner.getResult();
-      if (result == null) {
-        // Unable to get details on layout resource. This could happen if a layout value is
-        // hardcoded
-        continue;
-      }
-
-      if (layoutValue != result.resourceValue) {
-        // I don't know why this would happen, but it seems worth sanity checking for
-        errorLogger.logError(
-            "Layout resource from scanner did not match expected value. Class: %s Expected: %s "
-                + "Scanner Value: %s",
-            modelElement.getSimpleName(), layoutValue, result.resourceValue);
-        continue;
-      }
-
-      ModelLayoutResource layoutResource =
-          new ModelLayoutResource(
-              getClassName(result.rClass),
-              result.resourceName,
-              result.resourceValue
-          );
-
-      String modelName = getModelNameFromElement((TypeElement) modelElement);
-      modelLayoutMap.put(modelName, layoutResource);
-    }
+    return layoutResources;
   }
 
-  private AnnotationMirror getAnnotationMirror(Element element) {
+  private AnnotationMirror getAnnotationMirror(Element element, Class annotationClass) {
     for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
-      if (annotationMirror.getAnnotationType().toString().equals(CLASS_ANNOTATION_CANONICAL_NAME)) {
+      if (annotationMirror.getAnnotationType().toString()
+          .equals(annotationClass.getCanonicalName())) {
         return annotationMirror;
       }
     }
 
     errorLogger.logError("Unable to get %s annotation on model %",
-        EpoxyModelClass.class, element.getSimpleName());
+        annotationClass.getSimpleName(), element.getSimpleName());
 
     return null;
   }
 
-  /**
-   * Scans the EpoxyModelClass annotation to examine the layout resource parameter. It finds the R
-   * class that the layout resource belongs to, as well as the resource name and value.
-   */
-  private class ModelLayoutScanner extends TreeScanner {
-    private ScannerResult result;
+  List<ClassName> getRClassNames() {
+    return new ArrayList<>(rClassNameMap.values());
+  }
 
-    ScannerResult getResult() {
-      return result;
+  /**
+   * Scans annotations that have layout resources as parameters. It supports both one layout
+   * parameter, and parameters in an array. The R class, resource name, and value, is extract from
+   * each layout to create a corresponding {@link ScannerResult} for each layout.
+   */
+  private class AnnotationLayoutParamScanner extends TreeScanner {
+    private final List<ScannerResult> results = new ArrayList<>();
+    private Element element;
+    private Class annotationClass;
+
+    void clearResults() {
+      results.clear();
+    }
+
+    List<ScannerResult> getResults() {
+      return new ArrayList<>(results);
     }
 
     @Override
     public void visitSelect(JCTree.JCFieldAccess jcFieldAccess) {
+      // This "visit" method is called for each parameter in the annotation, but only if the
+      // parameter is a field type (eg R.layout.resource_name is a field inside the R.layout
+      // class). This means this method will not pick up things like booleans and strings.
+
       // This is the layout resource parameter inside the EpoxyModelClass annotation
       Symbol symbol = jcFieldAccess.sym;
 
@@ -219,9 +183,10 @@ class LayoutResourceProcessor {
           && symbol.getEnclosingElement().getEnclosingElement() != null // The R class
           && symbol.getEnclosingElement().getEnclosingElement().enclClass() != null) {
 
-        result = parseResourceSymbol((VarSymbol) symbol);
-      } else {
-        result = null;
+        ScannerResult result = parseResourceSymbol((VarSymbol) symbol);
+        if (result != null) {
+          results.add(result);
+        }
       }
     }
 
@@ -234,8 +199,9 @@ class LayoutResourceProcessor {
 
       // Make sure this is a layout resource
       if (!(rClass + ".layout").equals(layoutClass)) {
-        errorLogger.logError("%s annotation requires a layout resource but received %s",
-            EpoxyModelClass.class, layoutClass);
+        errorLogger
+            .logError("%s annotation requires a layout resource but received %s. (Element: %s)",
+                annotationClass.getSimpleName(), layoutClass, element.getSimpleName());
         return null;
       }
 
@@ -244,12 +210,17 @@ class LayoutResourceProcessor {
 
       Object layoutValue = symbol.getConstantValue();
       if (!(layoutValue instanceof Integer)) {
-        errorLogger.logError("%s annotation requires an int value but received %s",
-            EpoxyModelClass.class, symbol.getQualifiedName());
+        errorLogger.logError("%s annotation requires an int value but received %s. (Element: %s)",
+            annotationClass.getSimpleName(), symbol.getQualifiedName(), element.getSimpleName());
         return null;
       }
 
       return new ScannerResult(rClass, layoutResourceName, (int) layoutValue);
+    }
+
+    void setCurrentAnnotationDetails(Element element, Class annotationClass) {
+      this.element = element;
+      this.annotationClass = annotationClass;
     }
   }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
@@ -38,7 +38,7 @@ class ModelProcessor {
 
   ModelProcessor(Filer filer, Messager messager, Elements elementUtils, Types typeUtils,
       ConfigManager configManager, ErrorLogger errorLogger,
-      LayoutResourceProcessor layoutProcessor) {
+      LayoutResourceProcessor layoutProcessor, DataBindingModuleLookup dataBindingModuleLookup) {
     this.messager = messager;
     this.elementUtils = elementUtils;
     this.typeUtils = typeUtils;
@@ -46,7 +46,7 @@ class ModelProcessor {
     this.errorLogger = errorLogger;
     modelWriter =
         new GeneratedModelWriter(filer, typeUtils, elementUtils, errorLogger, layoutProcessor,
-            configManager);
+            configManager, dataBindingModuleLookup);
   }
 
   List<ClassToGenerateInfo> getGeneratedModels() {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
@@ -53,30 +53,6 @@ class ProcessorUtils {
     }
   }
 
-  /**
-   * Attempts to get the android module that is currently being processed.. We can do this because
-   * the package name of an R class is the module name. So, we take any element in the module,
-   * <p>
-   * We need to get the module name to know the path of the BR class for data binding.
-   */
-  static String getModelNameForElement(String packageName, Elements elements, Types types) {
-    String[] packageNameParts = packageName.split("\\.");
-
-    String moduleName = "";
-    for (int i = 0; i < packageNameParts.length; i++) {
-      moduleName += packageNameParts[i];
-
-      Element rClass = getElementByName(moduleName + ".R", elements, types);
-      if (rClass != null) {
-        return moduleName;
-      } else {
-        moduleName += ".";
-      }
-    }
-
-    return null;
-  }
-
   static ClassName getClassName(String className) {
     return ClassName.bestGuess(className);
   }


### PR DESCRIPTION
This adds a `EpoxyDataBindingLayouts` package annotation where people can specify databinding layouts that they want models generated for.

It also does a refactor of the layout processing to support this annotation. Previously the layout processing supported only the EpoxyModelClass annotation and a single layout in the annotation param. This makes the layout processing more general, so it can support multiple layout parameters. It also simplifies the layout processor to not store the layout resources via a map, and instead looks up the layout information off the annotation when it is requested.

Lastly, this sets up a DataBindingProcessor with stubbed out methods to generate the models for the layouts in `EpoxyDataBindingLayouts` annotations. That can be filled in a follow up PR.

fyi @geralt-encore 
cc @ngsilverman I like this layout processing a lot more since it gets rid of storing the resources in a map and supports multiple resource values.