### PR TITLE
Fix model type lookup breaking with custom types

### DIFF
--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/ModelsWithCustomTypes.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/ModelsWithCustomTypes.java
@@ -1,0 +1,34 @@
+package com.airbnb.epoxy;
+
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+/**
+ * This tests that the annotation processor looks up the correct bound object type on the model when
+ * a subclass defines a new type. In this test the generated model should correctly use TextView as
+ * the model type instead of the ImageView type of the subclass.
+ */
+class ModelsWithCustomTypes {
+
+  @EpoxyModelClass
+  abstract static class ModelWithCustomType extends BaseModelWithCustomType<ImageView> {
+
+    @Override
+    protected int getDefaultLayout() {
+      return 0;
+    }
+  }
+
+  abstract static class BaseModelWithCustomType<U extends View> extends EpoxyModel<TextView> {
+
+    public void testMethod(U param) {
+
+    }
+
+    @Override
+    protected int getDefaultLayout() {
+      return 0;
+    }
+  }
+}

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelIntegrationTest.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelIntegrationTest.java
@@ -1,0 +1,15 @@
+package com.airbnb.epoxy;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21)
+public class EpoxyModelIntegrationTest {
+
+  @Test
+  public void modelWithCustomTypesIsGeneratedCorrectly() {
+  }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
@@ -244,7 +244,7 @@ class ProcessorUtils {
     }
 
     return null;
-  }
+}
 
   static void validateFieldAccessibleViaGeneratedCode(Element fieldElement,
       Class<?> annotationClass, ErrorLogger errorLogger, boolean skipPrivateFieldCheck) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ProcessorUtils.java
@@ -31,6 +31,8 @@ class ProcessorUtils {
   static final String UNTYPED_EPOXY_MODEL_TYPE = "com.airbnb.epoxy.EpoxyModel";
   static final String EPOXY_MODEL_HOLDER_TYPE = "com.airbnb.epoxy.EpoxyModelWithHolder<?>";
   static final String EPOXY_VIEW_HOLDER_TYPE = "com.airbnb.epoxy.EpoxyViewHolder";
+  static final String EPOXY_HOLDER_TYPE = "com.airbnb.epoxy.EpoxyHolder";
+  static final String ANDROID_VIEW_TYPE = "android.view.View";
   static final String EPOXY_CONTROLLER_TYPE = "com.airbnb.epoxy.EpoxyController";
   static final String VIEW_CLICK_LISTENER_TYPE = "android.view.View.OnClickListener";
   static final String GENERATED_MODEL_INTERFACE = "com.airbnb.epoxy.GeneratedModel";
@@ -210,20 +212,38 @@ class ProcessorUtils {
    * Eg for "class MyModel extends EpoxyModel<TextView>" it would return TextView.
    */
   static TypeMirror getEpoxyObjectType(TypeElement clazz, Types typeUtils) {
-    if (clazz.asType().getKind() != TypeKind.DECLARED) {
+    if (clazz.getSuperclass().getKind() != TypeKind.DECLARED) {
       return null;
     }
 
     DeclaredType superclass = (DeclaredType) clazz.getSuperclass();
-    List<? extends TypeMirror> superTypeArguments = superclass.getTypeArguments();
+    TypeMirror recursiveResult =
+        getEpoxyObjectType((TypeElement) typeUtils.asElement(superclass), typeUtils);
 
-    if (superTypeArguments.isEmpty()) {
-      return getEpoxyObjectType((TypeElement) typeUtils.asElement(superclass), typeUtils);
+    if (recursiveResult != null && recursiveResult.getKind() != TypeKind.TYPEVAR) {
+      // Use the type on the parent highest in the class hierarchy so we can find the original type.
+      // We don't allow TypeVar since that is just type letter (eg T).
+      return recursiveResult;
     }
 
-    // TODO: (eli_hart 2/2/17) If the class added additional types this won't be correct. That
-    // should be rare, but it would be nice to handle.
-    return superTypeArguments.get(0);
+    List<? extends TypeMirror> superTypeArguments = superclass.getTypeArguments();
+
+    if (superTypeArguments.size() == 1) {
+      // If there is only one type then we use that
+      return superTypeArguments.get(0);
+    }
+
+    for (TypeMirror superTypeArgument : superTypeArguments) {
+      // The user might have added additional types to their class which makes it more difficult
+      // to figure out the base model type. We just look for the first type that is a view or
+      // view holder.
+      if (isSubtypeOfType(superTypeArgument, ANDROID_VIEW_TYPE)
+          || isSubtypeOfType(superTypeArgument, EPOXY_HOLDER_TYPE)) {
+        return superTypeArgument;
+      }
+    }
+
+    return null;
   }
 
   static void validateFieldAccessibleViaGeneratedCode(Element fieldElement,

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/SampleController.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/SampleController.java
@@ -44,7 +44,7 @@ public class SampleController extends TypedEpoxyController<List<CarouselData>> {
     header
         .title(R.string.epoxy)
         .caption(R.string.header_subtitle);
-    // "addTo" is not needed since implicit adding is enabled 
+    // "addTo" is not needed since implicit adding is enabled
     // (https://github.com/airbnb/epoxy/wiki/Epoxy-Controller#implicit-adding)
 
     addButton


### PR DESCRIPTION
The annotation processor has a method to look up a model's bound object type by inspecting the type variables of the class. The logic was a bit simplistic and had a long standing TODO - `// TODO: (eli_hart 2/2/17) If the class added additional types this won't be correct`. This meant that if a custom model defined new type variables then the annotation processor would use the wrong type in the generated model. This fixes that and makes the handling more robust.

Fixes https://github.com/airbnb/epoxy/issues/199