### PR TITLE
Generate model interfaces for interfaces on view

### DIFF
--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithInterface.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithInterface.kt
@@ -1,0 +1,64 @@
+package com.airbnb.epoxy.integrationtest
+
+import android.content.*
+import android.support.annotation.*
+import android.view.*
+import com.airbnb.epoxy.*
+import com.airbnb.epoxy.ModelView.Size
+
+@ModelView(autoLayout = Size.WRAP_WIDTH_MATCH_HEIGHT)
+class ViewWithInterface(context: Context) : View(context), InterfaceForView, InterfaceForView2 {
+
+    @ModelProp
+    override fun setText(title: CharSequence?) {
+
+    }
+
+    @TextProp
+    override fun setText2(title: CharSequence?) {
+
+    }
+
+    @ModelProp
+    override fun setText3(title: String) {
+
+    }
+
+    @ModelProp
+    fun nonInterfaceProp(title: Int) {
+        // method has different type from method of same name in other view
+    }
+}
+
+@ModelView(autoLayout = Size.WRAP_WIDTH_MATCH_HEIGHT)
+class ViewWithInterface2(context: Context) : View(context), InterfaceForView, InterfaceForView2 {
+
+    @TextProp
+    override fun setText(@Nullable title: CharSequence?) {
+        // It is intended that this override has the nullable annotation and the other doesn't, to check that it doesn't affect the interface
+    }
+
+    @TextProp
+    override fun setText2(@Nullable title: CharSequence?) {
+
+    }
+
+    @ModelProp
+    override fun setText3(title: String) {
+
+    }
+
+    @ModelProp
+    fun nonInterfaceProp(title: String) {
+
+    }
+}
+
+interface InterfaceForView {
+    fun setText(title: CharSequence?)
+    fun setText2(title: CharSequence?)
+}
+
+interface InterfaceForView2 {
+    fun setText3(title: String)
+}

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewInterfaceTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewInterfaceTest.kt
@@ -1,0 +1,59 @@
+package com.airbnb.epoxy
+
+import com.airbnb.epoxy.integrationtest.*
+import org.junit.*
+import org.junit.runner.*
+import org.robolectric.*
+import org.robolectric.annotation.*
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(21))
+class ModelViewInterfaceTest {
+
+    @Test
+    fun interfaceIsGeneratedForView() {
+        val model: InterfaceForViewModel_ = ViewWithInterfaceModel_()
+        model.text("")
+    }
+
+    @Test
+    fun generatedInterfaceIncludesBaseModelProps() {
+        val model: InterfaceForViewModel_ = ViewWithInterfaceModel_()
+        model.id(1)
+                .id("sfd")
+                .spanSizeOverride(null)
+    }
+
+    @Test
+    fun textPropMethodsAreOnInterface() {
+        val model: InterfaceForViewModel_ = ViewWithInterfaceModel_()
+        model.text("")
+                .text2("asdf")
+                .text2(3)
+                .text2(3, "arg")
+    }
+
+    @Test
+    fun multipleModelsDeclareInterface() {
+        val model1: InterfaceForViewModel_ = ViewWithInterfaceModel_()
+        val model2: InterfaceForViewModel_ = ViewWithInterface2Model_()
+
+        model1.text("")
+                .text2("")
+                .id(1)
+
+        model2.text("")
+                .text2("")
+                .id(1)
+    }
+
+    @Test
+    fun viewCanHaveMultipleInterfaces() {
+        val model = ViewWithInterfaceModel_()
+        val interface1 = model as InterfaceForViewModel_
+        val interface2 = model as InterfaceForView2Model_
+
+        interface1.text("")
+        interface2.text3("")
+    }
+}

--- a/epoxy-paging/src/main/java/com/airbnb/epoxy/paging/PagingEpoxyController.java
+++ b/epoxy-paging/src/main/java/com/airbnb/epoxy/paging/PagingEpoxyController.java
@@ -3,6 +3,7 @@ package com.airbnb.epoxy.paging;
 import android.arch.paging.PagedList;
 import android.arch.paging.PagedList.Callback;
 import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.airbnb.epoxy.EpoxyController;
