### PR TITLE
Improve how view state is saved

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -5,6 +5,8 @@ import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
+import com.airbnb.epoxy.ViewHolderState.ViewState;
+
 import java.util.List;
 
 @SuppressWarnings("WeakerAccess")
@@ -12,9 +14,24 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
   @SuppressWarnings("rawtypes") private EpoxyModel epoxyModel;
   private List<Object> payloads;
   private EpoxyHolder epoxyHolder;
+  @Nullable ViewHolderState.ViewState initialViewState;
 
-  public EpoxyViewHolder(View view) {
+  public EpoxyViewHolder(View view, boolean saveInitialState) {
     super(view);
+
+    if (saveInitialState) {
+      // We save the initial state of the view when it is created so that we can reset this initial
+      // state before a model is bound for the first time. Otherwise the view may carry over
+      // state from a previously bound view.
+      initialViewState = new ViewState();
+      initialViewState.save(itemView);
+    }
+  }
+
+  void restoreInitialViewState() {
+    if (initialViewState != null) {
+      initialViewState.restore(itemView);
+    }
   }
 
   public void bind(@SuppressWarnings("rawtypes") EpoxyModel model,

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ViewHolderState.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ViewHolderState.java
@@ -114,6 +114,10 @@ class ViewHolderState extends LongSparseArray<ViewState> implements Parcelable {
     ViewState state = get(holder.getItemId());
     if (state != null) {
       state.restore(holder.itemView);
+    } else {
+      // The first time a model is bound it won't have previous state. We need to make sure
+      // the view is reset to its initial state to clear any changes from previously bound models
+      holder.restoreInitialViewState();
     }
   }
 

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/GridCarousel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/GridCarousel.java
@@ -8,7 +8,7 @@ import com.airbnb.epoxy.Carousel;
 import com.airbnb.epoxy.ModelView;
 import com.airbnb.epoxy.ModelView.Size;
 
-@ModelView(autoLayout = Size.MATCH_WIDTH_WRAP_HEIGHT)
+@ModelView(saveViewState = true, autoLayout = Size.MATCH_WIDTH_WRAP_HEIGHT)
 public class GridCarousel extends Carousel {
   private static final int SPAN_COUNT = 2;
 


### PR DESCRIPTION
This should address https://github.com/airbnb/epoxy/issues/346 and https://github.com/airbnb/epoxy/issues/308

The first time a model is bound we ensure that the view's original state is restored, so that state from previous models isn't carried over.

Also, when a view is rebound due to a model change the state is no longer restored.

I have also updated the wiki page about saved state to clarify behavior and usage