### PR TITLE
Allow ModelView usage without an xml layout

### DIFF
--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/ModelView.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/ModelView.java
@@ -17,6 +17,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 public @interface ModelView {
 
+  /**
+   * Use with {@link #autoLayout()} to declare what layout parameters should be used to size your
+   * view when it is added to a RecyclerView. This maps to the LayoutParams options {@code
+   * layout_width} and {@code layout_height}.
+   */
   enum Size {
     NONE,
     WRAP_WIDTH_WRAP_HEIGHT,
@@ -25,11 +30,20 @@ public @interface ModelView {
     MATCH_WIDTH_MATCH_HEIGHT
   }
 
+  /**
+   * If set to an option besides {@link Size#NONE} Epoxy will create an instance of this view
+   * programmatically at runtime instead of inflating the view from xml. This is an alternative to
+   * using {@link #defaultLayout()}, and is a good option if you just need to specify layout
+   * parameters on your view with no other styling.
+   * <p>
+   * The size option you choose will define which layout parameters Epoxy uses at runtime when
+   * creating the view.
+   */
   Size autoLayout() default Size.NONE;
 
   /**
    * The layout file to use in the generated model to inflate the view. This is required unless a
-   * default pattern is set via {@link PackageModelViewConfig}.
+   * default pattern is set via {@link PackageModelViewConfig} or {@link #autoLayout()} is used.
    * <p>
    * Overrides any default set in {@link PackageModelViewConfig}
    */

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/ModelView.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/ModelView.java
@@ -16,6 +16,17 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
 public @interface ModelView {
+
+  enum Size {
+    NONE,
+    WRAP_WIDTH_WRAP_HEIGHT,
+    WRAP_WIDTH_MATCH_HEIGHT,
+    MATCH_WIDTH_WRAP_HEIGHT,
+    MATCH_WIDTH_MATCH_HEIGHT
+  }
+
+  Size autoLayout() default Size.NONE;
+
   /**
    * The layout file to use in the generated model to inflate the view. This is required unless a
    * default pattern is set via {@link PackageModelViewConfig}.

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ClassNames.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ClassNames.java
@@ -19,6 +19,8 @@ final class ClassNames {
   static final ClassName ANDROID_CONTEXT = get(PKG_ANDROID_CONTENT, "Context");
   static final ClassName ANDROID_VIEW = get(PKG_ANDROID_VIEW, "View");
   static final ClassName ANDROID_VIEW_GROUP = get(PKG_ANDROID_VIEW, "ViewGroup");
+  static final ClassName ANDROID_MARGIN_LAYOUT_PARAMS =
+      get(PKG_ANDROID_VIEW, "ViewGroup", "MarginLayoutParams");
   static final ClassName ANDROID_R = get(PKG_ANDROID, "R");
 
   static final ClassName LITHO_COMPONENT = get(PKG_LITHO, "Component");

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
@@ -2,6 +2,7 @@ package com.airbnb.epoxy;
 
 import android.support.annotation.Nullable;
 
+import com.airbnb.epoxy.ModelView.Size;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -63,6 +64,8 @@ abstract class GeneratedModelInfo {
    * otherwise.
    */
   private ParisStyleAttributeInfo styleBuilderInfo;
+
+  Size layoutParams = Size.NONE;
 
   /**
    * Get information about methods returning class type of the original class so we can duplicate
@@ -204,10 +207,14 @@ abstract class GeneratedModelInfo {
     return getStyleBuilderInfo() != null;
   }
 
-  public void setStyleable(
+  void setStyleable(
       @NotNull ParisStyleAttributeInfo parisStyleAttributeInfo) {
     styleBuilderInfo = parisStyleAttributeInfo;
     addAttribute(parisStyleAttributeInfo);
+  }
+
+  boolean isProgrammaticView() {
+    return isStyleable() || layoutParams != Size.NONE;
   }
 
   static class ConstructorInfo {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
@@ -65,6 +65,10 @@ abstract class GeneratedModelInfo {
    */
   private ParisStyleAttributeInfo styleBuilderInfo;
 
+  /**
+   * An option set via {@link ModelView#autoLayout()} to have Epoxy create the view programmatically
+   * instead of via xml layout resource inflation.
+   */
   Size layoutParams = Size.NONE;
 
   /**

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -458,6 +458,7 @@ class GeneratedModelWriter {
         break;
       case WRAP_WIDTH_WRAP_HEIGHT:
       default:
+        // This will be used for Styleable views as the default
         layoutWidth = LAYOUT_PARAMS_WRAP_CONTENT;
         layoutHeight = LAYOUT_PARAMS_WRAP_CONTENT;
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -75,6 +75,11 @@ class GeneratedModelWriter {
   private static final String GET_DEFAULT_LAYOUT_METHOD_NAME = "getDefaultLayout";
   static final String ATTRIBUTES_BITSET_FIELD_NAME = "assignedAttributes" + GENERATED_FIELD_SUFFIX;
 
+  private static final CodeBlock LAYOUT_PARAMS_MATCH_PARENT =
+      CodeBlock.of("$T.MATCH_PARENT", ClassNames.ANDROID_MARGIN_LAYOUT_PARAMS);
+  private static final CodeBlock LAYOUT_PARAMS_WRAP_CONTENT =
+      CodeBlock.of("$T.WRAP_CONTENT", ClassNames.ANDROID_MARGIN_LAYOUT_PARAMS);
+
   private final Filer filer;
   private final Types typeUtils;
   private final ErrorLogger errorLogger;
@@ -151,6 +156,7 @@ class GeneratedModelWriter {
     generateDebugAddToMethodIfNeeded(builder, info);
 
     builder
+        .addMethods(generateProgrammaticViewMethods(info))
         .addMethods(generateBindMethods(info))
         .addMethods(generateStyleableViewMethods(info))
         .addMethods(generateSettersAndGetters(info))
@@ -175,7 +181,7 @@ class GeneratedModelWriter {
 
   private Iterable<MethodSpec> generateOtherLayoutOptions(GeneratedModelInfo info) {
     if (!info.includeOtherLayoutOptions
-        || info.isStyleable()) { // Layout resources can't be mixed with programmatic styles
+        || info.isProgrammaticView()) { // Layout resources can't be mixed with programmatic views
       return Collections.emptyList();
     }
 
@@ -410,6 +416,66 @@ class GeneratedModelWriter {
     return index;
   }
 
+  private Iterable<MethodSpec> generateProgrammaticViewMethods(GeneratedModelInfo modelInfo) {
+
+    if (!modelInfo.isProgrammaticView()) {
+      return Collections.emptyList();
+    }
+
+    List<MethodSpec> methods = new ArrayList<>();
+
+    // getViewType method so that view type is generated at runtime
+    methods.add(MethodSpec.methodBuilder("getViewType")
+        .addAnnotation(Override.class)
+        .addModifiers(PROTECTED)
+        .returns(TypeName.INT)
+        .addStatement("return 0", modelInfo.boundObjectTypeName)
+        .build());
+
+    // buildView method to return new view instance
+    Builder builder = MethodSpec.methodBuilder("buildView")
+        .addAnnotation(Override.class)
+        .addParameter(ClassNames.ANDROID_VIEW_GROUP, "parent")
+        .addModifiers(PROTECTED)
+        .returns(modelInfo.boundObjectTypeName)
+        .addStatement("$T v = new $T(parent.getContext())", modelInfo.boundObjectTypeName,
+            modelInfo.boundObjectTypeName);
+
+    CodeBlock layoutWidth;
+    CodeBlock layoutHeight;
+    switch (modelInfo.layoutParams) {
+      case WRAP_WIDTH_MATCH_HEIGHT:
+        layoutWidth = LAYOUT_PARAMS_WRAP_CONTENT;
+        layoutHeight = LAYOUT_PARAMS_MATCH_PARENT;
+        break;
+      case MATCH_WIDTH_MATCH_HEIGHT:
+        layoutWidth = LAYOUT_PARAMS_MATCH_PARENT;
+        layoutHeight = LAYOUT_PARAMS_MATCH_PARENT;
+        break;
+      case MATCH_WIDTH_WRAP_HEIGHT:
+        layoutWidth = LAYOUT_PARAMS_MATCH_PARENT;
+        layoutHeight = LAYOUT_PARAMS_WRAP_CONTENT;
+        break;
+      case WRAP_WIDTH_WRAP_HEIGHT:
+      default:
+        layoutWidth = LAYOUT_PARAMS_WRAP_CONTENT;
+        layoutHeight = LAYOUT_PARAMS_WRAP_CONTENT;
+    }
+
+    builder
+        .addStatement("v.setLayoutParams(new $T($L, $L))",
+            ClassNames.ANDROID_MARGIN_LAYOUT_PARAMS, layoutWidth, layoutHeight);
+
+    ParisStyleAttributeInfo styleBuilderInfo = modelInfo.getStyleBuilderInfo();
+    if (styleBuilderInfo != null) {
+      addStyleApplierCode(builder, styleBuilderInfo, "v");
+    }
+
+    methods.add(builder.addStatement("return v").build());
+
+    return methods;
+  }
+
   private Iterable<MethodSpec> generateBindMethods(GeneratedModelInfo classInfo) {
     List<MethodSpec> methods = new ArrayList<>();
 
@@ -600,28 +666,6 @@ class GeneratedModelWriter {
     TypeName styleType = styleBuilderInfo.getTypeName();
     ClassName styleBuilderClass = styleBuilderInfo.getStyleBuilderClass();
 
-    // buildView method to return new view instance
-    Builder buildViewMethodBuilder = MethodSpec.methodBuilder("buildView")
-        .addAnnotation(Override.class)
-        .addParameter(ClassNames.ANDROID_VIEW_GROUP, "parent")
-        .addModifiers(PROTECTED)
-        .returns(modelInfo.boundObjectTypeName)
-        .addStatement("$T v = new $T(parent.getContext())", modelInfo.boundObjectTypeName,
-            modelInfo.boundObjectTypeName)
-        .addStatement("v.setLayoutParams(parent.generateLayoutParams(null))");
-
-    addStyleApplierCode(buildViewMethodBuilder, styleBuilderInfo, "v");
-    buildViewMethodBuilder.addStatement("return v");
-    methods.add(buildViewMethodBuilder.build());
-
-    // getViewType method so that view type is generated at runtime
-    methods.add(MethodSpec.methodBuilder("getViewType")
-        .addAnnotation(Override.class)
-        .addModifiers(PROTECTED)
-        .returns(TypeName.INT)
-        .addStatement("return 0", modelInfo.boundObjectTypeName)
-        .build());
-
     // setter for style object
     Builder builder = MethodSpec.methodBuilder(PARIS_STYLE_ATTR_NAME)
         .addModifiers(PUBLIC)
@@ -684,13 +728,14 @@ class GeneratedModelWriter {
           .varargs(methodInfo.varargs)
           .returns(info.getParameterizedGeneratedName());
 
-      if (info.isStyleable()
+      if (info.isProgrammaticView()
           && "layout".equals(methodInfo.name)
           && methodInfo.params.size() == 1
           && methodInfo.params.get(0).type == TypeName.INT) {
 
         builder
-            .addStatement("throw new $T(\"Layout resources are unsupported in @Styleable views.\")",
+            .addStatement(
+                "throw new $T(\"Layout resources are unsupported with programmatic views.\")",
                 UnsupportedOperationException.class);
       } else {
 
@@ -716,10 +761,12 @@ class GeneratedModelWriter {
   private Iterable<MethodSpec> generateDefaultMethodImplementations(GeneratedModelInfo info) {
     List<MethodSpec> methods = new ArrayList<>();
 
-    if (info.isStyleable()) {
+    if (info.isProgrammaticView()) {
       methods.add(buildDefaultLayoutMethodBase()
           .toBuilder()
-          .addStatement("throw new $T(\"Layout resources are unsupported in @Styleable views\")",
+          .addStatement(
+              "throw new $T(\"Layout resources are unsupported for views created programmatically"
+                  + ".\")",
               UnsupportedOperationException.class)
           .build());
     } else {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.java
@@ -60,6 +60,7 @@ class ModelViewInfo extends GeneratedModelInfo {
     boundObjectTypeName = ClassName.get(viewElement.asType());
 
     saveViewState = viewAnnotation.saveViewState();
+    layoutParams = viewAnnotation.autoLayout();
     fullSpanSize = viewAnnotation.fullSpan();
     includeOtherLayoutOptions = configManager.includeAlternateLayoutsForViews(viewElement);
   }

--- a/epoxy-processortest/src/test/java/com/airbnb/epoxy/ViewProcessorTest.java
+++ b/epoxy-processortest/src/test/java/com/airbnb/epoxy/ViewProcessorTest.java
@@ -700,4 +700,14 @@ public class ViewProcessorTest {
   public void testModelBuilderInterface() {
     assertGeneration("TestManyTypesView.java", "TestManyTypesViewModelBuilder.java");
   }
+
+  @Test
+  public void testAutoLayout() {
+    assertGeneration("AutoLayoutModelView.java", "AutoLayoutModelViewModel_.java");
+  }
+
+  @Test
+  public void testAutoLayoutMatchParent() {
+    assertGeneration("AutoLayoutModelViewMatchParent.java", "AutoLayoutModelViewMatchParentModel_.java");
+  }
 }

--- a/epoxy-processortest/src/test/resources/AutoLayoutModelView.java
+++ b/epoxy-processortest/src/test/resources/AutoLayoutModelView.java
@@ -1,0 +1,17 @@
+package com.airbnb.epoxy;
+
+import android.content.Context;
+import android.view.View;
+
+@ModelView(autoLayout = ModelView.Size.WRAP_WIDTH_WRAP_HEIGHT)
+public class AutoLayoutModelView extends View {
+
+  public AutoLayoutModelView(Context context) {
+    super(context);
+  }
+
+  @ModelProp
+  void setValue(int value) {
+
+  }
+}

--- a/epoxy-processortest/src/test/resources/AutoLayoutModelViewMatchParent.java
+++ b/epoxy-processortest/src/test/resources/AutoLayoutModelViewMatchParent.java
@@ -1,0 +1,19 @@
+package com.airbnb.epoxy;
+
+import android.content.Context;
+import android.view.View;
+
+import com.airbnb.epoxy.ModelView.Size;
+
+@ModelView(autoLayout = Size.MATCH_WIDTH_MATCH_HEIGHT)
+public class AutoLayoutModelViewMatchParent extends View {
+
+  public AutoLayoutModelViewMatchParent(Context context) {
+    super(context);
+  }
+
+  @ModelProp
+  void setValue(int value) {
+
+  }
+}

--- a/epoxy-processortest/src/test/resources/AutoLayoutModelViewMatchParentModel_.java
+++ b/epoxy-processortest/src/test/resources/AutoLayoutModelViewMatchParentModel_.java
@@ -1,0 +1,254 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.view.ViewGroup;
+import java.lang.CharSequence;
+import java.lang.Number;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.UnsupportedOperationException;
+import java.util.BitSet;
+
+/**
+ * Generated file. Do not modify! */
+public class AutoLayoutModelViewMatchParentModel_ extends EpoxyModel<AutoLayoutModelViewMatchParent> implements GeneratedModel<AutoLayoutModelViewMatchParent>, AutoLayoutModelViewMatchParentModelBuilder {
+  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
+
+  private OnModelBoundListener<AutoLayoutModelViewMatchParentModel_, AutoLayoutModelViewMatchParent> onModelBoundListener_epoxyGeneratedModel;
+
+  private OnModelUnboundListener<AutoLayoutModelViewMatchParentModel_, AutoLayoutModelViewMatchParent> onModelUnboundListener_epoxyGeneratedModel;
+
+  /**
+   * Bitset index: 0 */
+  private int value_Int = 0;
+
+  @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
+  protected int getViewType() {
+    return 0;
+  }
+
+  @Override
+  protected AutoLayoutModelViewMatchParent buildView(ViewGroup parent) {
+    AutoLayoutModelViewMatchParent v = new AutoLayoutModelViewMatchParent(parent.getContext());
+    v.setLayoutParams(new ViewGroup.MarginLayoutParams(ViewGroup.MarginLayoutParams.MATCH_PARENT, ViewGroup.MarginLayoutParams.MATCH_PARENT));
+    return v;
+  }
+
+  @Override
+  public void handlePreBind(final EpoxyViewHolder holder,
+      final AutoLayoutModelViewMatchParent object, int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
+  }
+
+  @Override
+  public void bind(final AutoLayoutModelViewMatchParent object) {
+    super.bind(object);
+    object.setValue(value_Int);
+  }
+
+  @Override
+  public void bind(final AutoLayoutModelViewMatchParent object, EpoxyModel previousModel) {
+    if (!(previousModel instanceof AutoLayoutModelViewMatchParentModel_)) {
+      bind(object);
+      return;
+    }
+    AutoLayoutModelViewMatchParentModel_ that = (AutoLayoutModelViewMatchParentModel_) previousModel;
+    super.bind(object);
+
+    if (value_Int != that.value_Int) {
+      object.setValue(value_Int);
+    }
+  }
+
+  @Override
+  public void handlePostBind(final AutoLayoutModelViewMatchParent object, int position) {
+    if (onModelBoundListener_epoxyGeneratedModel != null) {
+      onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
+    }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
+  }
+
+  /**
+   * Register a listener that will be called when this model is bound to a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public AutoLayoutModelViewMatchParentModel_ onBind(OnModelBoundListener<AutoLayoutModelViewMatchParentModel_, AutoLayoutModelViewMatchParent> listener) {
+    onMutation();
+    this.onModelBoundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  @Override
+  public void unbind(AutoLayoutModelViewMatchParent object) {
+    super.unbind(object);
+    if (onModelUnboundListener_epoxyGeneratedModel != null) {
+      onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
+    }
+  }
+
+  /**
+   * Register a listener that will be called when this model is unbound from a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public AutoLayoutModelViewMatchParentModel_ onUnbind(OnModelUnboundListener<AutoLayoutModelViewMatchParentModel_, AutoLayoutModelViewMatchParent> listener) {
+    onMutation();
+    this.onModelUnboundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  /**
+   * <i>Optional</i>: Default value is 0
+   *
+   * @see AutoLayoutModelViewMatchParent#setValue(int)
+   */
+  public AutoLayoutModelViewMatchParentModel_ value(int value) {
+    assignedAttributes_epoxyGeneratedModel.set(0);
+    onMutation();
+    this.value_Int = value;
+    return this;
+  }
+
+  public int value() {
+    return value_Int;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ id(Number... ids) {
+    super.id(ids);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ id(long id1, long id2) {
+    super.id(id1, id2);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ id(CharSequence key, CharSequence... otherKeys) {
+    super.id(key, otherKeys);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ id(CharSequence key, long id) {
+    super.id(key, id);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ layout(@LayoutRes int arg0) {
+    throw new UnsupportedOperationException("Layout resources are unsupported with programmatic views.");
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ spanSizeOverride(@Nullable EpoxyModel.SpanSizeOverrideCallback arg0) {
+    super.spanSizeOverride(arg0);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  @LayoutRes
+  protected int getDefaultLayout() {
+    throw new UnsupportedOperationException("Layout resources are unsupported for views created programmatically.");
+  }
+
+  @Override
+  public AutoLayoutModelViewMatchParentModel_ reset() {
+    onModelBoundListener_epoxyGeneratedModel = null;
+    onModelUnboundListener_epoxyGeneratedModel = null;
+    assignedAttributes_epoxyGeneratedModel.clear();
+    this.value_Int = 0;
+    super.reset();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof AutoLayoutModelViewMatchParentModel_)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    AutoLayoutModelViewMatchParentModel_ that = (AutoLayoutModelViewMatchParentModel_) o;
+    if ((onModelBoundListener_epoxyGeneratedModel == null) != (that.onModelBoundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if ((onModelUnboundListener_epoxyGeneratedModel == null) != (that.onModelUnboundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if (value_Int != that.value_Int) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (onModelBoundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + (onModelUnboundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + value_Int;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "AutoLayoutModelViewMatchParentModel_{" +
+        "value_Int=" + value_Int +
+        "}" + super.toString();
+  }
+
+  @Override
+  public int getSpanSize(int totalSpanCount, int position, int itemCount) {
+    return totalSpanCount;
+  }
+}

--- a/epoxy-processortest/src/test/resources/AutoLayoutModelViewModel_.java
+++ b/epoxy-processortest/src/test/resources/AutoLayoutModelViewModel_.java
@@ -1,0 +1,254 @@
+package com.airbnb.epoxy;
+
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.view.ViewGroup;
+import java.lang.CharSequence;
+import java.lang.Number;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.lang.UnsupportedOperationException;
+import java.util.BitSet;
+
+/**
+ * Generated file. Do not modify! */
+public class AutoLayoutModelViewModel_ extends EpoxyModel<AutoLayoutModelView> implements GeneratedModel<AutoLayoutModelView>, AutoLayoutModelViewModelBuilder {
+  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
+
+  private OnModelBoundListener<AutoLayoutModelViewModel_, AutoLayoutModelView> onModelBoundListener_epoxyGeneratedModel;
+
+  private OnModelUnboundListener<AutoLayoutModelViewModel_, AutoLayoutModelView> onModelUnboundListener_epoxyGeneratedModel;
+
+  /**
+   * Bitset index: 0 */
+  private int value_Int = 0;
+
+  @Override
+  public void addTo(EpoxyController controller) {
+    super.addTo(controller);
+    addWithDebugValidation(controller);
+  }
+
+  @Override
+  protected int getViewType() {
+    return 0;
+  }
+
+  @Override
+  protected AutoLayoutModelView buildView(ViewGroup parent) {
+    AutoLayoutModelView v = new AutoLayoutModelView(parent.getContext());
+    v.setLayoutParams(new ViewGroup.MarginLayoutParams(ViewGroup.MarginLayoutParams.WRAP_CONTENT, ViewGroup.MarginLayoutParams.WRAP_CONTENT));
+    return v;
+  }
+
+  @Override
+  public void handlePreBind(final EpoxyViewHolder holder, final AutoLayoutModelView object,
+      int position) {
+    validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
+  }
+
+  @Override
+  public void bind(final AutoLayoutModelView object) {
+    super.bind(object);
+    object.setValue(value_Int);
+  }
+
+  @Override
+  public void bind(final AutoLayoutModelView object, EpoxyModel previousModel) {
+    if (!(previousModel instanceof AutoLayoutModelViewModel_)) {
+      bind(object);
+      return;
+    }
+    AutoLayoutModelViewModel_ that = (AutoLayoutModelViewModel_) previousModel;
+    super.bind(object);
+
+    if (value_Int != that.value_Int) {
+      object.setValue(value_Int);
+    }
+  }
+
+  @Override
+  public void handlePostBind(final AutoLayoutModelView object, int position) {
+    if (onModelBoundListener_epoxyGeneratedModel != null) {
+      onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
+    }
+    validateStateHasNotChangedSinceAdded("The model was changed during the bind call.", position);
+  }
+
+  /**
+   * Register a listener that will be called when this model is bound to a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public AutoLayoutModelViewModel_ onBind(OnModelBoundListener<AutoLayoutModelViewModel_, AutoLayoutModelView> listener) {
+    onMutation();
+    this.onModelBoundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  @Override
+  public void unbind(AutoLayoutModelView object) {
+    super.unbind(object);
+    if (onModelUnboundListener_epoxyGeneratedModel != null) {
+      onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
+    }
+  }
+
+  /**
+   * Register a listener that will be called when this model is unbound from a view.
+   * <p>
+   * The listener will contribute to this model's hashCode state per the {@link
+   * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
+   * <p>
+   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+  public AutoLayoutModelViewModel_ onUnbind(OnModelUnboundListener<AutoLayoutModelViewModel_, AutoLayoutModelView> listener) {
+    onMutation();
+    this.onModelUnboundListener_epoxyGeneratedModel = listener;
+    return this;
+  }
+
+  /**
+   * <i>Optional</i>: Default value is 0
+   *
+   * @see AutoLayoutModelView#setValue(int)
+   */
+  public AutoLayoutModelViewModel_ value(int value) {
+    assignedAttributes_epoxyGeneratedModel.set(0);
+    onMutation();
+    this.value_Int = value;
+    return this;
+  }
+
+  public int value() {
+    return value_Int;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ id(long id) {
+    super.id(id);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ id(Number... ids) {
+    super.id(ids);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ id(long id1, long id2) {
+    super.id(id1, id2);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ id(CharSequence key) {
+    super.id(key);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ id(CharSequence key, CharSequence... otherKeys) {
+    super.id(key, otherKeys);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ id(CharSequence key, long id) {
+    super.id(key, id);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ layout(@LayoutRes int arg0) {
+    throw new UnsupportedOperationException("Layout resources are unsupported with programmatic views.");
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ spanSizeOverride(@Nullable EpoxyModel.SpanSizeOverrideCallback arg0) {
+    super.spanSizeOverride(arg0);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ show() {
+    super.show();
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ show(boolean show) {
+    super.show(show);
+    return this;
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ hide() {
+    super.hide();
+    return this;
+  }
+
+  @Override
+  @LayoutRes
+  protected int getDefaultLayout() {
+    throw new UnsupportedOperationException("Layout resources are unsupported for views created programmatically.");
+  }
+
+  @Override
+  public AutoLayoutModelViewModel_ reset() {
+    onModelBoundListener_epoxyGeneratedModel = null;
+    onModelUnboundListener_epoxyGeneratedModel = null;
+    assignedAttributes_epoxyGeneratedModel.clear();
+    this.value_Int = 0;
+    super.reset();
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof AutoLayoutModelViewModel_)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    AutoLayoutModelViewModel_ that = (AutoLayoutModelViewModel_) o;
+    if ((onModelBoundListener_epoxyGeneratedModel == null) != (that.onModelBoundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if ((onModelUnboundListener_epoxyGeneratedModel == null) != (that.onModelUnboundListener_epoxyGeneratedModel == null)) {
+      return false;
+    }
+    if (value_Int != that.value_Int) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (onModelBoundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + (onModelUnboundListener_epoxyGeneratedModel != null ? 1 : 0);
+    result = 31 * result + value_Int;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "AutoLayoutModelViewModel_{" +
+        "value_Int=" + value_Int +
+        "}" + super.toString();
+  }
+
+  @Override
+  public int getSpanSize(int totalSpanCount, int position, int itemCount) {
+    return totalSpanCount;
+  }
+}

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/HeaderView.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/HeaderView.java
@@ -1,7 +1,6 @@
 package com.airbnb.epoxy.sample.views;
 
 import android.content.Context;
-import android.util.AttributeSet;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -20,11 +19,6 @@ public class HeaderView extends LinearLayout {
 
   @BindView(R.id.title_text) TextView title;
   @BindView(R.id.caption_text) TextView caption;
-
-  public HeaderView(Context context, AttributeSet attrs) {
-    super(context, attrs);
-    init();
-  }
 
   public HeaderView(Context context) {
     super(context);

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/HeaderView.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/HeaderView.java
@@ -8,13 +8,14 @@ import android.widget.TextView;
 import com.airbnb.epoxy.ModelProp;
 import com.airbnb.epoxy.ModelProp.Option;
 import com.airbnb.epoxy.ModelView;
+import com.airbnb.epoxy.ModelView.Size;
 import com.airbnb.epoxy.R;
 import com.airbnb.epoxy.TextProp;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
-@ModelView
+@ModelView(autoLayout = Size.WRAP_WIDTH_WRAP_HEIGHT)
 public class HeaderView extends LinearLayout {
 
   @BindView(R.id.title_text) TextView title;
@@ -22,6 +23,11 @@ public class HeaderView extends LinearLayout {
 
   public HeaderView(Context context, AttributeSet attrs) {
     super(context, attrs);
+    init();
+  }
+
+  public HeaderView(Context context) {
+    super(context);
     init();
   }
 

--- a/epoxy-sample/src/main/res/layout/header_view.xml
+++ b/epoxy-sample/src/main/res/layout/header_view.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<com.airbnb.epoxy.sample.views.HeaderView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:minHeight="120dp" />


### PR DESCRIPTION
Instead of needing to create an xml layout for each `@ModelView` view, you can use the `@ModelView( autoLayout = Size. ...)` param to specify what layout params you want for your view.

Epoxy will then programmatically create the view and the layout params for you.

Looking for feedback on naming, if this seems good I will flesh out comments and tests.

There were a couple different approaches we could take here, I chose a simple path with just one param so that it is very quick and easy to set this up. I figure that if anybody wants more control with exact sizing they can use an xml file. 

Also, we will be releasing more powerful dynamic styling support soon which will also help with the more complex cases, and given that it seems nice to keep one very simple approach.