### PR TITLE
Specify custom model group root with view id

### DIFF
--- a/epoxy-adapter/src/main/res/values/ids.xml
+++ b/epoxy-adapter/src/main/res/values/ids.xml
@@ -4,4 +4,5 @@
     <item name="epoxy_touch_helper_selection_status" type="id" />
     <item name="epoxy_saved_view_style" type="id" />
     <item name="epoxy_recycler_view_child_initial_size_id" type="id" />
+    <item name="epoxy_model_group_child_container" type="id" />
 </resources>


### PR DESCRIPTION
Addresses https://github.com/airbnb/epoxy/issues/361

This allows you to mark a viewgroup inside an EpoxyModelGroup layout with the id `epoxy_model_group_child_container` so that it is used as the viewgroup where the model views are inserted into.