@@ -36,8 +37,8 @@ public abstract class PagingEpoxyController<T> extends EpoxyController {
   private static final int DEFAULT_PAGE_SIZE_HINT = 10;
   private static final int DEFAULT_NUM_PAGES_T0_LOAD = 10;
 
-  private PagedList<T> pagedList;
-  private List<T> list = Collections.emptyList();
+  @Nullable private PagedList<T> pagedList;
+  @NonNull private List<T> list = Collections.emptyList();
 
   private int pageSizeHint = DEFAULT_PAGE_SIZE_HINT;
   private int numPagesToLoad = DEFAULT_NUM_PAGES_T0_LOAD;
@@ -179,22 +180,18 @@ public abstract class PagingEpoxyController<T> extends EpoxyController {
   }
 
   /**
-     * Returns the list currently being displayed by the EpoxyController when you set data
-     * with an Android PagedList.
-     * <p>
-     * Or, the list inside EpoxyController when you set data with normal Java {@link List}.
-     *
-     * @return The list data.
-     */
+   * @return The list currently being displayed by the EpoxyController. This is either the Java List
+   * set with {@link #setList(List)}, the latest snapshot if a PagedList is set, or an empty list if
+   * nothing was set.
+   */
   public List<T> getCurrentList() {
     return this.list;
   }
 
   /**
-     * Returns the pagedList currently being displayed by the EpoxyController.
-     *
-     * @return The pagedList currently being displayed.
-     */
+   * @return The pagedList currently being displayed. Null if one has not been set.
+   */
+  @Nullable
   public PagedList<T> getPagedList() {
     return this.pagedList;
   }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.kt
@@ -59,7 +59,16 @@ internal class DataBindingProcessor(
                     }
         }
 
-        return resolveDataBindingClassesAndWriteJava()
+        val modelsWritten = resolveDataBindingClassesAndWriteJava()
+        if (modelsWritten.isNotEmpty()) {
+            // All databinding classes are generated at the same time, so once one is ready they
+            // all should be. Since we infer databinding layouts based on a naming pattern we may
+            // have some false positives which we can clear from the list if we can't find a
+            // databinding class for them.
+            modelsToWrite.clear()
+        }
+
+        return modelsWritten
     }
 
     /**
@@ -69,7 +78,8 @@ internal class DataBindingProcessor(
     fun hasModelsToWrite() = modelsToWrite.isNotEmpty()
 
     private fun resolveDataBindingClassesAndWriteJava(): List<DataBindingModelInfo> {
-        return modelsToWrite.filter { it.dataBindingClassElement != null }
+        return modelsToWrite
+                .filter { it.dataBindingClassElement != null }
                 .onEach {
                     it.parseDataBindingClass()
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/EpoxyProcessor.java
@@ -214,7 +214,9 @@ public class EpoxyProcessor extends AbstractProcessor {
   }
 
   private boolean areModelsWaitingToWrite() {
-    return dataBindingProcessor.hasModelsToWrite() || modelProcessor.hasModelsToWrite();
+    return dataBindingProcessor.hasModelsToWrite()
+        || modelProcessor.hasModelsToWrite()
+        || modelViewProcessor.hasModelsToWrite();
   }
 
   private void validateAttributesImplementHashCode(

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.kt
@@ -24,6 +24,9 @@ internal class GeneratedModelWriter(
         private val dataBindingModuleLookup: DataBindingModuleLookup,
         private val elements: Elements
 ) {
+
+    val modelInterfaceWriter = ModelBuilderInterfaceWriter(filer, types)
+
     private var builderHooks: BuilderHooks? = null
 
     internal open class BuilderHooks {
@@ -62,6 +65,10 @@ internal class GeneratedModelWriter(
         ) {
 
         }
+    }
+
+    fun writeFilesForViewInterfaces() {
+        modelInterfaceWriter.writeFilesForViewInterfaces()
     }
 
     @Throws(IOException::class)
@@ -105,12 +112,9 @@ internal class GeneratedModelWriter(
 
             builderHooks?.beforeFinalBuild(this)
 
-            ModelBuilderInterfaceWriter(filer, info, this.build().methodSpecs)
-                    .addInterface(this)
+
+            addSuperinterface(modelInterfaceWriter.writeInterface(info, this.build().methodSpecs))
         }
-
-
-
 
         JavaFile.builder(generatedModelName.packageName(), modelClass)
                 .build()

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/JavaPoetDsl.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/JavaPoetDsl.kt
@@ -10,6 +10,16 @@ inline internal fun buildClass(
         initializer: TypeSpec.Builder.() -> Unit
 ): TypeSpec = TypeSpec.classBuilder(name).apply(initializer).build()
 
+inline internal fun buildInterface(
+        name: String,
+        initializer: TypeSpec.Builder.() -> Unit
+): TypeSpec = TypeSpec.interfaceBuilder(name).apply(initializer).build()
+
+inline internal fun buildInterface(
+        name: ClassName,
+        initializer: TypeSpec.Builder.() -> Unit
+): TypeSpec = TypeSpec.interfaceBuilder(name).apply(initializer).build()
+
 inline internal fun buildClass(
         className: ClassName,
         initializer: TypeSpec.Builder.() -> Unit
@@ -29,7 +39,6 @@ inline internal fun TypeSpec.Builder.addAnnotation(
     addAnnotation(AnnotationSpec.builder(type).apply(initializer).build())
 }
 
-
 inline internal fun buildConstructor(
         initializer: MethodSpec.Builder.() -> Unit
 ): MethodSpec = MethodSpec.constructorBuilder().apply(initializer).build()
@@ -38,6 +47,30 @@ inline internal fun buildMethod(
         name: String,
         initializer: MethodSpec.Builder.() -> Unit
 ): MethodSpec = MethodSpec.methodBuilder(name).apply(initializer).build()
+
+/** Copies all details of a methodspec besides the statement, allowing you to override any piece of the method. */
+internal fun MethodSpec.copy(
+        name: String? = null,
+        modifiers: Iterable<Modifier>? = null, // replaces all existing modifiers if not null
+        additionalModifiers: Iterable<Modifier>? = null, // Appends to existing modifiers if not null
+        returns: TypeName? = null,
+        params: Iterable<ParameterSpec>? = null,
+        varargs: Boolean? = null,
+        typeVariables: Iterable<TypeVariableName>? = null,
+        exceptions: Iterable<TypeName>? = null,
+        callback: MethodSpec.Builder.() -> Unit = {} // Any other custom init code, like adding statements
+): MethodSpec {
+    val builder = MethodSpec.methodBuilder(name ?: this.name)
+            .addModifiers(modifiers ?: this.modifiers)
+            .addModifiers(additionalModifiers ?: emptyList())
+            .returns(returns ?: this.returnType)
+            .addParameters(params ?: this.parameters)
+            .varargs(varargs ?: this.varargs)
+            .addTypeVariables(typeVariables ?: this.typeVariables)
+            .addExceptions(exceptions ?: this.exceptions)
+
+    return builder.apply(callback).build()
+}
 
 inline internal fun MethodSpec.Builder.addAnnotation(
         type: Class<*>,

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelBuilderInterfaceWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelBuilderInterfaceWriter.kt
@@ -3,6 +3,7 @@ package com.airbnb.epoxy
 import com.squareup.javapoet.*
 import javax.annotation.processing.*
 import javax.lang.model.element.*
+import javax.lang.model.util.*
 
 const val MODEL_BUILDER_INTERFACE_SUFFIX = "Builder"
 
@@ -15,49 +16,153 @@ const val MODEL_BUILDER_INTERFACE_SUFFIX = "Builder"
  */
 internal class ModelBuilderInterfaceWriter(
         private val filer: Filer,
-        private val modelInfo: GeneratedModelInfo,
-        private val methods: MutableList<MethodSpec>
+        val types: Types
 ) {
+
+    private val viewInterfacesToGenerate = mutableMapOf<ClassName, Set<MethodDetails>>()
 
     /** These setters can't be used with models in an EpoxyController, they were made for EpoxyAdapter. */
     private val blackListedLegacySetterNames = setOf("hide", "show", "reset")
 
-    fun addInterface(modelBuilder: TypeSpec.Builder) {
-        modelBuilder.addSuperinterface(getBuilderInterfaceTypeName(modelInfo))
+    fun writeInterface(
+            modelInfo: GeneratedModelInfo,
+            methods: MutableList<MethodSpec>
+    ): TypeName {
 
-        val modelInterface = TypeSpec.interfaceBuilder(
-                getBuilderInterfaceClassName(modelInfo)).run {
+        val interfaceName = getBuilderInterfaceClassName(modelInfo)
+        val modelInterface = buildInterface(interfaceName) {
+            val interfaceMethods = getInterfaceMethods(modelInfo, methods, interfaceName)
+
+            if (modelInfo is ModelViewInfo) {
+                modelInfo.generatedViewInterfaceNames.forEach {
+                    addSuperinterface(it)
+
+                    // Store the subset of methods common to all interface implementations so we
+                    // can generate the interface with the proper methods later
+                    viewInterfacesToGenerate
+                            .putOrMerge(
+                                    it,
+                                    interfaceMethods.map { MethodDetails(it) }.toSet()
+                            ) { set1, set2 -> set1 intersect set2 }
+                }
+            }
+
             addModifiers(Modifier.PUBLIC)
             addTypeVariables(modelInfo.typeVariables)
-            addMethods(getInterfaceMethods())
-            build()
+            addMethods(interfaceMethods)
         }
 
         JavaFile.builder(modelInfo.generatedClassName.packageName(), modelInterface)
                 .build()
                 .writeTo(filer)
+
+        return getBuilderInterfaceTypeName(modelInfo)
     }
 
-    private fun getInterfaceMethods(): List<MethodSpec> {
-        return methods.filter {
-            it.returnType == modelInfo.parameterizedGeneratedName
-        }.filter {
-            !blackListedLegacySetterNames.contains(it.name)
-        }.map {
-            MethodSpec.methodBuilder(it.name).run {
-                // Copy everything besides the code implementation and make it abstract
-                addModifiers(it.modifiers)
-                addModifiers(Modifier.ABSTRACT)
-                returns(it.returnType)
-                addParameters(it.parameters)
-                varargs(it.varargs)
-                addTypeVariables(it.typeVariables)
-                addExceptions(it.exceptions)
+    private fun getInterfaceMethods(
+            modelInfo: GeneratedModelInfo,
+            methods: MutableList<MethodSpec>,
+            interfaceName: ClassName
+    ): List<MethodSpec> {
+        return methods
+                .filter {
+                    it.returnType == modelInfo.parameterizedGeneratedName
+                }
+                .filter {
+                    !blackListedLegacySetterNames.contains(it.name)
+                }
+                .filter {
+                    // Layout throws an exception for programmatic views, so we might a well leave it out too
+                    !(modelInfo.isProgrammaticView && it.name == "layout")
+                }
+                .map {
+                    it.copy(
+                            // We have the methods return the interface type instead of the model, so
+                            // that subclasses of the model can also implement this interface
+                            returns = interfaceName,
+                            additionalModifiers = listOf(Modifier.ABSTRACT)
+                    )
+                }
+    }
 
-                build()
+    /**
+     * We need to gather information about all of the view interfaces first, and then write the interface classes.
+     */
+    fun writeFilesForViewInterfaces() {
+        // For each interface we figure out which methods to add to it by getting the largest subset of props supported by all models with the interface.
+        // This approach has a few advantages:
+        // 1. Easily inherit TextProp and other overloads
+        // 2. Inherit base model props like id
+        // 3. Don't have to figure out if a prop matches an interface method exactly (eg the model method is "clickable" but the interface method is "setClickable")
+        // This means that the generated interface won't necesarily map exactly to the original view interface
+        // It just represents the set of props shared by all models with that view interface, which should be all we need in practice.
+
+        for ((interfaceName, methodsToWrite) in viewInterfacesToGenerate) {
+
+            val interfaceSpec = buildInterface(interfaceName) {
+                addModifiers(Modifier.PUBLIC)
+
+                addMethods(methodsToWrite.map {
+                    it.methodSpec.copy {
+                        returns(interfaceName)
+                    }
+                })
             }
+
+            JavaFile.builder(interfaceName.packageName(), interfaceSpec)
+                    .build()
+                    .writeTo(filer)
         }
+
+        viewInterfacesToGenerate.clear()
     }
+
+    /** A wrapper around MethodSpec that allows us to compare methods with equality that only
+     * checks name and param types. This prevents things like annotations and param name from
+     * affecting equality, and gets us closer to checking the actual method signature.
+     * */
+    class MethodDetails(val methodSpec: MethodSpec) {
+        val name = methodSpec.name!!
+        val params = methodSpec.parameters.map { ParamDetails(it) }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is MethodDetails) return false
+
+            if (name != other.name) return false
+            if (params != other.params) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = name.hashCode()
+            result = 31 * result + params.hashCode()
+            return result
+        }
+
+    }
+
+    /** A wrapper around ParameterSpec that allows us to compare params with equality that only
+     * checks param type. This prevents things like annotations and param name from
+     * affecting equality.
+     * */
+    class ParamDetails(val parameterSpec: ParameterSpec) {
+        val type = parameterSpec.type!!
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ParamDetails) return false
+
+            if (type != other.type) return false
+
+            return true
+        }
+
+        override fun hashCode() = type.hashCode()
+
+    }
+
 }
 
 internal fun getBuilderInterfaceTypeName(modelInfo: GeneratedModelInfo): TypeName {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.kt
@@ -20,6 +20,8 @@ internal class ModelViewInfo(
     private val viewAnnotation: ModelView = viewElement.getAnnotation(ModelView::class.java)
     val fullSpanSize: Boolean
 
+    val viewInterfaces: List<DeclaredType>
+
     val viewAttributes: List<ViewAttributeInfo>
         get() = attributeInfo.filterIsInstance<ViewAttributeInfo>()
 
@@ -47,6 +49,18 @@ internal class ModelViewInfo(
         layoutParams = viewAnnotation.autoLayout
         fullSpanSize = viewAnnotation.fullSpan
         includeOtherLayoutOptions = configManager.includeAlternateLayoutsForViews(viewElement)
+
+        viewInterfaces = viewElement
+                .interfaces
+                .filterIsInstance<DeclaredType>()
+    }
+
+    /** We generate an interface on the model to represent each interface on the view.
+     * This lets models with the same view interface be grouped together. */
+    val generatedViewInterfaceNames: List<ClassName> by lazy {
+        viewInterfaces.map {
+            ClassName.get(it.asElement() as TypeElement).appendToName("Model_")
+        }
     }
 
     private fun lookUpSuperClassElement(): TypeElement {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/Utils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/Utils.java
@@ -29,6 +29,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import static com.airbnb.epoxy.KotlinUtilsKt.getParentClassElement;
 import static com.squareup.javapoet.TypeName.BOOLEAN;
 import static com.squareup.javapoet.TypeName.BYTE;
 import static com.squareup.javapoet.TypeName.CHAR;
@@ -271,11 +272,6 @@ class Utils {
       return null;
     }
     return getMethodOnClass(superClazz, method, typeUtils, elements);
-  }
-
-  @Nullable
-  static TypeElement getParentClassElement(TypeElement element, Types types) {
-    return (TypeElement) types.asElement(element.getSuperclass());
   }
 
   private static boolean areParamsTheSame(ExecutableElement method1, MethodSpec method2,

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ViewAttributeInfo.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ViewAttributeInfo.java
@@ -1,5 +1,7 @@
 package com.airbnb.epoxy;
 
+import android.support.annotation.Nullable;
+
 import com.airbnb.epoxy.ModelProp.Option;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.AnnotationSpec.Builder;
@@ -27,9 +29,9 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import static com.airbnb.epoxy.KotlinUtilsKt.getParentClassElement;
 import static com.airbnb.epoxy.Utils.capitalizeFirstLetter;
 import static com.airbnb.epoxy.Utils.getDefaultValue;
-import static com.airbnb.epoxy.Utils.getParentClassElement;
 import static com.airbnb.epoxy.Utils.isFieldPackagePrivate;
 import static com.airbnb.epoxy.Utils.removeSetPrefix;
 
@@ -41,10 +43,12 @@ class ViewAttributeInfo extends AttributeInfo {
   final boolean resetWithNull;
   final boolean generateStringOverloads;
   String constantFieldNameForDefaultValue;
+  @Nullable ExecutableElement setterElementOnView;
 
   ViewAttributeInfo(ModelViewInfo modelInfo, ExecutableElement setterMethod, Types types,
       Elements elements, ErrorLogger errorLogger, ResourceProcessor resourceProcessor) {
     this.resourceProcessor = resourceProcessor;
+    setterElementOnView = setterMethod;
     ModelProp propAnnotation = setterMethod.getAnnotation(ModelProp.class);
     TextProp textAnnotation = setterMethod.getAnnotation(TextProp.class);
     CallbackProp callbackAnnotation = setterMethod.getAnnotation(CallbackProp.class);

--- a/epoxy-processortest/src/test/resources/ModelWithAllFieldTypesBuilder.java
+++ b/epoxy-processortest/src/test/resources/ModelWithAllFieldTypesBuilder.java
@@ -17,65 +17,65 @@ import java.lang.String;
 import java.util.List;
 
 public interface ModelWithAllFieldTypesBuilder {
-  ModelWithAllFieldTypes_ onBind(OnModelBoundListener<ModelWithAllFieldTypes_, Object> listener);
+  ModelWithAllFieldTypesBuilder onBind(OnModelBoundListener<ModelWithAllFieldTypes_, Object> listener);
 
-  ModelWithAllFieldTypes_ onUnbind(OnModelUnboundListener<ModelWithAllFieldTypes_, Object> listener);
+  ModelWithAllFieldTypesBuilder onUnbind(OnModelUnboundListener<ModelWithAllFieldTypes_, Object> listener);
 
-  ModelWithAllFieldTypes_ valueInt(int valueInt);
+  ModelWithAllFieldTypesBuilder valueInt(int valueInt);
 
-  ModelWithAllFieldTypes_ valueInteger(Integer valueInteger);
+  ModelWithAllFieldTypesBuilder valueInteger(Integer valueInteger);
 
-  ModelWithAllFieldTypes_ valueShort(short valueShort);
+  ModelWithAllFieldTypesBuilder valueShort(short valueShort);
 
-  ModelWithAllFieldTypes_ valueShortWrapper(Short valueShortWrapper);
+  ModelWithAllFieldTypesBuilder valueShortWrapper(Short valueShortWrapper);
 
-  ModelWithAllFieldTypes_ valueChar(char valueChar);
+  ModelWithAllFieldTypesBuilder valueChar(char valueChar);
 
-  ModelWithAllFieldTypes_ valueCharacter(Character valueCharacter);
+  ModelWithAllFieldTypesBuilder valueCharacter(Character valueCharacter);
 
-  ModelWithAllFieldTypes_ valuebByte(byte valuebByte);
+  ModelWithAllFieldTypesBuilder valuebByte(byte valuebByte);
 
-  ModelWithAllFieldTypes_ valueByteWrapper(Byte valueByteWrapper);
+  ModelWithAllFieldTypesBuilder valueByteWrapper(Byte valueByteWrapper);
 
-  ModelWithAllFieldTypes_ valueLong(long valueLong);
+  ModelWithAllFieldTypesBuilder valueLong(long valueLong);
 
-  ModelWithAllFieldTypes_ valueLongWrapper(Long valueLongWrapper);
+  ModelWithAllFieldTypesBuilder valueLongWrapper(Long valueLongWrapper);
 
-  ModelWithAllFieldTypes_ valueDouble(double valueDouble);
+  ModelWithAllFieldTypesBuilder valueDouble(double valueDouble);
 
-  ModelWithAllFieldTypes_ valueDoubleWrapper(Double valueDoubleWrapper);
+  ModelWithAllFieldTypesBuilder valueDoubleWrapper(Double valueDoubleWrapper);
 
-  ModelWithAllFieldTypes_ valueFloat(float valueFloat);
+  ModelWithAllFieldTypesBuilder valueFloat(float valueFloat);
 
-  ModelWithAllFieldTypes_ valueFloatWrapper(Float valueFloatWrapper);
+  ModelWithAllFieldTypesBuilder valueFloatWrapper(Float valueFloatWrapper);
 
-  ModelWithAllFieldTypes_ valueBoolean(boolean valueBoolean);
+  ModelWithAllFieldTypesBuilder valueBoolean(boolean valueBoolean);
 
-  ModelWithAllFieldTypes_ valueBooleanWrapper(Boolean valueBooleanWrapper);
+  ModelWithAllFieldTypesBuilder valueBooleanWrapper(Boolean valueBooleanWrapper);
 
-  ModelWithAllFieldTypes_ valueIntArray(int[] valueIntArray);
+  ModelWithAllFieldTypesBuilder valueIntArray(int[] valueIntArray);
 
-  ModelWithAllFieldTypes_ valueObjectArray(Object[] valueObjectArray);
+  ModelWithAllFieldTypesBuilder valueObjectArray(Object[] valueObjectArray);
 
-  ModelWithAllFieldTypes_ valueString(String valueString);
+  ModelWithAllFieldTypesBuilder valueString(String valueString);
 
-  ModelWithAllFieldTypes_ valueObject(Object valueObject);
+  ModelWithAllFieldTypesBuilder valueObject(Object valueObject);
 
-  ModelWithAllFieldTypes_ valueList(List<String> valueList);
+  ModelWithAllFieldTypesBuilder valueList(List<String> valueList);
 
-  ModelWithAllFieldTypes_ id(long id);
+  ModelWithAllFieldTypesBuilder id(long id);
 
-  ModelWithAllFieldTypes_ id(Number... ids);
+  ModelWithAllFieldTypesBuilder id(Number... ids);
 
-  ModelWithAllFieldTypes_ id(long id1, long id2);
+  ModelWithAllFieldTypesBuilder id(long id1, long id2);
 
-  ModelWithAllFieldTypes_ id(CharSequence key);
+  ModelWithAllFieldTypesBuilder id(CharSequence key);
 
-  ModelWithAllFieldTypes_ id(CharSequence key, CharSequence... otherKeys);
+  ModelWithAllFieldTypesBuilder id(CharSequence key, CharSequence... otherKeys);
 
-  ModelWithAllFieldTypes_ id(CharSequence key, long id);
+  ModelWithAllFieldTypesBuilder id(CharSequence key, long id);
 
-  ModelWithAllFieldTypes_ layout(@LayoutRes int arg0);
+  ModelWithAllFieldTypesBuilder layout(@LayoutRes int arg0);
 
-  ModelWithAllFieldTypes_ spanSizeOverride(@Nullable EpoxyModel.SpanSizeOverrideCallback arg0);
+  ModelWithAllFieldTypesBuilder spanSizeOverride(@Nullable EpoxyModel.SpanSizeOverrideCallback arg0);
 }

--- a/epoxy-processortest/src/test/resources/TestManyTypesViewModelBuilder.java
+++ b/epoxy-processortest/src/test/resources/TestManyTypesViewModelBuilder.java
@@ -16,60 +16,60 @@ import java.lang.String;
 import java.util.List;
 
 public interface TestManyTypesViewModelBuilder {
-  TestManyTypesViewModel_ onBind(OnModelBoundListener<TestManyTypesViewModel_, TestManyTypesView> listener);
+  TestManyTypesViewModelBuilder onBind(OnModelBoundListener<TestManyTypesViewModel_, TestManyTypesView> listener);
 
-  TestManyTypesViewModel_ onUnbind(OnModelUnboundListener<TestManyTypesViewModel_, TestManyTypesView> listener);
+  TestManyTypesViewModelBuilder onUnbind(OnModelUnboundListener<TestManyTypesViewModel_, TestManyTypesView> listener);
 
-  TestManyTypesViewModel_ stringValue(String stringValue);
+  TestManyTypesViewModelBuilder stringValue(String stringValue);
 
-  TestManyTypesViewModel_ nullableStringValue(@Nullable String nullableStringValue);
+  TestManyTypesViewModelBuilder nullableStringValue(@Nullable String nullableStringValue);
 
-  TestManyTypesViewModel_ intValue(int intValue);
+  TestManyTypesViewModelBuilder intValue(int intValue);
 
-  TestManyTypesViewModel_ intValueWithAnnotation(@StringRes int intValueWithAnnotation);
+  TestManyTypesViewModelBuilder intValueWithAnnotation(@StringRes int intValueWithAnnotation);
 
-  TestManyTypesViewModel_ intValueWithRangeAnnotation(@IntRange(from = 0, to = 200) int intValueWithRangeAnnotation);
+  TestManyTypesViewModelBuilder intValueWithRangeAnnotation(@IntRange(from = 0, to = 200) int intValueWithRangeAnnotation);
 
-  TestManyTypesViewModel_ intValueWithDimenTypeAnnotation(@Dimension(unit = 0) int intValueWithDimenTypeAnnotation);
+  TestManyTypesViewModelBuilder intValueWithDimenTypeAnnotation(@Dimension(unit = 0) int intValueWithDimenTypeAnnotation);
 
-  TestManyTypesViewModel_ intWithMultipleAnnotations(@IntRange(from = 0, to = 200) @Dimension(unit = 0) int intWithMultipleAnnotations);
+  TestManyTypesViewModelBuilder intWithMultipleAnnotations(@IntRange(from = 0, to = 200) @Dimension(unit = 0) int intWithMultipleAnnotations);
 
-  TestManyTypesViewModel_ integerValue(Integer integerValue);
+  TestManyTypesViewModelBuilder integerValue(Integer integerValue);
 
-  TestManyTypesViewModel_ boolValue(boolean boolValue);
+  TestManyTypesViewModelBuilder boolValue(boolean boolValue);
 
-  TestManyTypesViewModel_ booleanValue(Boolean booleanValue);
+  TestManyTypesViewModelBuilder booleanValue(Boolean booleanValue);
 
-  TestManyTypesViewModel_ arrayValue(String[] arrayValue);
+  TestManyTypesViewModelBuilder arrayValue(String[] arrayValue);
 
-  TestManyTypesViewModel_ listValue(List<String> listValue);
+  TestManyTypesViewModelBuilder listValue(List<String> listValue);
 
-  TestManyTypesViewModel_ clickListener(final OnModelClickListener<TestManyTypesViewModel_, TestManyTypesView> clickListener);
+  TestManyTypesViewModelBuilder clickListener(final OnModelClickListener<TestManyTypesViewModel_, TestManyTypesView> clickListener);
 
-  TestManyTypesViewModel_ clickListener(View.OnClickListener clickListener);
+  TestManyTypesViewModelBuilder clickListener(View.OnClickListener clickListener);
 
-  TestManyTypesViewModel_ title(@Nullable CharSequence title);
+  TestManyTypesViewModelBuilder title(@Nullable CharSequence title);
 
-  TestManyTypesViewModel_ title(@StringRes int stringRes);
+  TestManyTypesViewModelBuilder title(@StringRes int stringRes);
 
-  TestManyTypesViewModel_ title(@StringRes int stringRes, Object... formatArgs);
+  TestManyTypesViewModelBuilder title(@StringRes int stringRes, Object... formatArgs);
 
-  TestManyTypesViewModel_ titleQuantityRes(@PluralsRes int pluralRes, int quantity,
+  TestManyTypesViewModelBuilder titleQuantityRes(@PluralsRes int pluralRes, int quantity,
       Object... formatArgs);
 
-  TestManyTypesViewModel_ id(long id);
+  TestManyTypesViewModelBuilder id(long id);
 
-  TestManyTypesViewModel_ id(Number... ids);
+  TestManyTypesViewModelBuilder id(Number... ids);
 
-  TestManyTypesViewModel_ id(long id1, long id2);
+  TestManyTypesViewModelBuilder id(long id1, long id2);
 
-  TestManyTypesViewModel_ id(CharSequence key);
+  TestManyTypesViewModelBuilder id(CharSequence key);
 
-  TestManyTypesViewModel_ id(CharSequence key, CharSequence... otherKeys);
+  TestManyTypesViewModelBuilder id(CharSequence key, CharSequence... otherKeys);
 
-  TestManyTypesViewModel_ id(CharSequence key, long id);
+  TestManyTypesViewModelBuilder id(CharSequence key, long id);
 
-  TestManyTypesViewModel_ layout(@LayoutRes int arg0);
+  TestManyTypesViewModelBuilder layout(@LayoutRes int arg0);
 
-  TestManyTypesViewModel_ spanSizeOverride(@Nullable EpoxyModel.SpanSizeOverrideCallback arg0);
+  TestManyTypesViewModelBuilder spanSizeOverride(@Nullable EpoxyModel.SpanSizeOverrideCallback arg0);
 }


### PR DESCRIPTION
This is for custom views with the `@ModelView` annotation. If the view implements an interface then the generated model will also implement an interface representing the view's interface.

A separate interface is generated to represent the view's interface, this allows the model interface to include base model properties, like id, in addition to the interface methods. This also allows the generated interface to be flexible and not necessarily include every method in the view interface.

For example, say a view implements this
```
interface Clickable {
  void setClickable(boolean clickable);
  boolean isClickable();
}
```

If the `setClickable` implementation is annotated with `@ModelProp` then the generated model for the view will implement a `ClickablModel_` interface. This interface will include just the setter, not the getter.
```
interface ClickableModel_ {
 ClickableModel_ clickable(boolean clickable);
 ClickableModel_ id(long id);
 // other standard model methods
}
```

Then you can cast different models to `ClickableModel_` and access the shared props easily.

The generated interface does not necessarily mirror the original view interface. Instead, Epoxy looks at all generated models with that view type, gets the subset of props that they all share, and makes the generated interface implement methods for those props. This makes the generated interface flexible, and is easier to implement.

The generated interface is in the same package as the view interface.

The generated interface is the name of the original interface with `Model_` as a suffix.

Some caveats:
- This does not support views inheriting interfaces
- Does not support @ModelViews in other modules with the same interface
- Does not support abstract views partially implementing an interface

This was fairly difficult to implement and is complex, so I'm just supporting the basic case for now. I see a way forward to support the caveats, but might not get to it for a while unless there is demand.

I would also like to support doing something like this for models that inherit props from other models (ie a base model). That will have to be a slightly different approach, but similar ideas can be used.

