### PR TITLE
Fix model click listener setter name

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -830,7 +830,7 @@ class GeneratedModelWriter {
 
   private MethodSpec generateSetClickModelListener(GeneratedModelInfo classInfo,
       AttributeInfo attribute) {
-    String attributeName = attribute.getFieldName();
+    String attributeName = attribute.generatedSetterName();
 
     ParameterizedTypeName clickListenerType =
         isViewLongClickListenerType(attribute.getTypeMirror())

--- a/epoxy-processortest/src/test/resources/DoNotHashViewModel_.java
+++ b/epoxy-processortest/src/test/resources/DoNotHashViewModel_.java
@@ -150,14 +150,14 @@ public class DoNotHashViewModel_ extends EpoxyModel<DoNotHashView> implements Ge
 
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
-  public DoNotHashViewModel_ clickListener_OnClickListener(final OnModelClickListener<DoNotHashViewModel_, DoNotHashView> clickListener_OnClickListener) {
+  public DoNotHashViewModel_ clickListener(final OnModelClickListener<DoNotHashViewModel_, DoNotHashView> clickListener) {
     assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
-    if (clickListener_OnClickListener == null) {
+    if (clickListener == null) {
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener_OnClickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/IgnoreRequireHashCodeViewModel_.java
+++ b/epoxy-processortest/src/test/resources/IgnoreRequireHashCodeViewModel_.java
@@ -107,14 +107,14 @@ public class IgnoreRequireHashCodeViewModel_ extends EpoxyModel<IgnoreRequireHas
 
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
-  public IgnoreRequireHashCodeViewModel_ clickListener_OnClickListener(final OnModelClickListener<IgnoreRequireHashCodeViewModel_, IgnoreRequireHashCodeView> clickListener_OnClickListener) {
+  public IgnoreRequireHashCodeViewModel_ clickListener(final OnModelClickListener<IgnoreRequireHashCodeViewModel_, IgnoreRequireHashCodeView> clickListener) {
     assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
-    if (clickListener_OnClickListener == null) {
+    if (clickListener == null) {
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener_OnClickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
@@ -105,14 +105,14 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   @Nullable
-  public TestCallbackPropViewModel_ listener_OnClickListener(final OnModelClickListener<TestCallbackPropViewModel_, TestCallbackPropView> listener_OnClickListener) {
+  public TestCallbackPropViewModel_ listener(final OnModelClickListener<TestCallbackPropViewModel_, TestCallbackPropView> listener) {
     assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
-    if (listener_OnClickListener == null) {
+    if (listener == null) {
       this.listener_OnClickListener = null;
     }
     else {
-      this.listener_OnClickListener = new WrappedEpoxyModelClickListener(this, listener_OnClickListener);
+      this.listener_OnClickListener = new WrappedEpoxyModelClickListener(this, listener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
@@ -487,14 +487,14 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
 
   /**
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
-  public TestManyTypesViewModel_ clickListener_OnClickListener(final OnModelClickListener<TestManyTypesViewModel_, TestManyTypesView> clickListener_OnClickListener) {
+  public TestManyTypesViewModel_ clickListener(final OnModelClickListener<TestManyTypesViewModel_, TestManyTypesView> clickListener) {
     assignedAttributes_epoxyGeneratedModel.set(12);
     onMutation();
-    if (clickListener_OnClickListener == null) {
+    if (clickListener == null) {
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener_OnClickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener);
     }
     return this;
   }


### PR DESCRIPTION
The generated model click listener field was being given a name suffixed with `_OnClickListener` for models created with @ModelView. It should have had no suffix so it shared the same name with the normal click listener setter. The issue is the field name was used instead of the intended setter name.