### PR TITLE
[Databinding] Exclude variables without hash/equals from state

### DIFF
--- a/epoxy-integrationtest/src/main/res/layout/model_with_data_binding.xml
+++ b/epoxy-integrationtest/src/main/res/layout/model_with_data_binding.xml
@@ -6,6 +6,10 @@
         <variable
             name="stringValue"
             type="String" />
+
+        <variable
+            name="clickListener"
+            type="android.view.View.OnClickListener" />
     </data>
 
     <Button

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/AttributeInfo.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import javax.lang.model.type.TypeMirror;
 
-import static com.airbnb.epoxy.ProcessorUtils.isViewClickListenerType;
+import static com.airbnb.epoxy.Utils.isViewClickListenerType;
 
 abstract class AttributeInfo {
 
@@ -35,6 +35,12 @@ abstract class AttributeInfo {
   protected boolean isPrivate;
   protected String getterMethodName;
   protected String setterMethodName;
+
+  /**
+   * True if this attribute is completely generated as a field on the generated model. False if it
+   * exists as a user defined attribute in a model super class.
+   */
+  protected boolean isGenerated;
 
   String getName() {
     return name;
@@ -89,7 +95,8 @@ abstract class AttributeInfo {
   }
 
   String setterCode() {
-    return isPrivate ? setterMethodName + "($L)" : name + " = $L";
+    return (isGenerated ? "this." : "super.")
+        + (isPrivate ? setterMethodName + "($L)" : name + " = $L");
   }
 
   @Override

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/BaseModelAttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/BaseModelAttributeInfo.java
@@ -22,15 +22,15 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
-import static com.airbnb.epoxy.ProcessorUtils.capitalizeFirstLetter;
-import static com.airbnb.epoxy.ProcessorUtils.startsWithIs;
+import static com.airbnb.epoxy.Utils.capitalizeFirstLetter;
+import static com.airbnb.epoxy.Utils.startsWithIs;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
-public class BaseModelAttributeInfo extends AttributeInfo {
+class BaseModelAttributeInfo extends AttributeInfo {
 
   private final TypeElement classElement;
   protected Types typeUtils;
@@ -74,7 +74,7 @@ public class BaseModelAttributeInfo extends AttributeInfo {
    * Private methods are ignored since the generated subclass can't call super on those.
    */
   protected boolean hasSuperMethod(TypeElement classElement, Element attribute) {
-    if (!ProcessorUtils.isEpoxyModel(classElement.asType())) {
+    if (!Utils.isEpoxyModel(classElement.asType())) {
       return false;
     }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/BasicGeneratedModelInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/BasicGeneratedModelInfo.java
@@ -18,8 +18,8 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
-import static com.airbnb.epoxy.ProcessorUtils.getElementByName;
-import static com.airbnb.epoxy.ProcessorUtils.getEpoxyObjectType;
+import static com.airbnb.epoxy.Utils.getElementByName;
+import static com.airbnb.epoxy.Utils.getEpoxyObjectType;
 
  class BasicGeneratedModelInfo extends GeneratedModelInfo {
 
@@ -54,7 +54,7 @@ import static com.airbnb.epoxy.ProcessorUtils.getEpoxyObjectType;
               superClassElement.getSimpleName());
       // Return a basic view type so the code can be generated
       boundObjectTypeMirror =
-          getElementByName(ProcessorUtils.ANDROID_VIEW_TYPE, elementUtils, typeUtils).asType();
+          getElementByName(Utils.ANDROID_VIEW_TYPE, elementUtils, typeUtils).asType();
     }
     boundObjectTypeName = TypeName.get(boundObjectTypeMirror);
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
@@ -13,7 +13,7 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
-import static com.airbnb.epoxy.ProcessorUtils.buildEpoxyException;
+import static com.airbnb.epoxy.Utils.buildEpoxyException;
 
 /** Manages configuration settings for different packages. */
 class ConfigManager {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ControllerProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ControllerProcessor.java
@@ -26,13 +26,13 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 
-import static com.airbnb.epoxy.ProcessorUtils.EPOXY_CONTROLLER_TYPE;
-import static com.airbnb.epoxy.ProcessorUtils.EPOXY_MODEL_TYPE;
-import static com.airbnb.epoxy.ProcessorUtils.UNTYPED_EPOXY_MODEL_TYPE;
-import static com.airbnb.epoxy.ProcessorUtils.getClassName;
-import static com.airbnb.epoxy.ProcessorUtils.isController;
-import static com.airbnb.epoxy.ProcessorUtils.isEpoxyModel;
-import static com.airbnb.epoxy.ProcessorUtils.validateFieldAccessibleViaGeneratedCode;
+import static com.airbnb.epoxy.Utils.EPOXY_CONTROLLER_TYPE;
+import static com.airbnb.epoxy.Utils.EPOXY_MODEL_TYPE;
+import static com.airbnb.epoxy.Utils.UNTYPED_EPOXY_MODEL_TYPE;
+import static com.airbnb.epoxy.Utils.getClassName;
+import static com.airbnb.epoxy.Utils.isController;
+import static com.airbnb.epoxy.Utils.isEpoxyModel;
+import static com.airbnb.epoxy.Utils.validateFieldAccessibleViaGeneratedCode;
 
 class ControllerProcessor {
   private static final String CONTROLLER_HELPER_INTERFACE = "com.airbnb.epoxy.ControllerHelper";

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingAttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingAttributeInfo.java
@@ -2,22 +2,27 @@ package com.airbnb.epoxy;
 
 import com.squareup.javapoet.TypeName;
 
-import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+
+import static com.airbnb.epoxy.Utils.removeSetPrefix;
 
 class DataBindingAttributeInfo extends AttributeInfo {
 
-  public DataBindingAttributeInfo(DataBindingModelInfo modelInfo, Element dataBindingElement,
-      String name) {
-    this.name = name;
-    typeName = TypeName.get(dataBindingElement.asType());
-    typeMirror = dataBindingElement.asType();
+  DataBindingAttributeInfo(DataBindingModelInfo modelInfo, ExecutableElement setterMethod,
+      HashCodeValidator hashCodeValidator) {
+    VariableElement paramElement = setterMethod.getParameters().get(0);
+    this.name = removeSetPrefix(setterMethod.getSimpleName().toString());
+    typeName = TypeName.get(paramElement.asType());
+    typeMirror = paramElement.asType();
     modelName = modelInfo.getGeneratedName().simpleName();
     modelPackageName = modelInfo.getGeneratedName().packageName();
-    useInHash = true;
+    useInHash = hashCodeValidator.implementsHashCodeAndEquals(typeMirror);
     ignoreRequireHashCode = false;
     generateSetter = true;
     generateGetter = true;
     hasFinalModifier = false;
     packagePrivate = false;
+    isGenerated = true;
   }
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModuleLookup.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModuleLookup.java
@@ -109,7 +109,7 @@ class DataBindingModuleLookup {
     for (int i = 0; i < packageNameParts.length; i++) {
       moduleName += packageNameParts[i];
 
-      Element rClass = ProcessorUtils.getElementByName(moduleName + ".R", elements, types);
+      Element rClass = Utils.getElementByName(moduleName + ".R", elements, types);
       if (rClass != null) {
         return moduleName;
       } else {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -93,7 +93,7 @@ public class EpoxyProcessor extends AbstractProcessor {
         new DataBindingModuleLookup(elementUtils, typeUtils, errorLogger, layoutResourceProcessor);
 
     modelWriter =
-        new GeneratedModelWriter(filer, typeUtils, elementUtils, errorLogger,
+        new GeneratedModelWriter(filer, typeUtils, errorLogger,
             layoutResourceProcessor,
             configManager, dataBindingModuleLookup);
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ErrorLogger.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ErrorLogger.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.annotation.processing.Messager;
 import javax.tools.Diagnostic;
 
-import static com.airbnb.epoxy.ProcessorUtils.buildEpoxyException;
+import static com.airbnb.epoxy.Utils.buildEpoxyException;
 
 class ErrorLogger {
   private final List<Exception> loggedExceptions = new ArrayList<>();

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
@@ -38,7 +38,6 @@ abstract class GeneratedModelInfo {
   protected ClassName generatedClassName;
   protected TypeName boundObjectTypeName;
   protected boolean shouldGenerateModel;
-  protected boolean generateFieldsForAttributes;
   protected final Set<AttributeInfo> attributeInfo = new HashSet<>();
   protected final List<TypeVariableName> typeVariableNames = new ArrayList<>();
   protected final List<ConstructorInfo> constructors = new ArrayList<>();

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
@@ -16,10 +16,10 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 
-import static com.airbnb.epoxy.ProcessorUtils.getMethodOnClass;
-import static com.airbnb.epoxy.ProcessorUtils.isIterableType;
-import static com.airbnb.epoxy.ProcessorUtils.isSubtypeOfType;
-import static com.airbnb.epoxy.ProcessorUtils.throwError;
+import static com.airbnb.epoxy.Utils.getMethodOnClass;
+import static com.airbnb.epoxy.Utils.isIterableType;
+import static com.airbnb.epoxy.Utils.isSubtypeOfType;
+import static com.airbnb.epoxy.Utils.throwError;
 
 /** Validates that an attribute implements hashCode and equals. */
 class HashCodeValidator {
@@ -44,6 +44,15 @@ class HashCodeValidator {
 
   HashCodeValidator(Types typeUtils) {
     this.typeUtils = typeUtils;
+  }
+
+  boolean implementsHashCodeAndEquals(TypeMirror mirror) {
+    try {
+      validateImplementsHashCode(mirror);
+      return true;
+    } catch (EpoxyProcessorException e) {
+      return false;
+    }
   }
 
   void validate(AttributeInfo attribute) throws EpoxyProcessorException {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LayoutResourceProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LayoutResourceProcessor.java
@@ -244,7 +244,7 @@ class LayoutResourceProcessor {
     ClassName className = rClassNameMap.get(rClass);
 
     if (className == null) {
-      Element rClassElement = ProcessorUtils.getElementByName(rClass, elementUtils, typeUtils);
+      Element rClassElement = Utils.getElementByName(rClass, elementUtils, typeUtils);
 
       String rClassPackageName =
           elementUtils.getPackageOf(rClassElement).getQualifiedName().toString();

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoModelAttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoModelAttributeInfo.java
@@ -4,8 +4,8 @@ import com.squareup.javapoet.TypeName;
 
 import javax.lang.model.element.Element;
 
-public class LithoModelAttributeInfo extends AttributeInfo {
-  public LithoModelAttributeInfo(LithoModelInfo lithoModelInfo,
+class LithoModelAttributeInfo extends AttributeInfo {
+  LithoModelAttributeInfo(LithoModelInfo lithoModelInfo,
       Element propElement) {
     name = propElement.getSimpleName().toString();
     typeName = TypeName.get(propElement.asType());
@@ -20,5 +20,6 @@ public class LithoModelAttributeInfo extends AttributeInfo {
     generateGetter = true;
     hasFinalModifier = false;
     packagePrivate = false;
+    isGenerated = true;
   }
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoModelInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoModelInfo.java
@@ -16,7 +16,7 @@ class LithoModelInfo extends GeneratedModelInfo {
 
   LithoModelInfo(Types typeUtils, Elements elementUtils, TypeElement layoutSpecClassElement) {
     superClassElement =
-        (TypeElement) ProcessorUtils.getElementByName(EPOXY_LITHO_MODEL, elementUtils, typeUtils);
+        (TypeElement) Utils.getElementByName(EPOXY_LITHO_MODEL, elementUtils, typeUtils);
 
     lithoComponentName = getLithoComponentName(elementUtils, layoutSpecClassElement);
     this.superClassName = ParameterizedTypeName.get(EPOXY_LITHO_MODEL, lithoComponentName);
@@ -25,7 +25,6 @@ class LithoModelInfo extends GeneratedModelInfo {
     // We don't have any type parameters on our generated litho model
     this.parameterizedClassName = generatedClassName;
     shouldGenerateModel = true;
-    generateFieldsForAttributes = true;
 
     collectMethodsReturningClassType(superClassElement, typeUtils);
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoSpecProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoSpecProcessor.java
@@ -20,7 +20,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import static com.airbnb.epoxy.ClassNames.EPOXY_LITHO_MODEL;
-import static com.airbnb.epoxy.ProcessorUtils.getAnnotationClass;
+import static com.airbnb.epoxy.Utils.getAnnotationClass;
 
 class LithoSpecProcessor {
 
@@ -93,7 +93,7 @@ class LithoSpecProcessor {
 
   private boolean hasLithoEpoxyDependency() {
     // Only true if the epoxy-litho module is included in dependencies
-    return ProcessorUtils.getClass(EPOXY_LITHO_MODEL) != null;
+    return Utils.getClass(EPOXY_LITHO_MODEL) != null;
   }
 
   private void updateGeneratedClassForLithoComponent(LithoModelInfo modelInfo,

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelProcessor.java
@@ -17,9 +17,9 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
-import static com.airbnb.epoxy.ProcessorUtils.EPOXY_MODEL_TYPE;
-import static com.airbnb.epoxy.ProcessorUtils.isEpoxyModel;
-import static com.airbnb.epoxy.ProcessorUtils.validateFieldAccessibleViaGeneratedCode;
+import static com.airbnb.epoxy.Utils.EPOXY_MODEL_TYPE;
+import static com.airbnb.epoxy.Utils.isEpoxyModel;
+import static com.airbnb.epoxy.Utils.validateFieldAccessibleViaGeneratedCode;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.STATIC;
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/Utils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/Utils.java
@@ -8,6 +8,7 @@ import com.squareup.javapoet.TypeName;
 import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -26,7 +27,8 @@ import static javax.lang.model.element.ElementKind.CLASS;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.STATIC;
 
-class ProcessorUtils {
+class Utils {
+  private static final Pattern PATTERN_STARTS_WITH_SET = Pattern.compile("set[A-Z]\\w*");
 
   static final String EPOXY_MODEL_TYPE = "com.airbnb.epoxy.EpoxyModel<?>";
   static final String UNTYPED_EPOXY_MODEL_TYPE = "com.airbnb.epoxy.EpoxyModel";
@@ -333,5 +335,20 @@ class ProcessorUtils {
   static boolean startsWithIs(String original) {
     return original.startsWith("is") && original.length() > 2
         && Character.isUpperCase(original.charAt(2));
+  }
+
+  static boolean isSetterMethod(Element element) {
+    if (element.getKind() != ElementKind.METHOD) {
+      return false;
+    }
+
+    ExecutableElement method = (ExecutableElement) element;
+    String methodName = method.getSimpleName().toString();
+    return PATTERN_STARTS_WITH_SET.matcher(methodName).matches()
+        && method.getParameters().size() == 1;
+  }
+
+  static String removeSetPrefix(String string) {
+    return String.valueOf(string.charAt(3)).toLowerCase() + string.substring(4);
   }
 }

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
@@ -74,7 +74,7 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
 
   public AbstractModelWithHolder_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -145,7 +145,7 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
   public AbstractModelWithHolder_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
+++ b/epoxy-processortest/src/test/resources/BasicModelWithAttribute_.java
@@ -73,7 +73,7 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
 
   public BasicModelWithAttribute_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -139,7 +139,7 @@ public class BasicModelWithAttribute_ extends BasicModelWithAttribute implements
   public BasicModelWithAttribute_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypesNoValidation_.java
+++ b/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypesNoValidation_.java
@@ -77,7 +77,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueInteger(Integer valueInteger) {
     onMutation();
-    this.valueInteger = valueInteger;
+    super.valueInteger = valueInteger;
     return this;
   }
 
@@ -87,7 +87,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueShort(short valueShort) {
     onMutation();
-    this.valueShort = valueShort;
+    super.valueShort = valueShort;
     return this;
   }
 
@@ -97,7 +97,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueLong(long valueLong) {
     onMutation();
-    this.valueLong = valueLong;
+    super.valueLong = valueLong;
     return this;
   }
 
@@ -107,7 +107,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueList(List<String> valueList) {
     onMutation();
-    this.valueList = valueList;
+    super.valueList = valueList;
     return this;
   }
 
@@ -117,7 +117,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueShortWrapper(Short valueShortWrapper) {
     onMutation();
-    this.valueShortWrapper = valueShortWrapper;
+    super.valueShortWrapper = valueShortWrapper;
     return this;
   }
 
@@ -127,7 +127,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueDouble(double valueDouble) {
     onMutation();
-    this.valueDouble = valueDouble;
+    super.valueDouble = valueDouble;
     return this;
   }
 
@@ -137,7 +137,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueChar(char valueChar) {
     onMutation();
-    this.valueChar = valueChar;
+    super.valueChar = valueChar;
     return this;
   }
 
@@ -147,7 +147,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueInt(int valueInt) {
     onMutation();
-    this.valueInt = valueInt;
+    super.valueInt = valueInt;
     return this;
   }
 
@@ -157,7 +157,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueDoubleWrapper(Double valueDoubleWrapper) {
     onMutation();
-    this.valueDoubleWrapper = valueDoubleWrapper;
+    super.valueDoubleWrapper = valueDoubleWrapper;
     return this;
   }
 
@@ -167,7 +167,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueFloatWrapper(Float valueFloatWrapper) {
     onMutation();
-    this.valueFloatWrapper = valueFloatWrapper;
+    super.valueFloatWrapper = valueFloatWrapper;
     return this;
   }
 
@@ -177,7 +177,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
     onMutation();
-    this.valueBooleanWrapper = valueBooleanWrapper;
+    super.valueBooleanWrapper = valueBooleanWrapper;
     return this;
   }
 
@@ -187,7 +187,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueByteWrapper(Byte valueByteWrapper) {
     onMutation();
-    this.valueByteWrapper = valueByteWrapper;
+    super.valueByteWrapper = valueByteWrapper;
     return this;
   }
 
@@ -197,7 +197,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valuebByte(byte valuebByte) {
     onMutation();
-    this.valuebByte = valuebByte;
+    super.valuebByte = valuebByte;
     return this;
   }
 
@@ -207,7 +207,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueLongWrapper(Long valueLongWrapper) {
     onMutation();
-    this.valueLongWrapper = valueLongWrapper;
+    super.valueLongWrapper = valueLongWrapper;
     return this;
   }
 
@@ -217,7 +217,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueCharacter(Character valueCharacter) {
     onMutation();
-    this.valueCharacter = valueCharacter;
+    super.valueCharacter = valueCharacter;
     return this;
   }
 
@@ -227,7 +227,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueString(String valueString) {
     onMutation();
-    this.valueString = valueString;
+    super.valueString = valueString;
     return this;
   }
 
@@ -237,7 +237,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueFloat(float valueFloat) {
     onMutation();
-    this.valueFloat = valueFloat;
+    super.valueFloat = valueFloat;
     return this;
   }
 
@@ -247,7 +247,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueBoolean(boolean valueBoolean) {
     onMutation();
-    this.valueBoolean = valueBoolean;
+    super.valueBoolean = valueBoolean;
     return this;
   }
 
@@ -257,7 +257,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueObjectArray(Object[] valueObjectArray) {
     onMutation();
-    this.valueObjectArray = valueObjectArray;
+    super.valueObjectArray = valueObjectArray;
     return this;
   }
 
@@ -267,7 +267,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueObject(Object valueObject) {
     onMutation();
-    this.valueObject = valueObject;
+    super.valueObject = valueObject;
     return this;
   }
 
@@ -277,7 +277,7 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
 
   public DataBindingModelWithAllFieldTypesNoValidation_ valueIntArray(int[] valueIntArray) {
     onMutation();
-    this.valueIntArray = valueIntArray;
+    super.valueIntArray = valueIntArray;
     return this;
   }
 
@@ -440,27 +440,27 @@ public class DataBindingModelWithAllFieldTypesNoValidation_ extends DataBindingM
   public DataBindingModelWithAllFieldTypesNoValidation_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.valueInteger = null;
-    this.valueShort = (short) 0;
-    this.valueLong = 0L;
-    this.valueList = null;
-    this.valueShortWrapper = null;
-    this.valueDouble = 0.0d;
-    this.valueChar = (char) 0;
-    this.valueInt = 0;
-    this.valueDoubleWrapper = null;
-    this.valueFloatWrapper = null;
-    this.valueBooleanWrapper = null;
-    this.valueByteWrapper = null;
-    this.valuebByte = (byte) 0;
-    this.valueLongWrapper = null;
-    this.valueCharacter = null;
-    this.valueString = null;
-    this.valueFloat = 0.0f;
-    this.valueBoolean = false;
-    this.valueObjectArray = null;
-    this.valueObject = null;
-    this.valueIntArray = null;
+    super.valueInteger = null;
+    super.valueShort = (short) 0;
+    super.valueLong = 0L;
+    super.valueList = null;
+    super.valueShortWrapper = null;
+    super.valueDouble = 0.0d;
+    super.valueChar = (char) 0;
+    super.valueInt = 0;
+    super.valueDoubleWrapper = null;
+    super.valueFloatWrapper = null;
+    super.valueBooleanWrapper = null;
+    super.valueByteWrapper = null;
+    super.valuebByte = (byte) 0;
+    super.valueLongWrapper = null;
+    super.valueCharacter = null;
+    super.valueString = null;
+    super.valueFloat = 0.0f;
+    super.valueBoolean = false;
+    super.valueObjectArray = null;
+    super.valueObject = null;
+    super.valueIntArray = null;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/DataBindingModelWithAllFieldTypes_.java
@@ -86,7 +86,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueInteger(Integer valueInteger) {
     onMutation();
-    this.valueInteger = valueInteger;
+    super.valueInteger = valueInteger;
     return this;
   }
 
@@ -96,7 +96,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueShort(short valueShort) {
     onMutation();
-    this.valueShort = valueShort;
+    super.valueShort = valueShort;
     return this;
   }
 
@@ -106,7 +106,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueLong(long valueLong) {
     onMutation();
-    this.valueLong = valueLong;
+    super.valueLong = valueLong;
     return this;
   }
 
@@ -116,7 +116,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueList(List<String> valueList) {
     onMutation();
-    this.valueList = valueList;
+    super.valueList = valueList;
     return this;
   }
 
@@ -126,7 +126,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
     onMutation();
-    this.valueShortWrapper = valueShortWrapper;
+    super.valueShortWrapper = valueShortWrapper;
     return this;
   }
 
@@ -136,7 +136,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueDouble(double valueDouble) {
     onMutation();
-    this.valueDouble = valueDouble;
+    super.valueDouble = valueDouble;
     return this;
   }
 
@@ -146,7 +146,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueChar(char valueChar) {
     onMutation();
-    this.valueChar = valueChar;
+    super.valueChar = valueChar;
     return this;
   }
 
@@ -156,7 +156,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueInt(int valueInt) {
     onMutation();
-    this.valueInt = valueInt;
+    super.valueInt = valueInt;
     return this;
   }
 
@@ -166,7 +166,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
     onMutation();
-    this.valueDoubleWrapper = valueDoubleWrapper;
+    super.valueDoubleWrapper = valueDoubleWrapper;
     return this;
   }
 
@@ -176,7 +176,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
     onMutation();
-    this.valueFloatWrapper = valueFloatWrapper;
+    super.valueFloatWrapper = valueFloatWrapper;
     return this;
   }
 
@@ -186,7 +186,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
     onMutation();
-    this.valueBooleanWrapper = valueBooleanWrapper;
+    super.valueBooleanWrapper = valueBooleanWrapper;
     return this;
   }
 
@@ -196,7 +196,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
     onMutation();
-    this.valueByteWrapper = valueByteWrapper;
+    super.valueByteWrapper = valueByteWrapper;
     return this;
   }
 
@@ -206,7 +206,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valuebByte(byte valuebByte) {
     onMutation();
-    this.valuebByte = valuebByte;
+    super.valuebByte = valuebByte;
     return this;
   }
 
@@ -216,7 +216,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
     onMutation();
-    this.valueLongWrapper = valueLongWrapper;
+    super.valueLongWrapper = valueLongWrapper;
     return this;
   }
 
@@ -226,7 +226,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueCharacter(Character valueCharacter) {
     onMutation();
-    this.valueCharacter = valueCharacter;
+    super.valueCharacter = valueCharacter;
     return this;
   }
 
@@ -236,7 +236,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueString(String valueString) {
     onMutation();
-    this.valueString = valueString;
+    super.valueString = valueString;
     return this;
   }
 
@@ -246,7 +246,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueFloat(float valueFloat) {
     onMutation();
-    this.valueFloat = valueFloat;
+    super.valueFloat = valueFloat;
     return this;
   }
 
@@ -256,7 +256,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueBoolean(boolean valueBoolean) {
     onMutation();
-    this.valueBoolean = valueBoolean;
+    super.valueBoolean = valueBoolean;
     return this;
   }
 
@@ -266,7 +266,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
     onMutation();
-    this.valueObjectArray = valueObjectArray;
+    super.valueObjectArray = valueObjectArray;
     return this;
   }
 
@@ -276,7 +276,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueObject(Object valueObject) {
     onMutation();
-    this.valueObject = valueObject;
+    super.valueObject = valueObject;
     return this;
   }
 
@@ -286,7 +286,7 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
 
   public DataBindingModelWithAllFieldTypes_ valueIntArray(int[] valueIntArray) {
     onMutation();
-    this.valueIntArray = valueIntArray;
+    super.valueIntArray = valueIntArray;
     return this;
   }
 
@@ -491,27 +491,27 @@ public class DataBindingModelWithAllFieldTypes_ extends DataBindingModelWithAllF
   public DataBindingModelWithAllFieldTypes_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.valueInteger = null;
-    this.valueShort = (short) 0;
-    this.valueLong = 0L;
-    this.valueList = null;
-    this.valueShortWrapper = null;
-    this.valueDouble = 0.0d;
-    this.valueChar = (char) 0;
-    this.valueInt = 0;
-    this.valueDoubleWrapper = null;
-    this.valueFloatWrapper = null;
-    this.valueBooleanWrapper = null;
-    this.valueByteWrapper = null;
-    this.valuebByte = (byte) 0;
-    this.valueLongWrapper = null;
-    this.valueCharacter = null;
-    this.valueString = null;
-    this.valueFloat = 0.0f;
-    this.valueBoolean = false;
-    this.valueObjectArray = null;
-    this.valueObject = null;
-    this.valueIntArray = null;
+    super.valueInteger = null;
+    super.valueShort = (short) 0;
+    super.valueLong = 0L;
+    super.valueList = null;
+    super.valueShortWrapper = null;
+    super.valueDouble = 0.0d;
+    super.valueChar = (char) 0;
+    super.valueInt = 0;
+    super.valueDoubleWrapper = null;
+    super.valueFloatWrapper = null;
+    super.valueBooleanWrapper = null;
+    super.valueByteWrapper = null;
+    super.valuebByte = (byte) 0;
+    super.valueLongWrapper = null;
+    super.valueCharacter = null;
+    super.valueString = null;
+    super.valueFloat = 0.0f;
+    super.valueBoolean = false;
+    super.valueObjectArray = null;
+    super.valueObject = null;
+    super.valueIntArray = null;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodNextParentLayout$NoLayout_.java
@@ -73,7 +73,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
 
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -145,7 +145,7 @@ public class GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ extends Gener
   public GenerateDefaultLayoutMethodNextParentLayout$NoLayout_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethodParentLayout$NoLayout_.java
@@ -73,7 +73,7 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
 
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -145,7 +145,7 @@ public class GenerateDefaultLayoutMethodParentLayout$NoLayout_ extends GenerateD
   public GenerateDefaultLayoutMethodParentLayout$NoLayout_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
+++ b/epoxy-processortest/src/test/resources/GenerateDefaultLayoutMethod_.java
@@ -73,7 +73,7 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
 
   public GenerateDefaultLayoutMethod_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -145,7 +145,7 @@ public class GenerateDefaultLayoutMethod_ extends GenerateDefaultLayoutMethod im
   public GenerateDefaultLayoutMethod_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelDoNotHash_.java
@@ -73,7 +73,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
 
   public ModelDoNotHash_ value2(int value2) {
     onMutation();
-    this.value2 = value2;
+    super.value2 = value2;
     return this;
   }
 
@@ -83,7 +83,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
 
   public ModelDoNotHash_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -93,7 +93,7 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
 
   public ModelDoNotHash_ value3(String value3) {
     onMutation();
-    this.value3 = value3;
+    super.value3 = value3;
     return this;
   }
 
@@ -159,9 +159,9 @@ public class ModelDoNotHash_ extends ModelDoNotHash implements GeneratedModel<Ob
   public ModelDoNotHash_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value2 = 0;
-    this.value = 0;
-    this.value3 = null;
+    super.value2 = 0;
+    super.value = 0;
+    super.value3 = null;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
+++ b/epoxy-processortest/src/test/resources/ModelForRProcessingTest_.java
@@ -73,7 +73,7 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
 
   public ModelForRProcessingTest_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -145,7 +145,7 @@ public class ModelForRProcessingTest_ extends ModelForRProcessingTest implements
   public ModelForRProcessingTest_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
+++ b/epoxy-processortest/src/test/resources/ModelForTestingDuplicateRValues_.java
@@ -74,7 +74,7 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
 
   public ModelForTestingDuplicateRValues_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -146,7 +146,7 @@ public class ModelForTestingDuplicateRValues_ extends ModelForTestingDuplicateRV
   public ModelForTestingDuplicateRValues_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelNoValidation_.java
+++ b/epoxy-processortest/src/test/resources/ModelNoValidation_.java
@@ -65,7 +65,7 @@ public class ModelNoValidation_ extends ModelNoValidation implements GeneratedMo
 
   public ModelNoValidation_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -131,7 +131,7 @@ public class ModelNoValidation_ extends ModelNoValidation implements GeneratedMo
   public ModelNoValidation_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassTypeWithVarargs_.java
@@ -73,7 +73,7 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
 
   public ModelReturningClassTypeWithVarargs_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -151,7 +151,7 @@ public class ModelReturningClassTypeWithVarargs_ extends ModelReturningClassType
   public ModelReturningClassTypeWithVarargs_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
+++ b/epoxy-processortest/src/test/resources/ModelReturningClassType_.java
@@ -74,7 +74,7 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
 
   public ModelReturningClassType_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -158,7 +158,7 @@ public class ModelReturningClassType_ extends ModelReturningClassType implements
   public ModelReturningClassType_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllFieldTypes_.java
@@ -83,7 +83,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueInteger(Integer valueInteger) {
     onMutation();
-    this.valueInteger = valueInteger;
+    super.valueInteger = valueInteger;
     return this;
   }
 
@@ -93,7 +93,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueShort(short valueShort) {
     onMutation();
-    this.valueShort = valueShort;
+    super.valueShort = valueShort;
     return this;
   }
 
@@ -103,7 +103,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueLong(long valueLong) {
     onMutation();
-    this.valueLong = valueLong;
+    super.valueLong = valueLong;
     return this;
   }
 
@@ -113,7 +113,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueList(List<String> valueList) {
     onMutation();
-    this.valueList = valueList;
+    super.valueList = valueList;
     return this;
   }
 
@@ -123,7 +123,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
     onMutation();
-    this.valueShortWrapper = valueShortWrapper;
+    super.valueShortWrapper = valueShortWrapper;
     return this;
   }
 
@@ -133,7 +133,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueDouble(double valueDouble) {
     onMutation();
-    this.valueDouble = valueDouble;
+    super.valueDouble = valueDouble;
     return this;
   }
 
@@ -143,7 +143,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueChar(char valueChar) {
     onMutation();
-    this.valueChar = valueChar;
+    super.valueChar = valueChar;
     return this;
   }
 
@@ -153,7 +153,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueInt(int valueInt) {
     onMutation();
-    this.valueInt = valueInt;
+    super.valueInt = valueInt;
     return this;
   }
 
@@ -163,7 +163,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
     onMutation();
-    this.valueDoubleWrapper = valueDoubleWrapper;
+    super.valueDoubleWrapper = valueDoubleWrapper;
     return this;
   }
 
@@ -173,7 +173,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
     onMutation();
-    this.valueFloatWrapper = valueFloatWrapper;
+    super.valueFloatWrapper = valueFloatWrapper;
     return this;
   }
 
@@ -183,7 +183,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
     onMutation();
-    this.valueBooleanWrapper = valueBooleanWrapper;
+    super.valueBooleanWrapper = valueBooleanWrapper;
     return this;
   }
 
@@ -193,7 +193,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
     onMutation();
-    this.valueByteWrapper = valueByteWrapper;
+    super.valueByteWrapper = valueByteWrapper;
     return this;
   }
 
@@ -203,7 +203,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valuebByte(byte valuebByte) {
     onMutation();
-    this.valuebByte = valuebByte;
+    super.valuebByte = valuebByte;
     return this;
   }
 
@@ -213,7 +213,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
     onMutation();
-    this.valueLongWrapper = valueLongWrapper;
+    super.valueLongWrapper = valueLongWrapper;
     return this;
   }
 
@@ -223,7 +223,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueCharacter(Character valueCharacter) {
     onMutation();
-    this.valueCharacter = valueCharacter;
+    super.valueCharacter = valueCharacter;
     return this;
   }
 
@@ -233,7 +233,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueString(String valueString) {
     onMutation();
-    this.valueString = valueString;
+    super.valueString = valueString;
     return this;
   }
 
@@ -243,7 +243,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueFloat(float valueFloat) {
     onMutation();
-    this.valueFloat = valueFloat;
+    super.valueFloat = valueFloat;
     return this;
   }
 
@@ -253,7 +253,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueBoolean(boolean valueBoolean) {
     onMutation();
-    this.valueBoolean = valueBoolean;
+    super.valueBoolean = valueBoolean;
     return this;
   }
 
@@ -263,7 +263,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
     onMutation();
-    this.valueObjectArray = valueObjectArray;
+    super.valueObjectArray = valueObjectArray;
     return this;
   }
 
@@ -273,7 +273,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueObject(Object valueObject) {
     onMutation();
-    this.valueObject = valueObject;
+    super.valueObject = valueObject;
     return this;
   }
 
@@ -283,7 +283,7 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
 
   public ModelWithAllFieldTypes_ valueIntArray(int[] valueIntArray) {
     onMutation();
-    this.valueIntArray = valueIntArray;
+    super.valueIntArray = valueIntArray;
     return this;
   }
 
@@ -349,27 +349,27 @@ public class ModelWithAllFieldTypes_ extends ModelWithAllFieldTypes implements G
   public ModelWithAllFieldTypes_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.valueInteger = null;
-    this.valueShort = (short) 0;
-    this.valueLong = 0L;
-    this.valueList = null;
-    this.valueShortWrapper = null;
-    this.valueDouble = 0.0d;
-    this.valueChar = (char) 0;
-    this.valueInt = 0;
-    this.valueDoubleWrapper = null;
-    this.valueFloatWrapper = null;
-    this.valueBooleanWrapper = null;
-    this.valueByteWrapper = null;
-    this.valuebByte = (byte) 0;
-    this.valueLongWrapper = null;
-    this.valueCharacter = null;
-    this.valueString = null;
-    this.valueFloat = 0.0f;
-    this.valueBoolean = false;
-    this.valueObjectArray = null;
-    this.valueObject = null;
-    this.valueIntArray = null;
+    super.valueInteger = null;
+    super.valueShort = (short) 0;
+    super.valueLong = 0L;
+    super.valueList = null;
+    super.valueShortWrapper = null;
+    super.valueDouble = 0.0d;
+    super.valueChar = (char) 0;
+    super.valueInt = 0;
+    super.valueDoubleWrapper = null;
+    super.valueFloatWrapper = null;
+    super.valueBooleanWrapper = null;
+    super.valueByteWrapper = null;
+    super.valuebByte = (byte) 0;
+    super.valueLongWrapper = null;
+    super.valueCharacter = null;
+    super.valueString = null;
+    super.valueFloat = 0.0f;
+    super.valueBoolean = false;
+    super.valueObjectArray = null;
+    super.valueObject = null;
+    super.valueIntArray = null;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllPrivateFieldTypes_.java
@@ -83,7 +83,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueInteger(Integer valueInteger) {
     onMutation();
-    this.setValueInteger(valueInteger);
+    super.setValueInteger(valueInteger);
     return this;
   }
 
@@ -93,7 +93,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueShort(short valueShort) {
     onMutation();
-    this.setValueShort(valueShort);
+    super.setValueShort(valueShort);
     return this;
   }
 
@@ -103,7 +103,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueLong(long valueLong) {
     onMutation();
-    this.setValueLong(valueLong);
+    super.setValueLong(valueLong);
     return this;
   }
 
@@ -113,7 +113,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueList(List<String> valueList) {
     onMutation();
-    this.setValueList(valueList);
+    super.setValueList(valueList);
     return this;
   }
 
@@ -123,7 +123,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueShortWrapper(Short valueShortWrapper) {
     onMutation();
-    this.setValueShortWrapper(valueShortWrapper);
+    super.setValueShortWrapper(valueShortWrapper);
     return this;
   }
 
@@ -133,7 +133,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueDouble(double valueDouble) {
     onMutation();
-    this.setValueDouble(valueDouble);
+    super.setValueDouble(valueDouble);
     return this;
   }
 
@@ -143,7 +143,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueChar(char valueChar) {
     onMutation();
-    this.setValueChar(valueChar);
+    super.setValueChar(valueChar);
     return this;
   }
 
@@ -153,7 +153,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueInt(int valueInt) {
     onMutation();
-    this.setValueInt(valueInt);
+    super.setValueInt(valueInt);
     return this;
   }
 
@@ -163,7 +163,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper) {
     onMutation();
-    this.setValueDoubleWrapper(valueDoubleWrapper);
+    super.setValueDoubleWrapper(valueDoubleWrapper);
     return this;
   }
 
@@ -173,7 +173,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueFloatWrapper(Float valueFloatWrapper) {
     onMutation();
-    this.setValueFloatWrapper(valueFloatWrapper);
+    super.setValueFloatWrapper(valueFloatWrapper);
     return this;
   }
 
@@ -183,7 +183,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper) {
     onMutation();
-    this.setValueBooleanWrapper(valueBooleanWrapper);
+    super.setValueBooleanWrapper(valueBooleanWrapper);
     return this;
   }
 
@@ -193,7 +193,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueByteWrapper(Byte valueByteWrapper) {
     onMutation();
-    this.setValueByteWrapper(valueByteWrapper);
+    super.setValueByteWrapper(valueByteWrapper);
     return this;
   }
 
@@ -203,7 +203,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valuebByte(byte valuebByte) {
     onMutation();
-    this.setValuebByte(valuebByte);
+    super.setValuebByte(valuebByte);
     return this;
   }
 
@@ -213,7 +213,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueLongWrapper(Long valueLongWrapper) {
     onMutation();
-    this.setValueLongWrapper(valueLongWrapper);
+    super.setValueLongWrapper(valueLongWrapper);
     return this;
   }
 
@@ -223,7 +223,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueCharacter(Character valueCharacter) {
     onMutation();
-    this.setValueCharacter(valueCharacter);
+    super.setValueCharacter(valueCharacter);
     return this;
   }
 
@@ -233,7 +233,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueString(String valueString) {
     onMutation();
-    this.setValueString(valueString);
+    super.setValueString(valueString);
     return this;
   }
 
@@ -243,7 +243,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueFloat(float valueFloat) {
     onMutation();
-    this.setValueFloat(valueFloat);
+    super.setValueFloat(valueFloat);
     return this;
   }
 
@@ -253,7 +253,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueBoolean(boolean valueBoolean) {
     onMutation();
-    this.setValueBoolean(valueBoolean);
+    super.setValueBoolean(valueBoolean);
     return this;
   }
 
@@ -263,7 +263,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueObjectArray(Object[] valueObjectArray) {
     onMutation();
-    this.setValueObjectArray(valueObjectArray);
+    super.setValueObjectArray(valueObjectArray);
     return this;
   }
 
@@ -273,7 +273,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueObject(Object valueObject) {
     onMutation();
-    this.setValueObject(valueObject);
+    super.setValueObject(valueObject);
     return this;
   }
 
@@ -283,7 +283,7 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
 
   public ModelWithAllPrivateFieldTypes_ valueIntArray(int[] valueIntArray) {
     onMutation();
-    this.setValueIntArray(valueIntArray);
+    super.setValueIntArray(valueIntArray);
     return this;
   }
 
@@ -355,27 +355,27 @@ public class ModelWithAllPrivateFieldTypes_ extends ModelWithAllPrivateFieldType
   public ModelWithAllPrivateFieldTypes_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.setValueInteger(null);
-    this.setValueShort((short) 0);
-    this.setValueLong(0L);
-    this.setValueList(null);
-    this.setValueShortWrapper(null);
-    this.setValueDouble(0.0d);
-    this.setValueChar((char) 0);
-    this.setValueInt(0);
-    this.setValueDoubleWrapper(null);
-    this.setValueFloatWrapper(null);
-    this.setValueBooleanWrapper(null);
-    this.setValueByteWrapper(null);
-    this.setValuebByte((byte) 0);
-    this.setValueLongWrapper(null);
-    this.setValueCharacter(null);
-    this.setValueString(null);
-    this.setValueFloat(0.0f);
-    this.setValueBoolean(false);
-    this.setValueObjectArray(null);
-    this.setValueObject(null);
-    this.setValueIntArray(null);
+    super.setValueInteger(null);
+    super.setValueShort((short) 0);
+    super.setValueLong(0L);
+    super.setValueList(null);
+    super.setValueShortWrapper(null);
+    super.setValueDouble(0.0d);
+    super.setValueChar((char) 0);
+    super.setValueInt(0);
+    super.setValueDoubleWrapper(null);
+    super.setValueFloatWrapper(null);
+    super.setValueBooleanWrapper(null);
+    super.setValueByteWrapper(null);
+    super.setValuebByte((byte) 0);
+    super.setValueLongWrapper(null);
+    super.setValueCharacter(null);
+    super.setValueString(null);
+    super.setValueFloat(0.0f);
+    super.setValueBoolean(false);
+    super.setValueObjectArray(null);
+    super.setValueObject(null);
+    super.setValueIntArray(null);
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_.java
@@ -73,7 +73,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
 
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ superValue(int superValue) {
     onMutation();
-    this.superValue = superValue;
+    super.superValue = superValue;
     return this;
   }
 
@@ -141,7 +141,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClas
   public ModelWithAnnotatedClassAndSuperAttributes$SubModelWithAnnotatedClassAndSuperAttributes_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.superValue = 0;
+    super.superValue = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAnnotatedClassAndSuperAttributes_.java
@@ -73,7 +73,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
 
   public ModelWithAnnotatedClassAndSuperAttributes_ superValue(int superValue) {
     onMutation();
-    this.superValue = superValue;
+    super.superValue = superValue;
     return this;
   }
 
@@ -139,7 +139,7 @@ public class ModelWithAnnotatedClassAndSuperAttributes_ extends ModelWithAnnotat
   public ModelWithAnnotatedClassAndSuperAttributes_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.superValue = 0;
+    super.superValue = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithConstructors_.java
@@ -81,7 +81,7 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
 
   public ModelWithConstructors_ valueInt(int valueInt) {
     onMutation();
-    this.valueInt = valueInt;
+    super.valueInt = valueInt;
     return this;
   }
 
@@ -147,7 +147,7 @@ public class ModelWithConstructors_ extends ModelWithConstructors implements Gen
   public ModelWithConstructors_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.valueInt = 0;
+    super.valueInt = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithFieldAnnotation_.java
@@ -74,7 +74,7 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
 
   public ModelWithFieldAnnotation_ title(@Nullable String title) {
     onMutation();
-    this.title = title;
+    super.title = title;
     return this;
   }
 
@@ -141,7 +141,7 @@ public class ModelWithFieldAnnotation_ extends ModelWithFieldAnnotation implemen
   public ModelWithFieldAnnotation_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.title = null;
+    super.title = null;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithIntDef_.java
@@ -78,7 +78,7 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
 
   public ModelWithIntDef_ type(@ModelWithIntDef.MyType int type) {
     onMutation();
-    this.type = type;
+    super.type = type;
     return this;
   }
 
@@ -145,7 +145,7 @@ public class ModelWithIntDef_ extends ModelWithIntDef implements GeneratedModel<
   public ModelWithIntDef_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.type = 0;
+    super.type = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_.java
@@ -73,7 +73,7 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
 
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ isValue(boolean isValue) {
     onMutation();
-    this.setValue(isValue);
+    super.setValue(isValue);
     return this;
   }
 
@@ -139,7 +139,7 @@ public class ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ extends Mo
   public ModelWithPrivateFieldWithSameAsFieldGetterAndSetterName_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.setValue(false);
+    super.setValue(false);
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
@@ -104,7 +104,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
 
   public ModelWithPrivateViewClickListener_ clickListener(View.OnClickListener clickListener) {
     onMutation();
-    this.setClickListener(clickListener);
+    super.setClickListener(clickListener);
     this.clickListener_epoxyGeneratedModel = null;
     return this;
   }
@@ -171,7 +171,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   public ModelWithPrivateViewClickListener_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.setClickListener(null);
+    super.setClickListener(null);
     clickListener_epoxyGeneratedModel = null;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes$SubModelWithSuperAttributes_.java
@@ -73,7 +73,7 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
 
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ subValue(int subValue) {
     onMutation();
-    this.subValue = subValue;
+    super.subValue = subValue;
     return this;
   }
 
@@ -83,7 +83,7 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
 
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ superValue(int superValue) {
     onMutation();
-    this.superValue = superValue;
+    super.superValue = superValue;
     return this;
   }
 
@@ -149,8 +149,8 @@ public class ModelWithSuperAttributes$SubModelWithSuperAttributes_ extends Model
   public ModelWithSuperAttributes$SubModelWithSuperAttributes_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.subValue = 0;
-    this.superValue = 0;
+    super.subValue = 0;
+    super.superValue = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuperAttributes_.java
@@ -73,7 +73,7 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
 
   public ModelWithSuperAttributes_ superValue(int superValue) {
     onMutation();
-    this.superValue = superValue;
+    super.superValue = superValue;
     return this;
   }
 
@@ -139,7 +139,7 @@ public class ModelWithSuperAttributes_ extends ModelWithSuperAttributes implemen
   public ModelWithSuperAttributes_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.superValue = 0;
+    super.superValue = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithSuper_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithSuper_.java
@@ -73,7 +73,7 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
 
   public ModelWithSuper_ valueInt(int valueInt) {
     onMutation();
-    this.valueInt = valueInt;
+    super.valueInt = valueInt;
     super.valueInt(valueInt);
     return this;
   }
@@ -140,7 +140,7 @@ public class ModelWithSuper_ extends ModelWithSuper implements GeneratedModel<Ob
   public ModelWithSuper_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.valueInt = 0;
+    super.valueInt = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithType_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithType_.java
@@ -73,7 +73,7 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
 
   public ModelWithType_<T> value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -139,7 +139,7 @@ public class ModelWithType_<T extends String> extends ModelWithType<T> implement
   public ModelWithType_<T> reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithVarargsConstructors_.java
@@ -78,7 +78,7 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
 
   public ModelWithVarargsConstructors_ varargs(String[] varargs) {
     onMutation();
-    this.varargs = varargs;
+    super.varargs = varargs;
     return this;
   }
 
@@ -88,7 +88,7 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
 
   public ModelWithVarargsConstructors_ valueInt(int valueInt) {
     onMutation();
-    this.valueInt = valueInt;
+    super.valueInt = valueInt;
     return this;
   }
 
@@ -154,8 +154,8 @@ public class ModelWithVarargsConstructors_ extends ModelWithVarargsConstructors 
   public ModelWithVarargsConstructors_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.varargs = null;
-    this.valueInt = 0;
+    super.varargs = null;
+    super.valueInt = 0;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -104,7 +104,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
 
   public ModelWithViewClickListener_ clickListener(View.OnClickListener clickListener) {
     onMutation();
-    this.clickListener = clickListener;
+    super.clickListener = clickListener;
     this.clickListener_epoxyGeneratedModel = null;
     return this;
   }
@@ -171,7 +171,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   public ModelWithViewClickListener_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.clickListener = null;
+    super.clickListener = null;
     clickListener_epoxyGeneratedModel = null;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutHash_.java
@@ -73,7 +73,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
 
   public ModelWithoutHash_ value2(int value2) {
     onMutation();
-    this.value2 = value2;
+    super.value2 = value2;
     return this;
   }
 
@@ -83,7 +83,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
 
   public ModelWithoutHash_ value(int value) {
     onMutation();
-    this.value = value;
+    super.value = value;
     return this;
   }
 
@@ -93,7 +93,7 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
 
   public ModelWithoutHash_ value3(String value3) {
     onMutation();
-    this.value3 = value3;
+    super.value3 = value3;
     return this;
   }
 
@@ -159,9 +159,9 @@ public class ModelWithoutHash_ extends ModelWithoutHash implements GeneratedMode
   public ModelWithoutHash_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value2 = 0;
-    this.value = 0;
-    this.value3 = null;
+    super.value2 = 0;
+    super.value = 0;
+    super.value3 = null;
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithoutSetter_.java
@@ -133,7 +133,7 @@ public class ModelWithoutSetter_ extends ModelWithoutSetter implements Generated
   public ModelWithoutSetter_ reset() {
     onModelBoundListener_epoxyGeneratedModel = null;
     onModelUnboundListener_epoxyGeneratedModel = null;
-    this.value = 0;
+    super.value = 0;
     super.reset();
     return this;
   }


### PR DESCRIPTION
This does a simple check for each databinding variable - if the type of the variable implements equals/hashcode then that variable is included in the model's diffed state, otherwise it is given the equivalent of `DoNotHash` in a normal EpoxyModel. This will let databinding models exclude things like click listeners from state.

I went with this approach because it was very easy to implement, and will give good default behavior. The downside is it is less transparent and easily changeable, but I couldn't think of a great way to help that without being very verbose or complicated.

I also realized that databinding variables named `clickListener` would clash with the generated click listener code. I changed the model generation to properly use `this.` or `super.` when referencing a field so that problem wouldn't happen.

I also renamed ProcessorUtils to just Utils, and a little other clean up.

@ngsilverman @geralt-encore 