### PR TITLE
Paris improvements

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewWriter.kt
@@ -291,10 +291,10 @@ internal class ModelViewWriter(
             // Compare against the style on the previous model if it exists,
             // otherwise we look up the saved style from the view tag
             if (hasPreviousModel) {
-                beginControlFlow("\nif (!\$L.equals(that.\$L))",
+                beginControlFlow("\nif (\$L != that.\$L)",
                                  PARIS_STYLE_ATTR_NAME, PARIS_STYLE_ATTR_NAME)
             } else {
-                beginControlFlow("\nif (!\$L.equals(\$L.getTag(\$T.id.epoxy_saved_view_style)))",
+                beginControlFlow("\nif (\$L != \$L.getTag(\$T.id.epoxy_saved_view_style))",
                                  PARIS_STYLE_ATTR_NAME, boundObjectParam.name, ClassNames.EPOXY_R)
             }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ParisStyleAttributeInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ParisStyleAttributeInfo.kt
@@ -17,14 +17,14 @@ fun weakReferenceFieldForStyle(styleName: String) = "parisStyleReference_$styleN
  */
 internal class ParisStyleAttributeInfo(
         modelInfo: ModelViewInfo,
-        elements: Elements,
+        val elements: Elements,
         val types: Types,
         packageName: String,
         styleBuilderClassName: ClassName,
         styleBuilderElement: TypeMirror
 ) : AttributeInfo() {
 
-    val styleNames: List<String>
+    val styles: List<ParisStyle>
     val styleApplierClass: ClassName
     val styleBuilderClass: ClassName
 
@@ -38,7 +38,7 @@ internal class ParisStyleAttributeInfo(
         isGenerated = true
         useInHash = true
         isNullable = false
-        styleNames = findStyleNames(styleBuilderElement)
+        styles = findStyleNames(styleBuilderElement)
 
         // the builder is nested in the style applier class
         styleApplierClass = styleBuilderClassName.topLevelClassName()
@@ -46,7 +46,7 @@ internal class ParisStyleAttributeInfo(
         codeToSetDefault.explicit = CodeBlock.of(PARIS_DEFAULT_STYLE_CONSTANT_NAME)
     }
 
-    private fun findStyleNames(typeMirror: TypeMirror): List<String> {
+    private fun findStyleNames(typeMirror: TypeMirror): List<ParisStyle> {
         return types.asElement(typeMirror)
                 .enclosedElements
                 .filter {
@@ -54,11 +54,18 @@ internal class ParisStyleAttributeInfo(
                             && it.simpleName.startsWith(BUILDER_STYLE_METHOD_PREFIX)
                 }
                 .map {
-                    it.simpleName
+                    val name = it.simpleName
                             .toString()
                             .removePrefix(BUILDER_STYLE_METHOD_PREFIX)
                             .lowerCaseFirstLetter()
+
+                    ParisStyle(name, elements.getDocComment(it))
                 }
     }
 
 }
+
+data class ParisStyle(
+        val name: String,
+        val javadoc: String?
+)

--- a/epoxy-sample/build.gradle
+++ b/epoxy-sample/build.gradle
@@ -12,7 +12,7 @@ android {
 
   defaultConfig {
     applicationId "com.airbnb.android.epoxysample"
-    minSdkVersion rootProject.MIN_SDK_VERSION_LITHO
+    minSdkVersion 16
     targetSdkVersion rootProject.TARGET_SDK_VERSION
     vectorDrawables.useSupportLibrary = true
     versionCode 1
@@ -43,6 +43,9 @@ dependencies {
   compile project(':epoxy-databinding')
   compile project(':epoxy-adapter')
   annotationProcessor project(':epoxy-processor')
+
+//  compile "com.airbnb.android:paris:0.2.0"
+//  annotationProcessor "com.airbnb.android:paris-processor:0.2.0"
 
   // Dependencies for the optional litho integration
   compile project(':epoxy-litho')


### PR DESCRIPTION
This copies docs from the style applier to the model method for setting that style.

it also only does the style validation when a different style is set on a view, which should be more efficient.

another optimization is to compare styles with != instead of equals since style objects should be the same in most cases