### PR TITLE
Release 2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.7.3 (October 24, 2017)
+
+- **Fixed** When a model changed and a partial update was bound to an existing view the wrong values could be set for prop groups (https://github.com/airbnb/epoxy/pull/347)
+
 # 2.7.2 (October 24, 2017)
 
 - **Fixed** Using `EpoxyDataBindingPattern` could result in the wrong package being used for the BR class in generated models.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Gradle is the only supported build configuration, so just add the dependency to 
 
 ```groovy
 dependencies {
-  compile 'com.airbnb.android:epoxy:2.7.2'
+  compile 'com.airbnb.android:epoxy:2.7.3'
   // Add the annotation processor if you are using Epoxy's annotations (recommended)
-  annotationProcessor 'com.airbnb.android:epoxy-processor:2.7.2'
+  annotationProcessor 'com.airbnb.android:epoxy-processor:2.7.3'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.7.2
+VERSION_NAME=2.7.3
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **Fixed** When a model changed and a partial update was bound to an existing view the wrong values could be set for prop groups (https://github.com/airbnb/epoxy/pull/347)