### PR TITLE
New view annotation for hook after view bound

### DIFF
--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/AfterPropsSet.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/AfterPropsSet.java
@@ -1,0 +1,21 @@
+package com.airbnb.epoxy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This can be used to annotate methods inside classes with a {@link com.airbnb.epoxy.ModelView}
+ * annotation. Methods with this annotation will be called after a view instance  is bound to a
+ * model and all model props have been set. This is useful if you need to wait until multiple props
+ * are set before doing certain initialization.
+ * <p>
+ * Methods with this annotation will be called after both the initial bind when the view comes on
+ * screen, and after partial binds when an onscreen view is updated.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface AfterPropsSet {
+}
+

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/OnViewRecycled.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/OnViewRecycled.java
@@ -5,6 +5,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This can be used to annotate methods inside classes with a {@link com.airbnb.epoxy.ModelView}
+ * annotation. Methods with this annotation will be called when the view is recycled by the
+ * RecyclerView.
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.CLASS)
 public @interface OnViewRecycled {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -100,6 +100,10 @@ class GeneratedModelWriter {
         ParameterSpec previousModelParam) {
       return false;
     }
+
+    public void addToHandlePostBindMethod(Builder postBindBuilder, ParameterSpec boundObjectParam) {
+
+    }
   }
 
   GeneratedModelWriter(Filer filer, Types typeUtils, ErrorLogger errorLogger,
@@ -428,6 +432,8 @@ class GeneratedModelWriter {
 
     addHashCodeValidationIfNecessary(postBindBuilder,
         "The model was changed during the bind call.");
+
+    builderHooks.addToHandlePostBindMethod(postBindBuilder, boundObjectParam);
 
     methods.add(postBindBuilder
         .build());

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/LithoModelInfo.kt
@@ -1,19 +1,18 @@
 package com.airbnb.epoxy
 
+import com.airbnb.epoxy.ClassNames.EPOXY_LITHO_MODEL
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.ParameterizedTypeName
-
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
 
-import com.airbnb.epoxy.ClassNames.EPOXY_LITHO_MODEL
-
 internal class LithoModelInfo(
         typeUtils: Types,
         elementUtils: Elements,
-        layoutSpecClassElement: TypeElement) : GeneratedModelInfo() {
+        layoutSpecClassElement: TypeElement
+) : GeneratedModelInfo() {
 
     val lithoComponentName: ClassName
 
@@ -39,7 +38,7 @@ internal class LithoModelInfo(
      * package, and with the "Spec" term removed from the name.
      */
     fun getLithoComponentName(elementUtils: Elements,
-                                      layoutSpecClassElement: TypeElement): ClassName {
+                              layoutSpecClassElement: TypeElement): ClassName {
         val packageName = elementUtils.getPackageOf(layoutSpecClassElement).qualifiedName.toString()
 
         // Litho doesn't appear to allow specs as nested classes, so we don't check for nested

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.java
@@ -22,6 +22,7 @@ import static com.airbnb.epoxy.Utils.isEpoxyModel;
 
 class ModelViewInfo extends GeneratedModelInfo {
   final List<String> resetMethodNames = new ArrayList<>();
+  final List<String> afterPropsSetMethodNames = new ArrayList<>();
   final TypeElement viewElement;
   final Types typeUtils;
   final Elements elements;
@@ -144,6 +145,10 @@ class ModelViewInfo extends GeneratedModelInfo {
     resetMethodNames.add(resetMethod.getSimpleName().toString());
   }
 
+  void addAfterPropsSetMethod(ExecutableElement afterPropsSetMethod) {
+    afterPropsSetMethodNames.add(afterPropsSetMethod.getSimpleName().toString());
+  }
+
   LayoutResource getLayoutResource(LayoutResourceProcessor layoutResourceProcessor) {
     ModelView annotation = viewElement.getAnnotation(ModelView.class);
     int layoutValue = annotation.defaultLayout();
@@ -164,6 +169,10 @@ class ModelViewInfo extends GeneratedModelInfo {
 
   List<String> getResetMethodNames() {
     return resetMethodNames;
+  }
+
+  List<String> getAfterPropsSetMethodNames() {
+    return afterPropsSetMethodNames;
   }
 
   List<ViewAttributeInfo> getViewAttributes() {

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ViewProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ViewProcessorTest.java
@@ -857,4 +857,23 @@ public class ViewProcessorTest {
         .and()
         .generatesSources(generatedModel);
   }
+
+  @Test
+  public void afterBindProps() {
+    JavaFileObject model = JavaFileObjects
+        .forResource("TestAfterBindPropsView.java");
+
+    JavaFileObject superModel = JavaFileObjects
+        .forResource("TestAfterBindPropsSuperView.java");
+
+    JavaFileObject generatedModel =
+        JavaFileObjects.forResource("TestAfterBindPropsViewModel_.java");
+
+    assert_().about(javaSources())
+        .that(asList(model, superModel))
+        .processedWith(new EpoxyProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(generatedModel);
+  }
 }

--- a/epoxy-processortest/src/test/resources/TestAfterBindPropsSuperView.java
+++ b/epoxy-processortest/src/test/resources/TestAfterBindPropsSuperView.java
@@ -1,0 +1,22 @@
+package com.airbnb.epoxy;
+
+import android.content.Context;
+import android.view.View;
+
+@ModelView(defaultLayout = 1)
+public abstract class TestAfterBindPropsSuperView extends View {
+
+  public TestAfterBindPropsSuperView(Context context) {
+    super(context);
+  }
+
+  @ModelProp
+  public void setFlagSuper(boolean flag) {
+
+  }
+
+  @AfterPropsSet
+  public void afterFlagSetSuper() {
+
+  }
+}

--- a/epoxy-processortest/src/test/resources/TestAfterBindPropsView.java
+++ b/epoxy-processortest/src/test/resources/TestAfterBindPropsView.java
@@ -1,0 +1,21 @@
+package com.airbnb.epoxy;
+
+import android.content.Context;
+
+@ModelView(defaultLayout = 1)
+public class TestAfterBindPropsView extends TestAfterBindPropsSuperView {
+
+  public TestAfterBindPropsView(Context context) {
+    super(context);
+  }
+
+  @ModelProp
+  public void setFlag(boolean flag) {
+
+  }
+
+  @AfterPropsSet
+  public void afterFlagSet() {
+
+  }
+}

--- a/epoxy-processortest/src/test/resources/TestAfterBindPropsViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestAfterBindPropsViewModel_.java
@@ -1,0 +1,274 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import java.lang.CharSequence;
+import java.lang.Number;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.BitSet;
+
+/**
+ * Generated file. Do not modify! */
+public class TestAfterBindPropsViewModel_ extends EpoxyModel<TestAfterBindPropsView> implements GeneratedModel<TestAfterBindPropsView> {
+  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(2);
+
+  private OnModelBoundListener<TestAfterBindPropsViewModel_, TestAfterBindPropsView> onModelBoundListener_epoxyGeneratedModel;
+
+  private OnModelUnboundListener<TestAfterBindPropsViewModel_, TestAfterBindPropsView> onModelUnboundListener_epoxyGeneratedModel;
+
+  /**
+   * Bitset index: 0 */
+  private boolean flag_Boolean = false;
+
+  /**
+   * Bitset index: 1 */
+  private boolean flagSuper_Boolean = false;
+
+  @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
+  public void handlePreBind(final EpoxyViewHolder holder, final TestAfterBindPropsView object,
+      int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
+  }
+
+  @Override
+  public void bind(final TestAfterBindPropsView object) {
+    super.bind(object);
+    object.setFlagSuper(flagSuper_Boolean);
+    object.setFlag(flag_Boolean);
+  }
+
+  @Override
+  public void bind(final TestAfterBindPropsView object, EpoxyModel previousModel) {
+    if (!(previousModel instanceof TestAfterBindPropsViewModel_)) {
+      bind(object);
+      return;
+    }
+    TestAfterBindPropsViewModel_ that = (TestAfterBindPropsViewModel_) previousModel;
+    super.bind(object);
+
+    if (flagSuper_Boolean != that.flagSuper_Boolean) {
+      object.setFlagSuper(flagSuper_Boolean);
+    }
+
+    if (flag_Boolean != that.flag_Boolean) {
+      object.setFlag(flag_Boolean);
+    }
+  }
+
+  @Override
+  public void handlePostBind(final TestAfterBindPropsView object, int position) {
+    if (onModelBoundListener_epoxyGeneratedModel != null) {
+      onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
+    }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
+    object.afterFlagSet();
+    object.afterFlagSetSuper();
+  }
+
+  /**
+   * Register a listener that will be called when this model is bound to a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public TestAfterBindPropsViewModel_ onBind(OnModelBoundListener<TestAfterBindPropsViewModel_, TestAfterBindPropsView> listener) {
+    onMutation();
+    this.onModelBoundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  @Override
+  public void unbind(TestAfterBindPropsView object) {
+    super.unbind(object);
+    if (onModelUnboundListener_epoxyGeneratedModel != null) {
+      onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
+    }
+  }
+
+  /**
+   * Register a listener that will be called when this model is unbound from a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public TestAfterBindPropsViewModel_ onUnbind(OnModelUnboundListener<TestAfterBindPropsViewModel_, TestAfterBindPropsView> listener) {
+    onMutation();
+    this.onModelUnboundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  /**
+   * <i>Optional</i>: Default value is false
+   *
+   * @see TestAfterBindPropsView#setFlag(boolean)
+   */
+  public TestAfterBindPropsViewModel_ flag(boolean flag) {
+    assignedAttributes_epoxyGeneratedModel.set(0);
+    onMutation();
+    this.flag_Boolean = flag;
+    return this;
+  }
+
+  public boolean flag() {
+    return flag_Boolean;
+  }
+
+  /**
+   * <i>Optional</i>: Default value is false
+   *
+   * @see TestAfterBindPropsSuperView#setFlagSuper(boolean)
+   */
+  public TestAfterBindPropsViewModel_ flagSuper(boolean flagSuper) {
+    assignedAttributes_epoxyGeneratedModel.set(1);
+    onMutation();
+    this.flagSuper_Boolean = flagSuper;
+    return this;
+  }
+
+  public boolean flagSuper() {
+    return flagSuper_Boolean;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ id(Number... ids) {
+    super.id(ids);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ id(long id1, long id2) {
+    super.id(id1, id2);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ id(CharSequence key, CharSequence... otherKeys) {
+    super.id(key, otherKeys);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ id(CharSequence key, long id) {
+    super.id(key, id);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ layout(@LayoutRes int arg0) {
+    super.layout(arg0);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ spanSizeOverride(@Nullable EpoxyModel.SpanSizeOverrideCallback arg0) {
+    super.spanSizeOverride(arg0);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  @LayoutRes
+  protected int getDefaultLayout() {
+    return 1;
+  }
+
+  @Override
+  public TestAfterBindPropsViewModel_ reset() {
+    onModelBoundListener_epoxyGeneratedModel = null;
+    onModelUnboundListener_epoxyGeneratedModel = null;
+    assignedAttributes_epoxyGeneratedModel.clear();
+    this.flag_Boolean = false;
+    this.flagSuper_Boolean = false;
+    super.reset();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof TestAfterBindPropsViewModel_)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    TestAfterBindPropsViewModel_ that = (TestAfterBindPropsViewModel_) o;
+    if ((onModelBoundListener_epoxyGeneratedModel == null) != (that.onModelBoundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if ((onModelUnboundListener_epoxyGeneratedModel == null) != (that.onModelUnboundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if (flag_Boolean != that.flag_Boolean) {
+      return false;
+    }
+    if (flagSuper_Boolean != that.flagSuper_Boolean) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (onModelBoundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + (onModelUnboundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + (flag_Boolean ? 1 : 0);
+    result = 31 * result + (flagSuper_Boolean ? 1 : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "TestAfterBindPropsViewModel_{" +
+        "flag_Boolean=" + flag_Boolean +
+        ", flagSuper_Boolean=" + flagSuper_Boolean +
+        "}" + super.toString();
+  }
+
+  @Override
+  public int getSpanSize(int totalSpanCount, int position, int itemCount) {
+    return totalSpanCount;
+  }
+}


### PR DESCRIPTION
Adds the `AfterPropsSet` annotation for use with ModelView annotations.

```
/**
 * This can be used to annotate methods inside classes with a {@link com.airbnb.epoxy.ModelView}
 * annotation. Methods with this annotation will be called after a view instance  is bound to a
 * model and all model props have been set. This is useful if you need to wait until multiple props
 * are set before doing certain initialization.
 * <p>
 * Methods with this annotation will be called after both the initial bind when the view comes on
 * screen, and after partial binds when an onscreen view is updated.
 */
```