### PR TITLE
Clear adapter and view pool automatically from EpoxyRecyclerView

### DIFF
--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/GridCarousel.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/views/GridCarousel.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy.sample.views;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 
@@ -16,6 +17,7 @@ public class GridCarousel extends Carousel {
     super(context);
   }
 
+  @NonNull
   @Override
   protected LayoutManager createLayoutManager() {
     return new GridLayoutManager(getContext(), SPAN_COUNT, LinearLayoutManager.HORIZONTAL, false);


### PR DESCRIPTION
Addresses https://github.com/airbnb/epoxy/issues/344 to help prevent memory leaks.

This adds new behavior to EpoxyRecyclerView to automatically remove the adapter when detached from window (after a customizable delay). This is enabled by default but can be disabled. Removing the adapter forces views to be recycled and releases references to the recyclerview and the child views.

Additionally, a counter is now kept of how many recyclerviews are attached to the window, and when it hits 0 the view pool is cleared. This should help prevent bad memory leaks. It is perhaps too aggressive, since we don't want to prematurely clear the pool - I'm still thinking through how to best compromise here. Perhaps we could only clear the pool if the activity is destroyed.

Still a bit of a WIP while I add documentation and tweak this.