### PR TITLE
Do paris validations in background

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -15,7 +15,7 @@ rootProject.ext.COMPILE_SDK_VERSION = 25
 rootProject.ext.MIN_SDK_VERSION = 14
 rootProject.ext.MIN_SDK_VERSION_LITHO = 15
 
-rootProject.ext.ANDROID_BUILD_TOOLS_VERSION = "25.0.2"
+rootProject.ext.ANDROID_BUILD_TOOLS_VERSION = "26.0.2"
 rootProject.ext.ANDROID_SUPPORT_LIBS_VERSION = "25.3.1"
 rootProject.ext.ANDROID_DATA_BINDING = "1.3.1"
 rootProject.ext.BUTTERKNIFE_VERSION = "8.5.1"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
 
   ext.KOTLIN_VERSION = "1.1.50"
-  ext.ANDROID_PLUGIN_VERSION = "3.0.0-beta6"
+  ext.ANDROID_PLUGIN_VERSION = "3.0.0-beta7"
 
   repositories {
     google()

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ClassNames.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ClassNames.java
@@ -15,10 +15,12 @@ final class ClassNames {
   private static final String PKG_ANDROID = "android";
   private static final String PKG_ANDROID_CONTENT = "android.content";
   private static final String PKG_ANDROID_VIEW = "android.view";
+  private static final String PKG_ANDROID_OS = "android.os";
 
   static final ClassName ANDROID_CONTEXT = get(PKG_ANDROID_CONTENT, "Context");
   static final ClassName ANDROID_VIEW = get(PKG_ANDROID_VIEW, "View");
   static final ClassName ANDROID_VIEW_GROUP = get(PKG_ANDROID_VIEW, "ViewGroup");
+  static final ClassName ANDROID_ASYNC_TASK = get(PKG_ANDROID_OS, "AsyncTask");
   static final ClassName ANDROID_MARGIN_LAYOUT_PARAMS =
       get(PKG_ANDROID_VIEW, "ViewGroup", "MarginLayoutParams");
   static final ClassName ANDROID_R = get(PKG_ANDROID, "R");

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -32,6 +32,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import static com.airbnb.epoxy.ClassNames.ANDROID_ASYNC_TASK;
 import static com.airbnb.epoxy.ModelViewWriterKt.addStyleApplierCode;
 import static com.airbnb.epoxy.ParisStyleAttributeInfoKt.PARIS_DEFAULT_STYLE_CONSTANT_NAME;
 import static com.airbnb.epoxy.ParisStyleAttributeInfoKt.PARIS_STYLE_ATTR_NAME;
@@ -623,8 +624,16 @@ class GeneratedModelWriter {
         "The model was changed between being added to the controller and being bound.");
 
     if (modelInfo.isStyleable() && configManager.shouldValidateModelUsage()) {
-      preBindBuilder.beginControlFlow("try")
 
+      // We validate that the style attributes are the same as in the default, otherwise
+      // recycling will not work correctly. It is done in the background since it is fairly slow
+      // and can noticeably add jank to scrolling in dev
+      preBindBuilder
+          .beginControlFlow("new $T<$T, $T, $T>()", ANDROID_ASYNC_TASK, Void.class, Void.class,
+              Void.class)
+          .addCode("@$T\n", Override.class)
+          .beginControlFlow("protected $T doInBackground($T... voids)", Void.class, Void.class)
+          .beginControlFlow("try")
           .addStatement("$T.assertSameAttributes(new $T($L), $L, $L)",
               ClassNames.PARIS_STYLE_UTILS, modelInfo.getStyleBuilderInfo().getStyleApplierClass(),
               boundObjectParam.name, PARIS_STYLE_ATTR_NAME, PARIS_DEFAULT_STYLE_CONSTANT_NAME)
@@ -635,7 +644,11 @@ class GeneratedModelWriter {
                   + ".getMessage())",
               IllegalStateException.class, modelInfo.generatedClassName.simpleName(),
               positionParamName)
-          .endControlFlow();
+          .endControlFlow()
+          .addStatement("return null")
+          .endControlFlow()
+          .endControlFlow()
+          .addStatement(".executeOnExecutor($T.THREAD_POOL_EXECUTOR)", ANDROID_ASYNC_TASK);
     }
 
     ClassName clickWrapperType = getClassName(WRAPPED_LISTENER_TYPE);

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -629,10 +629,9 @@ class GeneratedModelWriter {
       // recycling will not work correctly. It is done in the background since it is fairly slow
       // and can noticeably add jank to scrolling in dev
       preBindBuilder
-          .beginControlFlow("new $T<$T, $T, $T>()", ANDROID_ASYNC_TASK, Void.class, Void.class,
-              Void.class)
-          .addCode("@$T\n", Override.class)
-          .beginControlFlow("protected $T doInBackground($T... voids)", Void.class, Void.class)
+          .beginControlFlow("$T.THREAD_POOL_EXECUTOR.execute(new $T()", ANDROID_ASYNC_TASK,
+              Runnable.class)
+          .beginControlFlow("public void run()")
           .beginControlFlow("try")
           .addStatement("$T.assertSameAttributes(new $T($L), $L, $L)",
               ClassNames.PARIS_STYLE_UTILS, modelInfo.getStyleBuilderInfo().getStyleApplierClass(),
@@ -645,10 +644,8 @@ class GeneratedModelWriter {
               IllegalStateException.class, modelInfo.generatedClassName.simpleName(),
               positionParamName)
           .endControlFlow()
-          .addStatement("return null")
           .endControlFlow()
-          .endControlFlow()
-          .addStatement(".executeOnExecutor($T.THREAD_POOL_EXECUTOR)", ANDROID_ASYNC_TASK);
+          .endControlFlow(")");
     }
 
     ClassName clickWrapperType = getClassName(WRAPPED_LISTENER_TYPE);


### PR DESCRIPTION
Moves the style validation to an async task like so
```
new AsyncTask<Void, Void, Void>() {
      @Override
      protected Void doInBackground(Void... voids) {
        try {
          StyleApplierUtils.Companion.assertSameAttributes(new HeaderViewStyleApplier(object), style, DEFAULT_PARIS_STYLE);
        }
        catch(AssertionError e) {
          throw new IllegalStateException("HeaderViewModel_ model at position " + position + " has an invalid style:\n\n" + e.getMessage());
        }
        return null;
      }
    }
    .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
```

even though this is only done in debug builds it can still noticeably slow down scroll performance, so hopefully this will be better.