### PR TITLE
Fix @AutoModel Model NPE crash with Proguard

### DIFF
--- a/epoxy-adapter/build.gradle
+++ b/epoxy-adapter/build.gradle
@@ -7,6 +7,7 @@ android {
   defaultConfig {
     minSdkVersion rootProject.MIN_SDK_VERSION
     targetSdkVersion rootProject.TARGET_SDK_VERSION
+    consumerProguardFiles 'proguard-rules.pro'
   }
 }
 

--- a/epoxy-adapter/proguard-rules.pro
+++ b/epoxy-adapter/proguard-rules.pro
@@ -15,3 +15,8 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keep class * extends com.airbnb.epoxy.EpoxyController { *; }
+-keep class * extends com.airbnb.epoxy.ControllerHelper { *; }
+-keepclasseswithmembernames class * { @com.airbnb.epoxy.* <methods>; }
+-keepclasseswithmembernames class * { @com.airbnb.epoxy.* <fields>; }

--- a/epoxy-adapter/proguard-rules.pro
+++ b/epoxy-adapter/proguard-rules.pro
@@ -18,5 +18,5 @@
 
 -keep class * extends com.airbnb.epoxy.EpoxyController { *; }
 -keep class * extends com.airbnb.epoxy.ControllerHelper { *; }
--keepclasseswithmembernames class * { @com.airbnb.epoxy.* <methods>; }
--keepclasseswithmembernames class * { @com.airbnb.epoxy.* <fields>; }
+-keepclasseswithmembernames class * { @com.airbnb.epoxy.AutoModel <methods>; }
+-keepclasseswithmembernames class * { @com.airbnb.epoxy.AutoModel <fields>; }

--- a/epoxy-sample/build.gradle
+++ b/epoxy-sample/build.gradle
@@ -35,6 +35,12 @@ android {
     versionName "1.0"
   }
 
+  buildTypes {
+    debug {
+      minifyEnabled true
+    }
+  }
+
   dataBinding {
     enabled = true
   }


### PR DESCRIPTION
Issue:
Epoxy Model class annotated with `@AutoModel` crashes with proguard setting on (ref #197, #198)

Cause:
Epoxy model was accessed from classes that extend ControllerHelper, EpoxyController which were obfuscated by proguard

Fix:
Apply proguard rules to autogenerated classes
