### PR TITLE
Include canvas in ItemTouchHelper swipe callback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
 
   ext.KOTLIN_VERSION = "1.1.4-3"
-  ext.ANDROID_PLUGIN_VERSION = "3.0.0-beta4"
+  ext.ANDROID_PLUGIN_VERSION = "3.0.0-beta5"
 
   repositories {
     google()

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelTouchCallback.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelTouchCallback.java
@@ -228,11 +228,12 @@ public abstract class EpoxyModelTouchCallback<T extends EpoxyModel>
     float clampedProgress = Math.max(-1f, Math.min(1f, swipeProgress));
 
     //noinspection unchecked
-    onSwipeProgressChanged((T) model, itemView, clampedProgress);
+    onSwipeProgressChanged((T) model, itemView, clampedProgress, c);
   }
 
   @Override
-  public void onSwipeProgressChanged(T model, View itemView, float swipeProgress) {
+  public void onSwipeProgressChanged(T model, View itemView, float swipeProgress,
+      Canvas canvas) {
 
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxySwipeCallback.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxySwipeCallback.java
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy;
 
+import android.graphics.Canvas;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.View;
 
@@ -30,10 +31,13 @@ public interface EpoxySwipeCallback<T extends EpoxyModel> extends BaseEpoxyTouch
    * @param itemView      The view that is being swiped
    * @param swipeProgress A float from -1 to 1 representing the percentage that the view has been
    *                      swiped relative to its width. This will be positive if the view is being
-   *                      swiped to the right and negative if it is swiped to the left. For example,
-   *                      if the view has been swiped halfway to the right this will be 0.5
+   *                      swiped to the right and negative if it is swiped to the left. For
+   *                      example,
+   * @param canvas        The canvas on which RecyclerView is drawing its children. You can draw to
+   *                      this to support custom swipe animations.
    */
-  void onSwipeProgressChanged(T model, View itemView, float swipeProgress);
+  void onSwipeProgressChanged(T model, View itemView, float swipeProgress,
+      Canvas canvas);
 
   /**
    * Called when the user has released their touch on the view. If the displacement passed the swipe

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyTouchHelper.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyTouchHelper.java
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy;
 
+import android.graphics.Canvas;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.View;
@@ -413,8 +414,9 @@ public abstract class EpoxyTouchHelper {
             }
 
             @Override
-            public void onSwipeProgressChanged(U model, View itemView, float swipeProgress) {
-              callbacks.onSwipeProgressChanged(model, itemView, swipeProgress);
+            public void onSwipeProgressChanged(U model, View itemView, float swipeProgress,
+                Canvas canvas) {
+              callbacks.onSwipeProgressChanged(model, itemView, swipeProgress, canvas);
             }
 
             @Override
@@ -448,7 +450,8 @@ public abstract class EpoxyTouchHelper {
     }
 
     @Override
-    public void onSwipeProgressChanged(T model, View itemView, float swipeProgress) {
+    public void onSwipeProgressChanged(T model, View itemView, float swipeProgress,
+        Canvas canvas) {
 
     }
 


### PR DESCRIPTION
This changes the `onSwipeProgressChanged` callback in EpoxyTouchHelper to take Canvas as a parameter. This will allows users to draw to the canvas to have more control in how the swipe is animated.

This is a breaking change to the touch helper API. I am ok with this because
1. It is fairly new and won't have much usage yet
2. This should be helpful to people
3. It is an easy change to make and probably won't have to be updated in many places