### PR TITLE
Improve kotlin extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-25.0.2
-  - android-25
+  - build-tools-26.0.2
+  - android-26
   - extra-google-google_play_services
   - extra-android-m2repository
   - extra-android-support

--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -10,8 +10,8 @@
 rootProject.ext.JAVA_SOURCE_VERSION = JavaVersion.VERSION_1_7
 rootProject.ext.JAVA_TARGET_VERSION = JavaVersion.VERSION_1_7
 
-rootProject.ext.TARGET_SDK_VERSION = 25
-rootProject.ext.COMPILE_SDK_VERSION = 25
+rootProject.ext.TARGET_SDK_VERSION = 26
+rootProject.ext.COMPILE_SDK_VERSION = 26
 rootProject.ext.MIN_SDK_VERSION = 14
 rootProject.ext.MIN_SDK_VERSION_LITHO = 15
 

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelWithConstructors.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelWithConstructors.java
@@ -1,0 +1,30 @@
+package com.airbnb.epoxy.integrationtest;
+
+import android.widget.TextView;
+
+import com.airbnb.epoxy.EpoxyAttribute;
+import com.airbnb.epoxy.EpoxyModel;
+import com.airbnb.epoxy.EpoxyModelClass;
+
+@EpoxyModelClass
+public abstract class ModelWithConstructors extends EpoxyModel<TextView> {
+  @EpoxyAttribute public int value;
+
+  public ModelWithConstructors(long id, int value) {
+    super(id);
+    this.value = value;
+  }
+
+  public ModelWithConstructors(int value) {
+    this.value = value;
+  }
+
+  public ModelWithConstructors(long id) {
+    super(id);
+  }
+
+  @Override
+  protected int getDefaultLayout() {
+    return R.layout.model_with_click_listener;
+  }
+}

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelBuilderExtensionIntegrationTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelBuilderExtensionIntegrationTest.kt
@@ -12,15 +12,25 @@ import org.robolectric.annotation.*
 class ModelBuilderExtensionIntegrationTest {
 
     @Test
-    fun basicAutoModels() {
+    fun generatedExtensionFunction() {
         Controller().run {
             requestModelBuild()
 
-            assertEquals(adapter.copyOfModels.size, 1)
-
             val model = adapter.copyOfModels.first() as Model
             assertEquals(model.value, 5)
-            assertEquals(model.id(), 10)
+            assertEquals(model.id(), 1)
+        }
+
+    }
+
+    @Test
+    fun modelsWithConstructors() {
+        Controller().run {
+            requestModelBuild()
+
+            val model = adapter.copyOfModels.get(1) as ModelWithConstructors
+            assertEquals(model.value, 10)
+            assertEquals(model.id(), 2)
         }
 
     }
@@ -29,9 +39,11 @@ class ModelBuilderExtensionIntegrationTest {
 private class Controller : EpoxyController() {
     override fun buildModels() {
         model {
-            id(10)
+            id(1)
             value(5)
         }
+
+        modelWithConstructors(value = 10, id = 2) { }
     }
 
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ConfigManager.java
@@ -27,6 +27,8 @@ class ConfigManager {
   static final String PROCESSOR_OPTION_REQUIRE_HASHCODE = "requireHashCodeInEpoxyModels";
   static final String PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS = "requireAbstractEpoxyModels";
   static final String PROCESSOR_OPTION_IMPLICITLY_ADD_AUTO_MODELS = "implicitlyAddAutoModels";
+  static final String PROCESSOR_OPTION_DISABLE_KOTLIN_EXTENSION_GENERATION =
+      "disableEpoxyKotlinExtensionGeneration";
 
   private static final PackageConfigSettings
       DEFAULT_PACKAGE_CONFIG_SETTINGS = PackageConfigSettings.Companion.forDefaults();
@@ -37,6 +39,7 @@ class ConfigManager {
   private final boolean globalRequireHashCode;
   private final boolean globalRequireAbstractModels;
   private final boolean globalImplicitlyAddAutoModels;
+  private final boolean disableKotlinExtensionGeneration;
   private final Types typeUtils;
 
   ConfigManager(Map<String, String> options, Elements elementUtils, Types typeUtils) {
@@ -53,6 +56,10 @@ class ConfigManager {
     globalImplicitlyAddAutoModels =
         getBooleanOption(options, PROCESSOR_OPTION_IMPLICITLY_ADD_AUTO_MODELS,
             PackageEpoxyConfig.IMPLICITLY_ADD_AUTO_MODELS_DEFAULT);
+
+    disableKotlinExtensionGeneration =
+        getBooleanOption(options, PROCESSOR_OPTION_DISABLE_KOTLIN_EXTENSION_GENERATION, false);
+
     this.typeUtils = typeUtils;
   }
 
@@ -152,6 +159,10 @@ class ConfigManager {
     return globalImplicitlyAddAutoModels
         || getConfigurationForElement(controller.getControllerClassElement())
         .getImplicitlyAddAutoModels();
+  }
+
+  boolean disableKotlinExtensionGeneration() {
+    return disableKotlinExtensionGeneration;
   }
 
   boolean shouldValidateModelUsage() {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -23,6 +23,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import static com.airbnb.epoxy.ConfigManager.PROCESSOR_OPTION_DISABLE_KOTLIN_EXTENSION_GENERATION;
 import static com.airbnb.epoxy.ConfigManager.PROCESSOR_OPTION_IMPLICITLY_ADD_AUTO_MODELS;
 import static com.airbnb.epoxy.ConfigManager.PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS;
 import static com.airbnb.epoxy.ConfigManager.PROCESSOR_OPTION_REQUIRE_HASHCODE;
@@ -42,6 +43,7 @@ import static com.airbnb.epoxy.EpoxyProcessor.KAPT_KOTLIN_GENERATED_OPTION_NAME;
     PROCESSOR_OPTION_VALIDATE_MODEL_USAGE,
     PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS,
     PROCESSOR_OPTION_REQUIRE_HASHCODE,
+    PROCESSOR_OPTION_DISABLE_KOTLIN_EXTENSION_GENERATION,
     KAPT_KOTLIN_GENERATED_OPTION_NAME
 })
 public class EpoxyProcessor extends AbstractProcessor {
@@ -202,7 +204,7 @@ public class EpoxyProcessor extends AbstractProcessor {
     }
 
     // TODO: (eli_hart 8/23/17) don't wait until round over?
-    if (roundEnv.processingOver()) {
+    if (roundEnv.processingOver() && !configManager.disableKotlinExtensionGeneration()) {
       kotlinExtensionWriter.generateExtensionsForModels(generatedModels);
     }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelInfo.java
@@ -163,10 +163,6 @@ abstract class GeneratedModelInfo {
     return superClassName;
   }
 
-  List<ConstructorInfo> getConstructors() {
-    return constructors;
-  }
-
   Set<MethodInfo> getMethodsReturningClassType() {
     return methodsReturningClassType;
   }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.java
@@ -344,9 +344,9 @@ class GeneratedModelWriter {
 
   /** Include any constructors that are in the super class. */
   private Iterable<MethodSpec> generateConstructors(GeneratedModelInfo info) {
-    List<MethodSpec> constructors = new ArrayList<>(info.getConstructors().size());
+    List<MethodSpec> constructors = new ArrayList<>(info.constructors.size());
 
-    for (GeneratedModelInfo.ConstructorInfo constructorInfo : info.getConstructors()) {
+    for (GeneratedModelInfo.ConstructorInfo constructorInfo : info.constructors) {
       Builder builder = MethodSpec.constructorBuilder()
           .addModifiers(constructorInfo.modifiers)
           .addParameters(constructorInfo.params)

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/PoetExtensions.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/PoetExtensions.kt
@@ -1,5 +1,8 @@
 package com.airbnb.epoxy
 
+import com.squareup.kotlinpoet.*
+import javax.lang.model.element.*
+
 typealias JavaClassName = com.squareup.javapoet.ClassName
 typealias JavaTypeName = com.squareup.javapoet.TypeName
 typealias JavaWildcardTypeName = com.squareup.javapoet.WildcardTypeName
@@ -53,6 +56,16 @@ fun JavaTypeVariableName.toKPoet()
         *bounds.toKPoet().toTypedArray())
 
 fun JavaTypeName.toKPoet(): KotlinTypeName = when (this) {
+    JavaTypeName.BOOLEAN -> BOOLEAN
+    JavaTypeName.BYTE -> BYTE
+    JavaTypeName.SHORT -> SHORT
+    JavaTypeName.CHAR -> CHAR
+    JavaTypeName.INT -> INT
+    JavaTypeName.LONG -> LONG
+    JavaTypeName.FLOAT -> FLOAT
+    JavaTypeName.DOUBLE -> DOUBLE
+    JavaTypeName.OBJECT -> ANY
+    JavaTypeName.VOID -> UNIT
     is JavaClassName -> toKPoet()
     is JavaParametrizedTypeName -> toKPoet()
     is JavaArrayTypeName -> toKPoet()
@@ -62,3 +75,25 @@ fun JavaTypeName.toKPoet(): KotlinTypeName = when (this) {
 }
 
 fun <T : JavaTypeName> Iterable<T>.toKPoet() = map { it.toKPoet() }
+
+fun JavaParameterSpec.toKPoet(): KotlinParameterSpec
+        = KotlinParameterSpec.builder(
+        name,
+        type.toKPoet(),
+        *modifiers.toKModifier().toTypedArray()
+).build()
+
+fun Iterable<JavaParameterSpec>.toKParams() = map { it.toKPoet() }
+
+fun Iterable<Modifier>.toKModifier(): List<KModifier> =
+        map { it.toKModifier() }.filter { it != null }.map { it!! }
+
+fun Modifier.toKModifier() = when (this) {
+    Modifier.PUBLIC -> KModifier.PUBLIC
+    Modifier.PRIVATE -> KModifier.PRIVATE
+    Modifier.PROTECTED -> KModifier.PROTECTED
+    Modifier.FINAL -> KModifier.FINAL
+    Modifier.ABSTRACT -> KModifier.ABSTRACT
+    else -> null
+}
+


### PR DESCRIPTION
This adds an annotation processor option `disableEpoxyKotlinExtensionGeneration` to disable generating kotlin extensions.

It also changes the generated extensions to support non empty constructors