### PR TITLE
Use proper bind super call for diff binding

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModelInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModelInfo.java
@@ -49,7 +49,7 @@ class DataBindingModelInfo extends GeneratedModelInfo {
     // it is generated in the first round.
     Element dataBindingClass = getElementByName(dataBindingClassName, elementUtils, typeUtils);
 
-    HashCodeValidator hashCodeValidator = new HashCodeValidator(typeUtils);
+    HashCodeValidator hashCodeValidator = new HashCodeValidator(typeUtils, elementUtils);
     for (Element element : dataBindingClass.getEnclosedElements()) {
       if (Utils.isSetterMethod(element)) {
         addAttribute(

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -100,7 +100,7 @@ public class EpoxyProcessor extends AbstractProcessor {
     modelWriter =
         new GeneratedModelWriter(filer, typeUtils, errorLogger,
             layoutResourceProcessor,
-            configManager, dataBindingModuleLookup);
+            configManager, dataBindingModuleLookup, elementUtils);
 
     controllerProcessor = new ControllerProcessor(filer, elementUtils, typeUtils, errorLogger,
         configManager);
@@ -181,7 +181,7 @@ public class EpoxyProcessor extends AbstractProcessor {
 
   private void validateAttributesImplementHashCode(
       Collection<GeneratedModelInfo> generatedClasses) {
-    HashCodeValidator hashCodeValidator = new HashCodeValidator(typeUtils);
+    HashCodeValidator hashCodeValidator = new HashCodeValidator(typeUtils, elementUtils);
 
     for (GeneratedModelInfo generatedClass : generatedClasses) {
       for (AttributeInfo attributeInfo : generatedClass.getAttributeInfo()) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -28,6 +28,7 @@ import java.util.List;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import static com.airbnb.epoxy.Utils.EPOXY_CONTROLLER_TYPE;
@@ -71,6 +72,7 @@ class GeneratedModelWriter {
   private final LayoutResourceProcessor layoutResourceProcessor;
   private final ConfigManager configManager;
   private final DataBindingModuleLookup dataBindingModuleLookup;
+  private final Elements elements;
   private BuilderHooks builderHooks;
 
   static class BuilderHooks {
@@ -100,13 +102,14 @@ class GeneratedModelWriter {
 
   GeneratedModelWriter(Filer filer, Types typeUtils, ErrorLogger errorLogger,
       LayoutResourceProcessor layoutResourceProcessor, ConfigManager configManager,
-      DataBindingModuleLookup dataBindingModuleLookup) {
+      DataBindingModuleLookup dataBindingModuleLookup, Elements elements) {
     this.filer = filer;
     this.typeUtils = typeUtils;
     this.errorLogger = errorLogger;
     this.layoutResourceProcessor = layoutResourceProcessor;
     this.configManager = configManager;
     this.dataBindingModuleLookup = dataBindingModuleLookup;
+    this.elements = elements;
   }
 
   void generateClassForModel(GeneratedModelInfo info) throws IOException {
@@ -578,7 +581,7 @@ class GeneratedModelWriter {
         .addModifiers(Modifier.PROTECTED)
         .build();
 
-    if (implementsMethod(originalClassElement, createHolderMethod, typeUtils)) {
+    if (implementsMethod(originalClassElement, createHolderMethod, typeUtils, elements)) {
       return;
     }
 
@@ -631,7 +634,7 @@ class GeneratedModelWriter {
     }
 
     TypeElement superClassElement = modelInfo.getSuperClassElement();
-    if (implementsMethod(superClassElement, buildDefaultLayoutMethodBase(), typeUtils)) {
+    if (implementsMethod(superClassElement, buildDefaultLayoutMethodBase(), typeUtils, elements)) {
       return null;
     }
 
@@ -667,7 +670,7 @@ class GeneratedModelWriter {
         .build();
 
     // If the base method is already implemented don't bother checking for the payload method
-    if (implementsMethod(info.getSuperClassElement(), bindVariablesMethod, typeUtils)) {
+    if (implementsMethod(info.getSuperClassElement(), bindVariablesMethod, typeUtils, elements)) {
       return Collections.emptyList();
     }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/HashCodeValidator.java
@@ -14,6 +14,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import static com.airbnb.epoxy.Utils.getMethodOnClass;
@@ -41,9 +42,11 @@ class HashCodeValidator {
       .build();
 
   private final Types typeUtils;
+  private final Elements elements;
 
-  HashCodeValidator(Types typeUtils) {
+  HashCodeValidator(Types typeUtils, Elements elements) {
     this.typeUtils = typeUtils;
+    this.elements = elements;
   }
 
   boolean implementsHashCodeAndEquals(TypeMirror mirror) {
@@ -61,11 +64,11 @@ class HashCodeValidator {
     } catch (EpoxyProcessorException e) {
       // Append information about the attribute and class to the existing exception
       throwError(e.getMessage()
-              + " (%s) Epoxy requires every model attribute to implement equals and hashCode "
-              + "so that changes in the model "
-              + "can be tracked. If you want the attribute to be excluded, use "
-              + "the option 'DoNotHash'. If you want to ignore this warning use "
-              + "the option 'IgnoreRequireHashCode'", attribute);
+          + " (%s) Epoxy requires every model attribute to implement equals and hashCode "
+          + "so that changes in the model "
+          + "can be tracked. If you want the attribute to be excluded, use "
+          + "the option 'DoNotHash'. If you want to ignore this warning use "
+          + "the option 'IgnoreRequireHashCode'", attribute);
     }
   }
 
@@ -117,7 +120,8 @@ class HashCodeValidator {
   }
 
   private boolean hasHashCodeInClassHierarchy(TypeElement clazz) {
-    ExecutableElement methodOnClass = getMethodOnClass(clazz, HASH_CODE_METHOD, typeUtils);
+    ExecutableElement methodOnClass =
+        getMethodOnClass(clazz, HASH_CODE_METHOD, typeUtils, elements);
     if (methodOnClass == null) {
       return false;
     }
@@ -135,7 +139,7 @@ class HashCodeValidator {
   }
 
   private boolean hasEqualsInClassHierarchy(TypeElement clazz) {
-    ExecutableElement methodOnClass = getMethodOnClass(clazz, EQUALS_METHOD, typeUtils);
+    ExecutableElement methodOnClass = getMethodOnClass(clazz, EQUALS_METHOD, typeUtils, elements);
     if (methodOnClass == null) {
       return false;
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoSpecProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoSpecProcessor.java
@@ -67,7 +67,7 @@ class LithoSpecProcessor {
     }
 
     Class<? extends Annotation> propClass = getAnnotationClass(ClassNames.LITHO_ANNOTATION_PROP);
-    HashCodeValidator hashCodeValidator = new HashCodeValidator(typeUtils);
+    HashCodeValidator hashCodeValidator = new HashCodeValidator(typeUtils, elementUtils);
     for (Element propElement : roundEnv.getElementsAnnotatedWith(propClass)) {
       LithoModelInfo lithoModelInfo = getModelInfoForProp(modelInfoMap, propElement);
       if (lithoModelInfo != null) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.java
@@ -75,9 +75,13 @@ class ModelViewInfo extends GeneratedModelInfo {
 
     if (classToExtend == null
         || classToExtend.toString().equals(Void.class.getCanonicalName())) {
+
       TypeMirror defaultBaseModel = configManager.getDefaultBaseModel(viewElement);
-      return defaultBaseModel != null
-          ? (TypeElement) typeUtils.asElement(defaultBaseModel) : defaultSuper;
+      if (defaultBaseModel != null) {
+        classToExtend = defaultBaseModel;
+      } else {
+        return defaultSuper;
+      }
     }
 
     if (!isEpoxyModel(classToExtend)) {

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/BaseTestModel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/BaseTestModel.java
@@ -8,4 +8,9 @@ import com.airbnb.epoxy.EpoxyModel;
 
 public abstract class BaseTestModel<T extends View> extends EpoxyModel<T> {
   @EpoxyAttribute @Nullable Boolean showDivider;
+
+  @Override
+  public void bind(T view, EpoxyModel<?> previouslyBoundModel) {
+
+  }
 }


### PR DESCRIPTION
Models generated from view annotations handle binding with payloads. However, a super class can be specified which this model must extend. When binding the payload the generated model needs to know if it should call the super class's bind call as well. This adds support for that.