### PR TITLE
Improve transformation of java types to kotlin for extensions

### DIFF
--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelGroupWithAnnotation.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelGroupWithAnnotation.java
@@ -1,0 +1,23 @@
+package com.airbnb.epoxy.integrationtest;
+
+import com.airbnb.epoxy.EpoxyAttribute;
+import com.airbnb.epoxy.EpoxyModel;
+import com.airbnb.epoxy.EpoxyModelClass;
+import com.airbnb.epoxy.EpoxyModelGroup;
+
+import java.util.List;
+
+@EpoxyModelClass
+public abstract class ModelGroupWithAnnotation extends EpoxyModelGroup {
+  @EpoxyAttribute int backgroundColor;
+
+  public ModelGroupWithAnnotation(List<? extends EpoxyModel<?>> models) {
+    super(R.layout.model_with_click_listener, models);
+  }
+
+  @Override
+  public void bind(Holder holder) {
+    super.bind(holder);
+    holder.getRootView().setBackgroundColor(backgroundColor);
+  }
+}

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelWithConstructors.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelWithConstructors.java
@@ -6,6 +6,11 @@ import com.airbnb.epoxy.EpoxyAttribute;
 import com.airbnb.epoxy.EpoxyModel;
 import com.airbnb.epoxy.EpoxyModelClass;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 @EpoxyModelClass
 public abstract class ModelWithConstructors extends EpoxyModel<TextView> {
   @EpoxyAttribute public int value;
@@ -21,6 +26,48 @@ public abstract class ModelWithConstructors extends EpoxyModel<TextView> {
 
   public ModelWithConstructors(long id) {
     super(id);
+  }
+
+  // Tests that kotlin extension functions
+  public ModelWithConstructors(
+      Collection<String> collection,
+      Iterable<String> iterable,
+      List<String> list,
+      List<? extends String> upperBoundList,
+//      List<? super String> lowerBoundList,!!! Doesn't work, we would need to transform this
+// type to
+// a MutableList
+      List<?> wildCardList,
+      Map<String, String> map,
+      Set<String> set,
+      Boolean boxedBoolean,
+      Byte boxedByte,
+      Short boxedShort,
+      Integer boxedInteger,
+      Long boxedLong,
+      Character boxedCharacter,
+      Float boxedFloat,
+      Double boxedDouble,
+      String[] stringArray,
+      byte[] byteArray,
+      short[] shortArray,
+      char[] charArray,
+      int[] intArray,
+      float[] floatArray,
+      double[] doubleArray,
+      long[] longArray,
+      boolean[] booleanArray,
+      Byte[] boxedByteArray,
+      Short[] boxedShortArray,
+      Character[] boxedCharArray,
+      Integer[] boxedIntArray,
+      Float[] boxedFloatArray,
+      Double[] boxedDoubleArray,
+      Long[] boxedLongArray,
+      Boolean[] boxedBooleanArray,
+      Object objectParam
+  ) {
+
   }
 
   @Override

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelGroupIntegrationTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelGroupIntegrationTest.kt
@@ -1,0 +1,18 @@
+package com.airbnb.epoxy
+
+import com.airbnb.epoxy.integrationtest.*
+import org.junit.*
+import org.junit.runner.*
+import org.robolectric.*
+import org.robolectric.annotation.*
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(21))
+class ModelGroupIntegrationTest {
+
+    @Test
+    fun modelGroupSubclassIsGenerated() {
+        // Just checking that the generated class exists and compiles
+        ModelGroupWithAnnotation_(listOf(Model_()))
+    }
+}


### PR DESCRIPTION
The kotlin extension methods generated for models were using java types instead of kotlin types. When kotlin has a different type for certain classes, like collection classes, strings, or primitives, we now use the correct kotlin class.

This also uses the special kotlin array classes for primitives, like IntArray instead of Array<Int>.