### PR TITLE
Option to implicitly add AutoModels

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelper.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ControllerHelper.java
@@ -10,7 +10,7 @@ import java.util.List;
 public abstract class ControllerHelper<T extends EpoxyController> {
   public abstract void resetAutoModels();
 
-  protected void validateModelHashCodesHaveNotChanged(EpoxyController controller) {
+  protected void validateModelHashCodesHaveNotChanged(T controller) {
     List<EpoxyModel<?>> currentModels = controller.getAdapter().getCopyOfModels();
 
     for (int i = 0; i < currentModels.size(); i++) {
@@ -18,5 +18,9 @@ public abstract class ControllerHelper<T extends EpoxyController> {
       model.validateStateHasNotChangedSinceAdded(
           "Model has changed since it was added to the controller.", i);
     }
+  }
+
+  protected void setControllerToStageTo(EpoxyModel<?> model, T controller) {
+    model.controllerToStageTo = controller;
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -41,6 +41,12 @@ public abstract class EpoxyModel<T> {
    * reference to the first.
    */
   private EpoxyController firstControllerAddedTo;
+  /**
+   * Models are staged when they are changed. This allows them to be automatically added when they
+   * are done being changed (eg the next model is changed/added or buildModels finishes). It is only
+   * allowed for AutoModels, and only if implicity adding is enabled.
+   */
+  EpoxyController controllerToStageTo;
   private boolean currentlyInInterceptors;
   private int hashCodeWhenAdded;
   private boolean hasDefaultId;
@@ -260,7 +266,7 @@ public abstract class EpoxyModel<T> {
   protected abstract int getDefaultLayout();
 
   public EpoxyModel<T> layout(@LayoutRes int layoutRes) {
-    validateMutability();
+    onMutation();
     layout = layoutRes;
     return this;
   }
@@ -278,7 +284,7 @@ public abstract class EpoxyModel<T> {
    * Sets fields of the model to default ones.
    */
   public EpoxyModel<T> reset() {
-    validateMutability();
+    onMutation();
 
     layout = 0;
     shown = true;
@@ -301,6 +307,12 @@ public abstract class EpoxyModel<T> {
   public void addIf(boolean condition, EpoxyController controller) {
     if (condition) {
       addTo(controller);
+    } else if (controllerToStageTo != null) {
+      // Clear this model from staging since it failed the add condition. If this model wasn't
+      // staged (eg not changed before addIf was called, then we need to make sure to add the
+      // previously staged model.
+      controllerToStageTo.clearModelFromStaging(this);
+      controllerToStageTo = null;
     }
   }
 
@@ -309,9 +321,7 @@ public abstract class EpoxyModel<T> {
    * called from inside {@link EpoxyController#buildModels()}.
    */
   public void addIf(AddPredicate predicate, EpoxyController controller) {
-    if (predicate.addIf()) {
-      addTo(controller);
-    }
+    addIf(predicate.addIf(), controller);
   }
 
   /**
@@ -372,14 +382,21 @@ public abstract class EpoxyModel<T> {
    * This method validates that it is ok to change this model. It is only valid if the model hasn't
    * yet been added, or the change is being done from an {@link EpoxyController.Interceptor}
    * callback.
+   * <p>
+   * This is also used to stage the model for implicitly adding it, if it is an AutoModel and
+   * implicit adding is enabled.
    */
-  protected final void validateMutability() {
+  protected final void onMutation() {
     // The model may be added to multiple controllers, in which case if it was already diffed
     // and added to an adapter in one controller we don't want to even allow interceptors
     // from changing the model in a different controller
     if (isDebugValidationEnabled() && !currentlyInInterceptors) {
       throw new ImmutableModelException(this,
           getPosition(firstControllerAddedTo, this));
+    }
+
+    if (controllerToStageTo != null) {
+      controllerToStageTo.setStagedModel(this);
     }
   }
 
@@ -398,7 +415,7 @@ public abstract class EpoxyModel<T> {
    * This is used internally by generated models to do validation checking when
    * "validateEpoxyModelUsage" is enabled and the model is used with a {@link EpoxyController}. This
    * method validates that the model's hashCode hasn't been changed since it was added to the
-   * controller. This is similar to {@link #validateMutability()}, but that method is only used for
+   * controller. This is similar to {@link #onMutation()}, but that method is only used for
    * specific model changes such as calling a setter. By checking the hashCode, this method allows
    * us to catch more subtle changes, such as through setting a field directly or through changing
    * an object that is set on the model.
@@ -467,7 +484,7 @@ public abstract class EpoxyModel<T> {
    * EpoxyController}
    */
   public EpoxyModel<T> show(boolean show) {
-    validateMutability();
+    onMutation();
     shown = show;
     return this;
   }

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageEpoxyConfig.java
@@ -11,12 +11,15 @@ import java.lang.annotation.Target;
  * package.
  * <p>
  * If an instance of this annotation is not found in a package then the default values are used.
+ * <p>
+ * See https://github.com/airbnb/epoxy/wiki/Configuration for more details on these options.
  */
 @Target(ElementType.PACKAGE)
 @Retention(RetentionPolicy.CLASS)
 public @interface PackageEpoxyConfig {
   boolean REQUIRE_HASHCODE_DEFAULT = false;
   boolean REQUIRE_ABSTRACT_MODELS_DEFAULT = false;
+  boolean IMPLICITLY_ADD_AUTO_MODELS_DEFAULT = false;
   /**
    * If true, all fields marked with {@link com.airbnb.epoxy.EpoxyAttribute} must have a type that
    * implements hashCode and equals (besides the default Object implementation), or the attribute
@@ -47,4 +50,14 @@ public @interface PackageEpoxyConfig {
    * of the generated class.
    */
   boolean requireAbstractModels() default REQUIRE_ABSTRACT_MODELS_DEFAULT;
+
+  /**
+   * If true, models in an EpoxyController that use the {@link AutoModel} annotation don't need to
+   * be explicitly added to the controller with ".addTo". Instead, they will be added automatically
+   * after they are modified.
+   * <p>
+   * For more details, see the wiki:
+   * https://github.com/airbnb/epoxy/wiki/Epoxy-Controller#implicit-adding
+   */
+  boolean implicitlyAddAutoModels() default IMPLICITLY_ADD_AUTO_MODELS_DEFAULT;
 }

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/ControllerWithoutImplicityAdding.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/ControllerWithoutImplicityAdding.java
@@ -1,0 +1,10 @@
+package com.airbnb.epoxy;
+
+public class ControllerWithoutImplicityAdding extends EpoxyController {
+  @AutoModel Model_ model1;
+
+  @Override
+  protected void buildModels() {
+    model1.value(3);
+  }
+}

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/Model.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/Model.java
@@ -3,7 +3,7 @@ package com.airbnb.epoxy;
 import android.widget.TextView;
 
 @EpoxyModelClass
-abstract class Model extends EpoxyModel<TextView> {
+public abstract class Model extends EpoxyModel<TextView> {
   @EpoxyAttribute int value;
 
   @Override

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/ControllerWithImplicitlyAddedModels.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/ControllerWithImplicitlyAddedModels.java
@@ -1,0 +1,74 @@
+package com.airbnb.epoxy.autoaddautomodels;
+
+import com.airbnb.epoxy.AutoModel;
+import com.airbnb.epoxy.EpoxyController;
+import com.airbnb.epoxy.EpoxyModel.AddPredicate;
+import com.airbnb.epoxy.Model_;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ControllerWithImplicitlyAddedModels extends EpoxyController {
+  @AutoModel Model_ model1;
+  @AutoModel Model_ model2;
+  @AutoModel Model_ model3;
+  @AutoModel Model_ model4;
+  @AutoModel Model_ model5;
+  @AutoModel Model_ model6;
+  @AutoModel Model_ model7;
+  @AutoModel Model_ model8;
+  @AutoModel Model_ model9;
+
+  private List<Model_> expectedModels;
+
+  @Override
+  protected void buildModels() {
+    expectedModels = new ArrayList<>();
+
+    model1
+        .value(3);
+    expectedModels.add(model1);
+
+    add(model2);
+    expectedModels.add(model2);
+
+    model3
+        .addTo(this);
+    expectedModels.add(model3);
+
+    model4
+        .value(4)
+        .addTo(this);
+    expectedModels.add(model4);
+
+    model5
+        .value(34)
+        .addIf(false, this);
+
+    model6
+        .value(34)
+        .addIf(new AddPredicate() {
+          @Override
+          public boolean addIf() {
+            return false;
+          }
+        }, this);
+
+    model7
+        .addIf(true, this);
+    expectedModels.add(model7);
+
+    model8
+        .value(2)
+        .addIf(true, this);
+    expectedModels.add(model8);
+
+    model9
+        .value(34);
+    expectedModels.add(model9);
+  }
+
+  public List<Model_> getExpectedModels() {
+    return expectedModels;
+  }
+}

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/ControllerWithImplicitlyAddedModels2.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/ControllerWithImplicitlyAddedModels2.java
@@ -1,0 +1,56 @@
+package com.airbnb.epoxy.autoaddautomodels;
+
+import com.airbnb.epoxy.AutoModel;
+import com.airbnb.epoxy.EpoxyController;
+import com.airbnb.epoxy.Model_;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ControllerWithImplicitlyAddedModels2 extends EpoxyController {
+  @AutoModel Model_ model1;
+  @AutoModel Model_ model2;
+  @AutoModel Model_ model3;
+  @AutoModel Model_ model4;
+  @AutoModel Model_ model5;
+  @AutoModel Model_ model6;
+  @AutoModel Model_ model7;
+  @AutoModel Model_ model8;
+  @AutoModel Model_ model9;
+
+  private List<Model_> expectedModels;
+
+  @Override
+  protected void buildModels() {
+    expectedModels = new ArrayList<>();
+
+    add(model1);
+    expectedModels.add(model1);
+
+    add(model2.value(2));
+    expectedModels.add(model2);
+
+    add(model3.value(3));
+    expectedModels.add(model3);
+
+    model4.value(4);
+    expectedModels.add(model4);
+
+    model5.value(5);
+    expectedModels.add(model5);
+
+    model6.addIf(false, this);
+
+    model7.addIf(false, this);
+
+    model8.addIf(true, this);
+    expectedModels.add(model8);
+
+    add(model9);
+    expectedModels.add(model9);
+  }
+
+  public List<Model_> getExpectedModels() {
+    return expectedModels;
+  }
+}

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/ControllerWithImplicitlyAddedModels3.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/ControllerWithImplicitlyAddedModels3.java
@@ -1,0 +1,49 @@
+package com.airbnb.epoxy.autoaddautomodels;
+
+import com.airbnb.epoxy.AutoModel;
+import com.airbnb.epoxy.EpoxyController;
+import com.airbnb.epoxy.Model_;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ControllerWithImplicitlyAddedModels3 extends EpoxyController {
+  @AutoModel Model_ model1;
+  @AutoModel Model_ model2;
+  @AutoModel Model_ model3;
+  @AutoModel Model_ model4;
+
+  private List<Model_> expectedModels;
+
+  @Override
+  protected void buildModels() {
+    expectedModels = new ArrayList<>();
+
+    model1.value(1);
+    expectedModels.add(model1);
+
+    Model_ localModel = new Model_();
+    add(localModel.id(1));
+    expectedModels.add(localModel);
+
+    localModel = new Model_();
+    add(localModel.id(2).value(2));
+    expectedModels.add(localModel);
+
+    model2.value(2);
+    expectedModels.add(model2);
+
+    localModel = new Model_();
+    localModel.id(3).value(3).addTo(this);
+    expectedModels.add(localModel);
+
+    model3.addIf(false, this);
+
+    add(model4);
+    expectedModels.add(model4);
+  }
+
+  public List<Model_> getExpectedModels() {
+    return expectedModels;
+  }
+}

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/package-info.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/autoaddautomodels/package-info.java
@@ -1,0 +1,4 @@
+@PackageEpoxyConfig(implicitlyAddAutoModels = true)
+package com.airbnb.epoxy.autoaddautomodels;
+
+import com.airbnb.epoxy.PackageEpoxyConfig;

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/AutoModelIntegrationTest.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/AutoModelIntegrationTest.java
@@ -1,10 +1,15 @@
 package com.airbnb.epoxy;
 
+import com.airbnb.epoxy.autoaddautomodels.ControllerWithImplicitlyAddedModels;
+import com.airbnb.epoxy.autoaddautomodels.ControllerWithImplicitlyAddedModels2;
+import com.airbnb.epoxy.autoaddautomodels.ControllerWithImplicitlyAddedModels3;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -35,5 +40,37 @@ public class AutoModelIntegrationTest {
   public void assigningIdToAutoModelFails() {
     AdapterWithIdChanged testAdapter = new AdapterWithIdChanged();
     testAdapter.requestModelBuild();
+  }
+
+  @Test
+  public void implicitlyAddingAutoModelsDisabledByDefault() {
+    ControllerWithoutImplicityAdding controller = new ControllerWithoutImplicityAdding();
+    controller.requestModelBuild();
+
+    assertEquals(new ArrayList<>(), controller.getAdapter().getCopyOfModels());
+  }
+
+  @Test
+  public void implicitlyAddingAutoModels() {
+    ControllerWithImplicitlyAddedModels controller = new ControllerWithImplicitlyAddedModels();
+    controller.requestModelBuild();
+
+    assertEquals(controller.getExpectedModels(), controller.getAdapter().getCopyOfModels());
+  }
+
+  @Test
+  public void implicitlyAddingAutoModels2() {
+    ControllerWithImplicitlyAddedModels2 controller = new ControllerWithImplicitlyAddedModels2();
+    controller.requestModelBuild();
+
+    assertEquals(controller.getExpectedModels(), controller.getAdapter().getCopyOfModels());
+  }
+
+  @Test
+  public void implicitlyAddingAutoModels3() {
+    ControllerWithImplicitlyAddedModels3 controller = new ControllerWithImplicitlyAddedModels3();
+    controller.requestModelBuild();
+
+    assertEquals(controller.getExpectedModels(), controller.getAdapter().getCopyOfModels());
   }
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
@@ -19,6 +19,7 @@ class ConfigManager {
   static final String PROCESSOR_OPTION_VALIDATE_MODEL_USAGE = "validateEpoxyModelUsage";
   static final String PROCESSOR_OPTION_REQUIRE_HASHCODE = "requireHashCodeInEpoxyModels";
   static final String PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS = "requireAbstractEpoxyModels";
+  static final String PROCESSOR_IMPLICITLY_ADD_AUTO_MODELS = "implicitlyAddAutoModels";
 
   private static final PackageConfigSettings
       DEFAULT_PACKAGE_CONFIG_SETTINGS = PackageConfigSettings.forDefaults();
@@ -27,6 +28,7 @@ class ConfigManager {
   private final boolean validateModelUsage;
   private final boolean globalRequireHashCode;
   private final boolean globalRequireAbstractModels;
+  private final boolean globalImplicitlyAddAutoModels;
 
   ConfigManager(Map<String, String> options, Elements elementUtils) {
     this.elementUtils = elementUtils;
@@ -38,6 +40,10 @@ class ConfigManager {
     globalRequireAbstractModels =
         getBooleanOption(options, PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS,
             PackageEpoxyConfig.REQUIRE_ABSTRACT_MODELS_DEFAULT);
+
+    globalImplicitlyAddAutoModels =
+        getBooleanOption(options, PROCESSOR_IMPLICITLY_ADD_AUTO_MODELS,
+            PackageEpoxyConfig.IMPLICITLY_ADD_AUTO_MODELS_DEFAULT);
   }
 
   private static boolean getBooleanOption(Map<String, String> options, String option,
@@ -92,6 +98,11 @@ class ConfigManager {
   boolean requiresAbstractModels(TypeElement classElement) {
     return globalRequireAbstractModels
         || getConfigurationForElement(classElement).requireAbstractModels;
+  }
+
+  boolean implicitlyAddAutoModels(ControllerClassInfo controller) {
+    return globalImplicitlyAddAutoModels
+        || getConfigurationForElement(controller.controllerClassElement).implicitlyAddAutoModels;
   }
 
   boolean shouldValidateModelUsage() {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ControllerProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ControllerProcessor.java
@@ -292,10 +292,15 @@ class ControllerProcessor {
       builder.addStatement("validateModelsHaveNotChanged()");
     }
 
+    boolean implicitlyAddAutoModels = configManager.implicitlyAddAutoModels(controllerInfo);
     long id = -1;
     for (ControllerModelField model : controllerInfo.models) {
       builder.addStatement("controller.$L = new $T()", model.fieldName, model.typeName)
           .addStatement("controller.$L.id($L)", model.fieldName, id--);
+
+      if (implicitlyAddAutoModels) {
+        builder.addStatement("setControllerToStageTo(controller.$L, controller)", model.fieldName);
+      }
     }
 
     if (configManager.shouldValidateModelUsage()) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -20,6 +20,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import static com.airbnb.epoxy.ConfigManager.PROCESSOR_IMPLICITLY_ADD_AUTO_MODELS;
 import static com.airbnb.epoxy.ConfigManager.PROCESSOR_OPTION_VALIDATE_MODEL_USAGE;
 
 /**
@@ -59,6 +60,13 @@ public class EpoxyProcessor extends AbstractProcessor {
   public static EpoxyProcessor withNoValidation() {
     HashMap<String, String> options = new HashMap<>();
     options.put(PROCESSOR_OPTION_VALIDATE_MODEL_USAGE, "false");
+    return new EpoxyProcessor(options);
+  }
+
+  /** For testing. */
+  public static EpoxyProcessor withImplicitAdding() {
+    HashMap<String, String> options = new HashMap<>();
+    options.put(PROCESSOR_IMPLICITLY_ADD_AUTO_MODELS, "true");
     return new EpoxyProcessor(options);
   }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -237,7 +237,7 @@ class GeneratedModelWriter {
         .addParameter(boundObjectParam)
         .addParameter(TypeName.INT, "position");
 
-    addHashCodeValidationIfNecessary(preBindBuilder, classInfo,
+    addHashCodeValidationIfNecessary(preBindBuilder,
         "The model was changed between being added to the controller and being bound.");
 
     ClassName viewType = getClassName("android.view.View");
@@ -280,7 +280,7 @@ class GeneratedModelWriter {
         .addStatement("$L.onModelBound(this, object, position)", modelBindListenerFieldName())
         .endControlFlow();
 
-    addHashCodeValidationIfNecessary(postBindBuilder, classInfo,
+    addHashCodeValidationIfNecessary(postBindBuilder,
         "The model was changed during the bind call.");
 
     methods.add(postBindBuilder
@@ -305,7 +305,7 @@ class GeneratedModelWriter {
         .returns(classInfo.getParameterizedGeneratedName())
         .addParameter(bindListenerParam);
 
-    addMutabilityValidationIfNecessary(onBind, classInfo)
+    addOnMutationCall(onBind)
         .addStatement("this.$L = listener", modelBindListenerFieldName())
         .addStatement("return this")
         .build();
@@ -349,7 +349,7 @@ class GeneratedModelWriter {
         .addModifiers(PUBLIC)
         .returns(classInfo.getParameterizedGeneratedName());
 
-    addMutabilityValidationIfNecessary(onUnbind, classInfo)
+    addOnMutationCall(onUnbind)
         .addParameter(unbindListenerParam)
         .addStatement("this.$L = listener", modelUnbindListenerFieldName())
         .addStatement("return this");
@@ -658,7 +658,7 @@ class GeneratedModelWriter {
             + "      }",
         clickWrapperType, attributeName, viewType, modelClickListenerType);
 
-    addMutabilityValidationIfNecessary(builder, classInfo)
+    addOnMutationCall(builder)
         .addStatement("this.$L = $L", attribute.getModelClickListenerName(), attributeName)
         .beginControlFlow("if ($L == null)", attributeName)
         .addStatement("super." + attribute.setterCode(), "null")
@@ -876,7 +876,7 @@ class GeneratedModelWriter {
         .addParameter(ParameterSpec.builder(attribute.getType(), attributeName)
             .addAnnotations(attribute.getSetterAnnotations()).build());
 
-    addMutabilityValidationIfNecessary(builder, helperClass)
+    addOnMutationCall(builder)
         .addStatement("this." + attribute.setterCode(), attributeName);
 
     if (attribute.isViewClickListener()) {
@@ -918,17 +918,13 @@ class GeneratedModelWriter {
         .build();
   }
 
-  private MethodSpec.Builder addMutabilityValidationIfNecessary(MethodSpec.Builder method,
-      ClassToGenerateInfo classInfo) {
-    if (configManager.shouldValidateModelUsage()) {
-      method.addStatement("validateMutability()");
-    }
-
+  private MethodSpec.Builder addOnMutationCall(MethodSpec.Builder method) {
+      method.addStatement("onMutation()");
     return method;
   }
 
   private MethodSpec.Builder addHashCodeValidationIfNecessary(MethodSpec.Builder method,
-      ClassToGenerateInfo classInfo, String message) {
+      String message) {
     if (configManager.shouldValidateModelUsage()) {
       method.addStatement("validateStateHasNotChangedSinceAdded($S, position)", message);
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/PackageConfigSettings.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/PackageConfigSettings.java
@@ -7,23 +7,27 @@ class PackageConfigSettings {
 
   final boolean requireHashCode;
   final boolean requireAbstractModels;
+  final boolean implicitlyAddAutoModels;
 
-  private PackageConfigSettings(boolean requireHashCode, boolean requireAbstractModels) {
+  private PackageConfigSettings(boolean requireHashCode, boolean requireAbstractModels,
+      boolean implicitlyAddAutoModels) {
     this.requireHashCode = requireHashCode;
     this.requireAbstractModels = requireAbstractModels;
+    this.implicitlyAddAutoModels = implicitlyAddAutoModels;
   }
 
   static PackageConfigSettings forDefaults() {
     return new PackageConfigSettings(
         PackageEpoxyConfig.REQUIRE_HASHCODE_DEFAULT,
-        PackageEpoxyConfig.REQUIRE_ABSTRACT_MODELS_DEFAULT
+        PackageEpoxyConfig.REQUIRE_ABSTRACT_MODELS_DEFAULT,
+        PackageEpoxyConfig.IMPLICITLY_ADD_AUTO_MODELS_DEFAULT
     );
   }
 
   static PackageConfigSettings create(PackageEpoxyConfig configAnnotation) {
     return new PackageConfigSettings(
         configAnnotation.requireHashCode(),
-        configAnnotation.requireAbstractModels()
-    );
+        configAnnotation.requireAbstractModels(),
+        configAnnotation.implicitlyAddAutoModels());
   }
 }

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ControllerProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ControllerProcessorTest.java
@@ -18,14 +18,14 @@ public class ControllerProcessorTest {
     JavaFileObject model = JavaFileObjects
         .forResource("BasicModelWithAttribute.java");
 
-    JavaFileObject adapter = JavaFileObjects
+    JavaFileObject controller = JavaFileObjects
         .forResource("ControllerWithAutoModel.java");
 
     JavaFileObject generatedHelper = JavaFileObjects
         .forResource("ControllerWithAutoModel_EpoxyHelper.java");
 
     assert_().about(javaSources())
-        .that(asList(model, adapter))
+        .that(asList(model, controller))
         .processedWith(new EpoxyProcessor())
         .compilesWithoutError()
         .and()
@@ -71,5 +71,25 @@ public class ControllerProcessorTest {
         .that(badClass)
         .processedWith(new EpoxyProcessor())
         .failsToCompile();
+  }
+
+  @Test
+  public void setsStagingControllerWhenImplicitlyAddingModels() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("BasicModelWithAttribute.java");
+
+    JavaFileObject controller = JavaFileObjects
+        .forResource("ControllerWithAutoModelAndImplicitAdding.java");
+
+    JavaFileObject generatedHelper = JavaFileObjects
+        .forResource("ControllerWithAutoModelAndImplicitAdding_EpoxyHelper.java");
+
+    assert_().about(javaSources())
+        .that(asList(model, controller))
+        .processedWith(EpoxyProcessor.withImplicitAdding())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedHelper);
+
   }
 }

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
@@ -46,7 +46,7 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public AbstractModelWithHolder_ onBind(OnModelBoundListener<AbstractModelWithHolder_, AbstractModelWithHolder.Holder> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -67,13 +67,13 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public AbstractModelWithHolder_ onUnbind(OnModelUnboundListener<AbstractModelWithHolder_, AbstractModelWithHolder.Holder> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public AbstractModelWithHolder_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
+++ b/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
@@ -45,7 +45,7 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public BasicModelWithAttribute_ onBind(OnModelBoundListener<BasicModelWithAttribute_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public BasicModelWithAttribute_ onUnbind(OnModelUnboundListener<BasicModelWithAttribute_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public BasicModelWithAttribute_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ControllerWithAutoModelAndImplicitAdding.java
+++ b/epoxy-processortest/src/test/resources/ControllerWithAutoModelAndImplicitAdding.java
@@ -1,0 +1,16 @@
+package com.airbnb.epoxy.adapter;
+
+import com.airbnb.epoxy.AutoModel;
+import com.airbnb.epoxy.BasicModelWithAttribute_;
+import com.airbnb.epoxy.EpoxyController;
+
+public class ControllerWithAutoModelAndImplicitAdding extends EpoxyController {
+
+  @AutoModel BasicModelWithAttribute_ modelWithAttribute1;
+  @AutoModel BasicModelWithAttribute_ modelWithAttribute2;
+
+  @Override
+  protected void buildModels() {
+
+  }
+}

--- a/epoxy-processortest/src/test/resources/ControllerWithAutoModelAndImplicitAdding_EpoxyHelper.java
+++ b/epoxy-processortest/src/test/resources/ControllerWithAutoModelAndImplicitAdding_EpoxyHelper.java
@@ -1,0 +1,55 @@
+package com.airbnb.epoxy.adapter;
+
+import com.airbnb.epoxy.BasicModelWithAttribute_;
+import com.airbnb.epoxy.ControllerHelper;
+import com.airbnb.epoxy.EpoxyModel;
+import java.lang.IllegalStateException;
+import java.lang.Override;
+import java.lang.String;
+
+/**
+ * Generated file. Do not modify! */
+public class ControllerWithAutoModelAndImplicitAdding_EpoxyHelper extends ControllerHelper<ControllerWithAutoModelAndImplicitAdding> {
+  private final ControllerWithAutoModelAndImplicitAdding controller;
+
+  private EpoxyModel modelWithAttribute1;
+
+  private EpoxyModel modelWithAttribute2;
+
+  public ControllerWithAutoModelAndImplicitAdding_EpoxyHelper(ControllerWithAutoModelAndImplicitAdding controller) {
+    this.controller = controller;
+  }
+
+  @Override
+  public void resetAutoModels() {
+    validateModelsHaveNotChanged();
+    controller.modelWithAttribute1 = new BasicModelWithAttribute_();
+    controller.modelWithAttribute1.id(-1);
+    setControllerToStageTo(controller.modelWithAttribute1, controller);
+    controller.modelWithAttribute2 = new BasicModelWithAttribute_();
+    controller.modelWithAttribute2.id(-2);
+    setControllerToStageTo(controller.modelWithAttribute2, controller);
+    saveModelsForNextValidation();
+  }
+
+  private void validateModelsHaveNotChanged() {
+    validateSameModel(modelWithAttribute1, controller.modelWithAttribute1, "modelWithAttribute1", -1);
+    validateSameModel(modelWithAttribute2, controller.modelWithAttribute2, "modelWithAttribute2", -2);
+    validateModelHashCodesHaveNotChanged(controller);
+  }
+
+  private void validateSameModel(EpoxyModel expectedObject, EpoxyModel actualObject,
+      String fieldName, int id) {
+    if (expectedObject != actualObject) {
+      throw new IllegalStateException("Fields annotated with AutoModel cannot be directly assigned. The controller manages these fields for you. (" + controller.getClass().getSimpleName() + "#" + fieldName + ")");
+    }
+    if (actualObject != null && actualObject.id() != id) {
+      throw new IllegalStateException("Fields annotated with AutoModel cannot have their id changed manually. The controller manages the ids of these models for you. (" + controller.getClass().getSimpleName() + "#" + fieldName + ")");
+    }
+  }
+
+  private void saveModelsForNextValidation() {
+    modelWithAttribute1 = controller.modelWithAttribute1;
+    modelWithAttribute2 = controller.modelWithAttribute2;
+  }
+}

--- a/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypesNoValidation_.java
+++ b/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypesNoValidation_.java
@@ -49,6 +49,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public DataBindingModelWithAllFieldTypesNoValidation_ onBind(OnModelBoundListener<DataBindingModelWithAllFieldTypesNoValidation_, DataBindingEpoxyModel.DataBindingHolder> listener) {
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -69,11 +70,13 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public DataBindingModelWithAllFieldTypesNoValidation_ onUnbind(OnModelUnboundListener<DataBindingModelWithAllFieldTypesNoValidation_, DataBindingEpoxyModel.DataBindingHolder> listener) {
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueInteger(Integer valueInteger) {
+    onMutation();
     this.valueInteger = valueInteger;
     return this;
   }
@@ -83,6 +86,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueShort(short valueShort) {
+    onMutation();
     this.valueShort = valueShort;
     return this;
   }
@@ -92,6 +96,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueLong(long valueLong) {
+    onMutation();
     this.valueLong = valueLong;
     return this;
   }
@@ -101,6 +106,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueList(List<String> valueList) {
+    onMutation();
     this.valueList = valueList;
     return this;
   }
@@ -110,6 +116,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueShortWrapper(Short valueShortWrapper) {
+    onMutation();
     this.valueShortWrapper = valueShortWrapper;
     return this;
   }
@@ -119,6 +126,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueDouble(double valueDouble) {
+    onMutation();
     this.valueDouble = valueDouble;
     return this;
   }
@@ -128,6 +136,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueChar(char valueChar) {
+    onMutation();
     this.valueChar = valueChar;
     return this;
   }
@@ -137,6 +146,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueInt(int valueInt) {
+    onMutation();
     this.valueInt = valueInt;
     return this;
   }
@@ -146,6 +156,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueDoubleWrapper(Double valueDoubleWrapper) {
+    onMutation();
     this.valueDoubleWrapper = valueDoubleWrapper;
     return this;
   }
@@ -155,6 +166,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueFloatWrapper(Float valueFloatWrapper) {
+    onMutation();
     this.valueFloatWrapper = valueFloatWrapper;
     return this;
   }
@@ -164,6 +176,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
+    onMutation();
     this.valueBooleanWrapper = valueBooleanWrapper;
     return this;
   }
@@ -173,6 +186,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueByteWrapper(Byte valueByteWrapper) {
+    onMutation();
     this.valueByteWrapper = valueByteWrapper;
     return this;
   }
@@ -182,6 +196,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valuebByte(byte valuebByte) {
+    onMutation();
     this.valuebByte = valuebByte;
     return this;
   }
@@ -191,6 +206,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueLongWrapper(Long valueLongWrapper) {
+    onMutation();
     this.valueLongWrapper = valueLongWrapper;
     return this;
   }
@@ -200,6 +216,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueCharacter(Character valueCharacter) {
+    onMutation();
     this.valueCharacter = valueCharacter;
     return this;
   }
@@ -209,6 +226,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueString(String valueString) {
+    onMutation();
     this.valueString = valueString;
     return this;
   }
@@ -218,6 +236,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueFloat(float valueFloat) {
+    onMutation();
     this.valueFloat = valueFloat;
     return this;
   }
@@ -227,6 +246,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueBoolean(boolean valueBoolean) {
+    onMutation();
     this.valueBoolean = valueBoolean;
     return this;
   }
@@ -236,6 +256,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueObjectArray(Object[] valueObjectArray) {
+    onMutation();
     this.valueObjectArray = valueObjectArray;
     return this;
   }
@@ -245,6 +266,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueObject(Object valueObject) {
+    onMutation();
     this.valueObject = valueObject;
     return this;
   }
@@ -254,6 +276,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   }
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueIntArray(int[] valueIntArray) {
+    onMutation();
     this.valueIntArray = valueIntArray;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypes_.java
@@ -58,7 +58,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public DataBindingModelWithAllFieldTypes_ onBind(OnModelBoundListener<DataBindingModelWithAllFieldTypes_, DataBindingEpoxyModel.DataBindingHolder> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -79,13 +79,13 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public DataBindingModelWithAllFieldTypes_ onUnbind(OnModelUnboundListener<DataBindingModelWithAllFieldTypes_, DataBindingEpoxyModel.DataBindingHolder> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public DataBindingModelWithAllFieldTypes_ valueInteger(Integer valueInteger) {
-    validateMutability();
+    onMutation();
     this.valueInteger = valueInteger;
     return this;
   }
@@ -95,7 +95,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueShort(short valueShort) {
-    validateMutability();
+    onMutation();
     this.valueShort = valueShort;
     return this;
   }
@@ -105,7 +105,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueLong(long valueLong) {
-    validateMutability();
+    onMutation();
     this.valueLong = valueLong;
     return this;
   }
@@ -115,7 +115,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueList(List<String> valueList) {
-    validateMutability();
+    onMutation();
     this.valueList = valueList;
     return this;
   }
@@ -125,7 +125,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
-    validateMutability();
+    onMutation();
     this.valueShortWrapper = valueShortWrapper;
     return this;
   }
@@ -135,7 +135,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueDouble(double valueDouble) {
-    validateMutability();
+    onMutation();
     this.valueDouble = valueDouble;
     return this;
   }
@@ -145,7 +145,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueChar(char valueChar) {
-    validateMutability();
+    onMutation();
     this.valueChar = valueChar;
     return this;
   }
@@ -155,7 +155,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueInt(int valueInt) {
-    validateMutability();
+    onMutation();
     this.valueInt = valueInt;
     return this;
   }
@@ -165,7 +165,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
-    validateMutability();
+    onMutation();
     this.valueDoubleWrapper = valueDoubleWrapper;
     return this;
   }
@@ -175,7 +175,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
-    validateMutability();
+    onMutation();
     this.valueFloatWrapper = valueFloatWrapper;
     return this;
   }
@@ -185,7 +185,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
-    validateMutability();
+    onMutation();
     this.valueBooleanWrapper = valueBooleanWrapper;
     return this;
   }
@@ -195,7 +195,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
-    validateMutability();
+    onMutation();
     this.valueByteWrapper = valueByteWrapper;
     return this;
   }
@@ -205,7 +205,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valuebByte(byte valuebByte) {
-    validateMutability();
+    onMutation();
     this.valuebByte = valuebByte;
     return this;
   }
@@ -215,7 +215,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
-    validateMutability();
+    onMutation();
     this.valueLongWrapper = valueLongWrapper;
     return this;
   }
@@ -225,7 +225,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueCharacter(Character valueCharacter) {
-    validateMutability();
+    onMutation();
     this.valueCharacter = valueCharacter;
     return this;
   }
@@ -235,7 +235,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueString(String valueString) {
-    validateMutability();
+    onMutation();
     this.valueString = valueString;
     return this;
   }
@@ -245,7 +245,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueFloat(float valueFloat) {
-    validateMutability();
+    onMutation();
     this.valueFloat = valueFloat;
     return this;
   }
@@ -255,7 +255,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueBoolean(boolean valueBoolean) {
-    validateMutability();
+    onMutation();
     this.valueBoolean = valueBoolean;
     return this;
   }
@@ -265,7 +265,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
-    validateMutability();
+    onMutation();
     this.valueObjectArray = valueObjectArray;
     return this;
   }
@@ -275,7 +275,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueObject(Object valueObject) {
-    validateMutability();
+    onMutation();
     this.valueObject = valueObject;
     return this;
   }
@@ -285,7 +285,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   }
 
   public DataBindingModelWithAllFieldTypes_ valueIntArray(int[] valueIntArray) {
-    validateMutability();
+    onMutation();
     this.valueIntArray = valueIntArray;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
@@ -45,7 +45,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodNextParentLayout$NoLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodNextParentLayout$NoLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_.java
@@ -45,7 +45,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,7 +66,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ extends 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodNextParentLayout$StillNoLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$WithLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$WithLayout_.java
@@ -45,7 +45,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodNextParentLayout$WithLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,7 +66,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ extends Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodNextParentLayout$WithLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodNextParentLayout$WithLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
@@ -45,7 +45,7 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodParentLayout$NoLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodParentLayout$NoLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$WithLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$WithLayout_.java
@@ -45,7 +45,7 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$WithLayout_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethodParentLayout$WithLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,7 +66,7 @@ public class GenerateDefaultLayoutMethodParentLayout$WithLayout_ extends Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethodParentLayout$WithLayout_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethodParentLayout$WithLayout_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
@@ -45,7 +45,7 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethod_ onBind(OnModelBoundListener<GenerateDefaultLayoutMethod_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public GenerateDefaultLayoutMethod_ onUnbind(OnModelUnboundListener<GenerateDefaultLayoutMethod_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public GenerateDefaultLayoutMethod_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
@@ -45,7 +45,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelDoNotHash_ onBind(OnModelBoundListener<ModelDoNotHash_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelDoNotHash_ onUnbind(OnModelUnboundListener<ModelDoNotHash_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelDoNotHash_ value2(int value2) {
-    validateMutability();
+    onMutation();
     this.value2 = value2;
     return this;
   }
@@ -82,7 +82,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
   }
 
   public ModelDoNotHash_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }
@@ -92,7 +92,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
   }
 
   public ModelDoNotHash_ value3(String value3) {
-    validateMutability();
+    onMutation();
     this.value3 = value3;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
+++ b/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
@@ -45,7 +45,7 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForRProcessingTest_ onBind(OnModelBoundListener<ModelForRProcessingTest_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForRProcessingTest_ onUnbind(OnModelUnboundListener<ModelForRProcessingTest_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelForRProcessingTest_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
+++ b/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
@@ -46,7 +46,7 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForTestingDuplicateRValues_ onBind(OnModelBoundListener<ModelForTestingDuplicateRValues_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -67,13 +67,13 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelForTestingDuplicateRValues_ onUnbind(OnModelUnboundListener<ModelForTestingDuplicateRValues_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelForTestingDuplicateRValues_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelNoValidation_.java
+++ b/epoxy-processortest/src/test/resources/ModelNoValidation_.java
@@ -37,6 +37,7 @@ public class ModelNoValidation_ extends ModelNoValidation implements GeneratedMo
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelNoValidation_ onBind(OnModelBoundListener<ModelNoValidation_, Object> listener) {
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -57,11 +58,13 @@ public class ModelNoValidation_ extends ModelNoValidation implements GeneratedMo
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelNoValidation_ onUnbind(OnModelUnboundListener<ModelNoValidation_, Object> listener) {
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelNoValidation_ value(int value) {
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
@@ -45,7 +45,7 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelReturningClassTypeWithVarargs_ onBind(OnModelBoundListener<ModelReturningClassTypeWithVarargs_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelReturningClassTypeWithVarargs_ onUnbind(OnModelUnboundListener<ModelReturningClassTypeWithVarargs_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelReturningClassTypeWithVarargs_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
@@ -46,7 +46,7 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelReturningClassType_ onBind(OnModelBoundListener<ModelReturningClassType_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -67,13 +67,13 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelReturningClassType_ onUnbind(OnModelUnboundListener<ModelReturningClassType_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelReturningClassType_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAbstractClassAndAnnotation_.java
@@ -45,7 +45,7 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAbstractClassAndAnnotation_ onBind(OnModelBoundListener<ModelWithAbstractClassAndAnnotation_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,7 +66,7 @@ public class ModelWithAbstractClassAndAnnotation_ extends ModelWithAbstractClass
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAbstractClassAndAnnotation_ onUnbind(OnModelUnboundListener<ModelWithAbstractClassAndAnnotation_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
@@ -55,7 +55,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllFieldTypes_ onBind(OnModelBoundListener<ModelWithAllFieldTypes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -76,13 +76,13 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllFieldTypes_ onUnbind(OnModelUnboundListener<ModelWithAllFieldTypes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAllFieldTypes_ valueInteger(Integer valueInteger) {
-    validateMutability();
+    onMutation();
     this.valueInteger = valueInteger;
     return this;
   }
@@ -92,7 +92,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueShort(short valueShort) {
-    validateMutability();
+    onMutation();
     this.valueShort = valueShort;
     return this;
   }
@@ -102,7 +102,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueLong(long valueLong) {
-    validateMutability();
+    onMutation();
     this.valueLong = valueLong;
     return this;
   }
@@ -112,7 +112,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueList(List<String> valueList) {
-    validateMutability();
+    onMutation();
     this.valueList = valueList;
     return this;
   }
@@ -122,7 +122,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
-    validateMutability();
+    onMutation();
     this.valueShortWrapper = valueShortWrapper;
     return this;
   }
@@ -132,7 +132,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueDouble(double valueDouble) {
-    validateMutability();
+    onMutation();
     this.valueDouble = valueDouble;
     return this;
   }
@@ -142,7 +142,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueChar(char valueChar) {
-    validateMutability();
+    onMutation();
     this.valueChar = valueChar;
     return this;
   }
@@ -152,7 +152,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueInt(int valueInt) {
-    validateMutability();
+    onMutation();
     this.valueInt = valueInt;
     return this;
   }
@@ -162,7 +162,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
-    validateMutability();
+    onMutation();
     this.valueDoubleWrapper = valueDoubleWrapper;
     return this;
   }
@@ -172,7 +172,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
-    validateMutability();
+    onMutation();
     this.valueFloatWrapper = valueFloatWrapper;
     return this;
   }
@@ -182,7 +182,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
-    validateMutability();
+    onMutation();
     this.valueBooleanWrapper = valueBooleanWrapper;
     return this;
   }
@@ -192,7 +192,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
-    validateMutability();
+    onMutation();
     this.valueByteWrapper = valueByteWrapper;
     return this;
   }
@@ -202,7 +202,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valuebByte(byte valuebByte) {
-    validateMutability();
+    onMutation();
     this.valuebByte = valuebByte;
     return this;
   }
@@ -212,7 +212,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
-    validateMutability();
+    onMutation();
     this.valueLongWrapper = valueLongWrapper;
     return this;
   }
@@ -222,7 +222,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueCharacter(Character valueCharacter) {
-    validateMutability();
+    onMutation();
     this.valueCharacter = valueCharacter;
     return this;
   }
@@ -232,7 +232,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueString(String valueString) {
-    validateMutability();
+    onMutation();
     this.valueString = valueString;
     return this;
   }
@@ -242,7 +242,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueFloat(float valueFloat) {
-    validateMutability();
+    onMutation();
     this.valueFloat = valueFloat;
     return this;
   }
@@ -252,7 +252,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueBoolean(boolean valueBoolean) {
-    validateMutability();
+    onMutation();
     this.valueBoolean = valueBoolean;
     return this;
   }
@@ -262,7 +262,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
-    validateMutability();
+    onMutation();
     this.valueObjectArray = valueObjectArray;
     return this;
   }
@@ -272,7 +272,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueObject(Object valueObject) {
-    validateMutability();
+    onMutation();
     this.valueObject = valueObject;
     return this;
   }
@@ -282,7 +282,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   }
 
   public ModelWithAllFieldTypes_ valueIntArray(int[] valueIntArray) {
-    validateMutability();
+    onMutation();
     this.valueIntArray = valueIntArray;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
@@ -55,7 +55,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllPrivateFieldTypes_ onBind(OnModelBoundListener<ModelWithAllPrivateFieldTypes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -76,13 +76,13 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAllPrivateFieldTypes_ onUnbind(OnModelUnboundListener<ModelWithAllPrivateFieldTypes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAllPrivateFieldTypes_ valueInteger(Integer valueInteger) {
-    validateMutability();
+    onMutation();
     this.setValueInteger(valueInteger);
     return this;
   }
@@ -92,7 +92,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueShort(short valueShort) {
-    validateMutability();
+    onMutation();
     this.setValueShort(valueShort);
     return this;
   }
@@ -102,7 +102,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueLong(long valueLong) {
-    validateMutability();
+    onMutation();
     this.setValueLong(valueLong);
     return this;
   }
@@ -112,7 +112,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueList(List<String> valueList) {
-    validateMutability();
+    onMutation();
     this.setValueList(valueList);
     return this;
   }
@@ -122,7 +122,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
-    validateMutability();
+    onMutation();
     this.setValueShortWrapper(valueShortWrapper);
     return this;
   }
@@ -132,7 +132,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueDouble(double valueDouble) {
-    validateMutability();
+    onMutation();
     this.setValueDouble(valueDouble);
     return this;
   }
@@ -142,7 +142,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueChar(char valueChar) {
-    validateMutability();
+    onMutation();
     this.setValueChar(valueChar);
     return this;
   }
@@ -152,7 +152,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueInt(int valueInt) {
-    validateMutability();
+    onMutation();
     this.setValueInt(valueInt);
     return this;
   }
@@ -162,7 +162,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
-    validateMutability();
+    onMutation();
     this.setValueDoubleWrapper(valueDoubleWrapper);
     return this;
   }
@@ -172,7 +172,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
-    validateMutability();
+    onMutation();
     this.setValueFloatWrapper(valueFloatWrapper);
     return this;
   }
@@ -182,7 +182,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
-    validateMutability();
+    onMutation();
     this.setValueBooleanWrapper(valueBooleanWrapper);
     return this;
   }
@@ -192,7 +192,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
-    validateMutability();
+    onMutation();
     this.setValueByteWrapper(valueByteWrapper);
     return this;
   }
@@ -202,7 +202,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valuebByte(byte valuebByte) {
-    validateMutability();
+    onMutation();
     this.setValuebByte(valuebByte);
     return this;
   }
@@ -212,7 +212,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
-    validateMutability();
+    onMutation();
     this.setValueLongWrapper(valueLongWrapper);
     return this;
   }
@@ -222,7 +222,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueCharacter(Character valueCharacter) {
-    validateMutability();
+    onMutation();
     this.setValueCharacter(valueCharacter);
     return this;
   }
@@ -232,7 +232,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueString(String valueString) {
-    validateMutability();
+    onMutation();
     this.setValueString(valueString);
     return this;
   }
@@ -242,7 +242,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueFloat(float valueFloat) {
-    validateMutability();
+    onMutation();
     this.setValueFloat(valueFloat);
     return this;
   }
@@ -252,7 +252,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueBoolean(boolean valueBoolean) {
-    validateMutability();
+    onMutation();
     this.setValueBoolean(valueBoolean);
     return this;
   }
@@ -262,7 +262,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
-    validateMutability();
+    onMutation();
     this.setValueObjectArray(valueObjectArray);
     return this;
   }
@@ -272,7 +272,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueObject(Object valueObject) {
-    validateMutability();
+    onMutation();
     this.setValueObject(valueObject);
     return this;
   }
@@ -282,7 +282,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   }
 
   public ModelWithAllPrivateFieldTypes_ valueIntArray(int[] valueIntArray) {
-    validateMutability();
+    onMutation();
     this.setValueIntArray(valueIntArray);
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
@@ -45,7 +45,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ onBind(OnModelBoundListener<ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ superValue(int superValue) {
-    validateMutability();
+    onMutation();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
@@ -45,7 +45,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes_ onBind(OnModelBoundListener<ModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClassAndSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithAnnotatedClassAndSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithAnnotatedClassAndSuperAttributes_ superValue(int superValue) {
-    validateMutability();
+    onMutation();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClass_.java
@@ -45,7 +45,7 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClass_ onBind(OnModelBoundListener<ModelWithAnnotatedClass_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,7 +66,7 @@ public class ModelWithAnnotatedClass_ extends ModelWithAnnotatedClass implements
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithAnnotatedClass_ onUnbind(OnModelUnboundListener<ModelWithAnnotatedClass_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
@@ -53,7 +53,7 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithConstructors_ onBind(OnModelBoundListener<ModelWithConstructors_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -74,13 +74,13 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithConstructors_ onUnbind(OnModelUnboundListener<ModelWithConstructors_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithConstructors_ valueInt(int valueInt) {
-    validateMutability();
+    onMutation();
     this.valueInt = valueInt;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
@@ -46,7 +46,7 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFieldAnnotation_ onBind(OnModelBoundListener<ModelWithFieldAnnotation_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -67,13 +67,13 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFieldAnnotation_ onUnbind(OnModelUnboundListener<ModelWithFieldAnnotation_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithFieldAnnotation_ title(@Nullable String title) {
-    validateMutability();
+    onMutation();
     this.title = title;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFinalField_.java
@@ -45,7 +45,7 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFinalField_ onBind(OnModelBoundListener<ModelWithFinalField_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,7 +66,7 @@ public class ModelWithFinalField_ extends ModelWithFinalField implements Generat
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithFinalField_ onUnbind(OnModelUnboundListener<ModelWithFinalField_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
@@ -50,7 +50,7 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithIntDef_ onBind(OnModelBoundListener<ModelWithIntDef_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -71,13 +71,13 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithIntDef_ onUnbind(OnModelUnboundListener<ModelWithIntDef_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithIntDef_ type(@ModelWithIntDef.MyType int type) {
-    validateMutability();
+    onMutation();
     this.type = type;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
@@ -45,7 +45,7 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ onBind(OnModelBoundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ onUnbind(OnModelUnboundListener<ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ isValue(boolean isValue) {
-    validateMutability();
+    onMutation();
     this.setValue(isValue);
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
@@ -57,7 +57,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateViewClickListener_ onBind(OnModelBoundListener<ModelWithPrivateViewClickListener_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -78,7 +78,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithPrivateViewClickListener_ onUnbind(OnModelUnboundListener<ModelWithPrivateViewClickListener_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -86,7 +86,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public ModelWithPrivateViewClickListener_ clickListener(final OnModelClickListener<ModelWithPrivateViewClickListener_, Object> clickListener) {
-    validateMutability();
+    onMutation();
     this.clickListener_epoxyGeneratedModel = clickListener;
     if (clickListener == null) {
       super.setClickListener(null);
@@ -103,7 +103,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   }
 
   public ModelWithPrivateViewClickListener_ clickListener(View.OnClickListener clickListener) {
-    validateMutability();
+    onMutation();
     this.setClickListener(clickListener);
     this.clickListener_epoxyGeneratedModel = null;
     return this;

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
@@ -45,7 +45,7 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ onBind(OnModelBoundListener<ModelWithSuperAttributes$SubModelWithSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithSuperAttributes$SubModelWithSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ subValue(int subValue) {
-    validateMutability();
+    onMutation();
     this.subValue = subValue;
     return this;
   }
@@ -82,7 +82,7 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
   }
 
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ superValue(int superValue) {
-    validateMutability();
+    onMutation();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
@@ -45,7 +45,7 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes_ onBind(OnModelBoundListener<ModelWithSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuperAttributes_ onUnbind(OnModelUnboundListener<ModelWithSuperAttributes_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithSuperAttributes_ superValue(int superValue) {
-    validateMutability();
+    onMutation();
     this.superValue = superValue;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithSuper_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuper_.java
@@ -45,7 +45,7 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuper_ onBind(OnModelBoundListener<ModelWithSuper_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithSuper_ onUnbind(OnModelUnboundListener<ModelWithSuper_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithSuper_ valueInt(int valueInt) {
-    validateMutability();
+    onMutation();
     this.valueInt = valueInt;
     super.valueInt(valueInt);
     return this;

--- a/epoxy-processortest/src/test/resources/ModelWithType_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithType_.java
@@ -45,7 +45,7 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithType_<T> onBind(OnModelBoundListener<ModelWithType_<T>, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithType_<T> onUnbind(OnModelUnboundListener<ModelWithType_<T>, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithType_<T> value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
@@ -50,7 +50,7 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithVarargsConstructors_ onBind(OnModelBoundListener<ModelWithVarargsConstructors_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -71,13 +71,13 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithVarargsConstructors_ onUnbind(OnModelUnboundListener<ModelWithVarargsConstructors_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithVarargsConstructors_ varargs(String[] varargs) {
-    validateMutability();
+    onMutation();
     this.varargs = varargs;
     return this;
   }
@@ -87,7 +87,7 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
   }
 
   public ModelWithVarargsConstructors_ valueInt(int valueInt) {
-    validateMutability();
+    onMutation();
     this.valueInt = valueInt;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -57,7 +57,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithViewClickListener_ onBind(OnModelBoundListener<ModelWithViewClickListener_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -78,7 +78,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithViewClickListener_ onUnbind(OnModelUnboundListener<ModelWithViewClickListener_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -86,7 +86,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public ModelWithViewClickListener_ clickListener(final OnModelClickListener<ModelWithViewClickListener_, Object> clickListener) {
-    validateMutability();
+    onMutation();
     this.clickListener_epoxyGeneratedModel = clickListener;
     if (clickListener == null) {
       super.clickListener = null;
@@ -103,7 +103,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   }
 
   public ModelWithViewClickListener_ clickListener(View.OnClickListener clickListener) {
-    validateMutability();
+    onMutation();
     this.clickListener = clickListener;
     this.clickListener_epoxyGeneratedModel = null;
     return this;

--- a/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
@@ -45,7 +45,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutHash_ onBind(OnModelBoundListener<ModelWithoutHash_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,13 +66,13 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutHash_ onUnbind(OnModelUnboundListener<ModelWithoutHash_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   public ModelWithoutHash_ value2(int value2) {
-    validateMutability();
+    onMutation();
     this.value2 = value2;
     return this;
   }
@@ -82,7 +82,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
   }
 
   public ModelWithoutHash_ value(int value) {
-    validateMutability();
+    onMutation();
     this.value = value;
     return this;
   }
@@ -92,7 +92,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
   }
 
   public ModelWithoutHash_ value3(String value3) {
-    validateMutability();
+    onMutation();
     this.value3 = value3;
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
@@ -45,7 +45,7 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutSetter_ onBind(OnModelBoundListener<ModelWithoutSetter_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
@@ -66,7 +66,7 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public ModelWithoutSetter_ onUnbind(OnModelUnboundListener<ModelWithoutSetter_, Object> listener) {
-    validateMutability();
+    onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/SampleController.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/SampleController.java
@@ -43,15 +43,13 @@ public class SampleController extends TypedEpoxyController<List<CarouselData>> {
   protected void buildModels(List<CarouselData> carousels) {
     header
         .title(R.string.epoxy)
-        .caption(R.string.header_subtitle)
-        .addTo(this);
+        .caption(R.string.header_subtitle);
 
     addButton
         .textRes(R.string.button_add)
         .clickListener((model, parentView, clickedView, position) -> {
           callbacks.onAddCarouselClicked();
-        })
-        .addTo(this);
+        });
 
     clearButton
         .textRes(R.string.button_clear)


### PR DESCRIPTION
This adds an option to automatically add automodels to a controller https://github.com/airbnb/epoxy/issues/186

If an automodel is modified in `buildModels` it is staged as the next model to add. The next time a different model is changed (or added), the previously staged model is added.

This is off by default.

