### PR TITLE
 Improve handling of interfaces without props

### DIFF
--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithInterface.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithInterface.kt
@@ -7,7 +7,15 @@ import com.airbnb.epoxy.*
 import com.airbnb.epoxy.ModelView.Size
 
 @ModelView(autoLayout = Size.WRAP_WIDTH_MATCH_HEIGHT)
-class ViewWithInterface(context: Context) : View(context), InterfaceForView, InterfaceForView2 {
+class ViewWithInterface(context: Context) : View(
+        context), InterfaceForView, InterfaceForView2, ClassWithNestedInterface.NestedInterface, InterfaceWithNoPropMethods {
+
+    override fun getSomething() = 5
+
+//    @ModelProp
+    override fun valueOnNestedInterface(value: Int) {
+
+    }
 
     @ModelProp
     override fun setText(title: CharSequence?) {
@@ -19,8 +27,8 @@ class ViewWithInterface(context: Context) : View(context), InterfaceForView, Int
 
     }
 
-    @ModelProp
-    override fun setText3(title: String) {
+    @CallbackProp
+    override fun setListener(title: View.OnClickListener?) {
 
     }
 
@@ -28,6 +36,7 @@ class ViewWithInterface(context: Context) : View(context), InterfaceForView, Int
     fun nonInterfaceProp(title: Int) {
         // method has different type from method of same name in other view
     }
+
 }
 
 @ModelView(autoLayout = Size.WRAP_WIDTH_MATCH_HEIGHT)
@@ -43,8 +52,8 @@ class ViewWithInterface2(context: Context) : View(context), InterfaceForView, In
 
     }
 
-    @ModelProp
-    override fun setText3(title: String) {
+    @CallbackProp
+    override fun setListener(title: View.OnClickListener?) {
 
     }
 
@@ -60,5 +69,15 @@ interface InterfaceForView {
 }
 
 interface InterfaceForView2 {
-    fun setText3(title: String)
+    fun setListener(title: View.OnClickListener?)
+}
+
+interface InterfaceWithNoPropMethods {
+    fun getSomething(): Int
+}
+
+class ClassWithNestedInterface {
+    interface NestedInterface {
+        fun valueOnNestedInterface(value: Int)
+    }
 }

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithInterface.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithInterface.kt
@@ -7,12 +7,11 @@ import com.airbnb.epoxy.*
 import com.airbnb.epoxy.ModelView.Size
 
 @ModelView(autoLayout = Size.WRAP_WIDTH_MATCH_HEIGHT)
-class ViewWithInterface(context: Context) : View(
-        context), InterfaceForView, InterfaceForView2, ClassWithNestedInterface.NestedInterface, InterfaceWithNoPropMethods {
+class ViewWithInterface(context: Context) : View(context), InterfaceForView, InterfaceForView2, ClassWithNestedInterface.NestedInterface, InterfaceWithNoPropMethods {
 
     override fun getSomething() = 5
 
-//    @ModelProp
+    @ModelProp
     override fun valueOnNestedInterface(value: Int) {
 
     }
@@ -36,8 +35,8 @@ class ViewWithInterface(context: Context) : View(
     fun nonInterfaceProp(title: Int) {
         // method has different type from method of same name in other view
     }
-
 }
+
 
 @ModelView(autoLayout = Size.WRAP_WIDTH_MATCH_HEIGHT)
 class ViewWithInterface2(context: Context) : View(context), InterfaceForView, InterfaceForView2 {

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewInterfaceTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewInterfaceTest.kt
@@ -54,6 +54,6 @@ class ModelViewInterfaceTest {
         val interface2 = model as InterfaceForView2Model_
 
         interface1.text("")
-        interface2.text3("")
+        interface2.listener(null)
     }
 }

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewInterfaceTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewInterfaceTest.kt
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy
 
+import android.view.*
 import com.airbnb.epoxy.integrationtest.*
 import org.junit.*
 import org.junit.runner.*
@@ -55,5 +56,11 @@ class ModelViewInterfaceTest {
 
         interface1.text("")
         interface2.listener(null)
+    }
+
+    @Test
+    fun nestedInterfaceWorks() {
+        val model = ViewWithInterfaceModel_() as ClassWithNestedInterface_NestedInterfaceModel_
+        model.listener( View.OnClickListener {  })
     }
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/KotlinUtils.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/KotlinUtils.kt
@@ -67,7 +67,7 @@ fun AnnotatedConstruct.hasAnyAnnotation(annotationClasses: List<Class<out Annota
 fun ClassName.appendToName(suffix: String)
         = ClassName.get(
         packageName(),
-        simpleNames().joinToString(separator = "$", postfix = suffix)
+        simpleNames().joinToString( separator = "_", postfix = suffix)
 ).annotated(annotations)!!
 
 /** Iterates through each character, allowing you to build a string by transforming the characters as needed. */

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewProcessor.kt
@@ -19,8 +19,7 @@ internal class ModelViewProcessor(
         private val resourceProcessor: ResourceProcessor
 ) {
 
-    private val modelPropAnnotations = listOf(ModelProp::class, TextProp::class,
-                                              CallbackProp::class).map { it.java }
+
 
     private val modelClassMap = LinkedHashMap<Element, ModelViewInfo>()
     private val styleableModelsToWrite = mutableListOf<ModelViewInfo>()
@@ -359,6 +358,11 @@ internal class ModelViewProcessor(
 
     private fun getModelInfoForMethodElement(element: Element): ModelViewInfo? =
             element.enclosingElement?.let { modelClassMap[it] }
+
+    companion object {
+        val modelPropAnnotations = listOf(ModelProp::class, TextProp::class,
+                                          CallbackProp::class).map { it.java }
+    }
 }
 
 


### PR DESCRIPTION
A view interface is only included if at least one of its methods has a prop annotation.

Fixes the naming of nested interfaces.