### PR TITLE
Improve model click listener handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-  ext.KOTLIN_VERSION = "1.2.20"
+  ext.KOTLIN_VERSION = "1.2.21"
   ext.ANDROID_PLUGIN_VERSION = "3.0.1"
 
   repositories {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/WrappedEpoxyModelClickListener.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/WrappedEpoxyModelClickListener.java
@@ -72,7 +72,7 @@ public class WrappedEpoxyModelClickListener<T extends EpoxyModel<?>, V>
 
   @Nullable
   private static EpoxyViewHolder getEpoxyHolderForChildView(View v) {
-    RecyclerView recyclerView = findParentRecyclerView(v.getParent());
+    RecyclerView recyclerView = findParentRecyclerView(v);
     if (recyclerView == null) {
       return null;
     }
@@ -90,16 +90,21 @@ public class WrappedEpoxyModelClickListener<T extends EpoxyModel<?>, V>
   }
 
   @Nullable
-  private static RecyclerView findParentRecyclerView(@Nullable ViewParent v) {
+  private static RecyclerView findParentRecyclerView(@Nullable View v) {
     if (v == null) {
       return null;
     }
 
-    if (v instanceof RecyclerView) {
-      return (RecyclerView) v;
+    ViewParent parent = v.getParent();
+    if (parent instanceof RecyclerView) {
+      return (RecyclerView) parent;
     }
 
-    return findParentRecyclerView(v.getParent());
+    if (parent instanceof View) {
+      return findParentRecyclerView((View) parent);
+    }
+
+    return null;
   }
 
   @Override

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/GeneratedModelWriter.kt
@@ -597,22 +597,6 @@ internal class GeneratedModelWriter(
                     .endControlFlow()
         }
 
-        val clickWrapperType = getClassName(WRAPPED_LISTENER_TYPE)
-        for (attribute in modelInfo.getAttributeInfo()) {
-            if (!attribute.isViewClickListener) {
-                continue
-            }
-            // Pass the view holder and bound object on to the wrapped click listener
-
-            preBindBuilder
-                    .beginControlFlow("if (\$L instanceof \$T)", attribute.superGetterCode(),
-                                      clickWrapperType)
-                    .addStatement("((\$L) \$L).bind(\$L, \$L)", clickWrapperType,
-                                  attribute.superGetterCode(),
-                                  viewHolderParam.name, boundObjectParam.name)
-                    .endControlFlow()
-        }
-
         return preBindBuilder.build()
     }
 
@@ -1018,7 +1002,7 @@ internal class GeneratedModelWriter(
 
         setBitSetIfNeeded(classInfo, attribute, builder)
 
-        val wrapperClickListenerConstructor = CodeBlock.of("new \$T(this, \$L)",
+        val wrapperClickListenerConstructor = CodeBlock.of("new \$T(\$L)",
                                                            getClassName(WRAPPED_LISTENER_TYPE),
                                                            param.name)
 

--- a/epoxy-processortest/src/test/resources/DoNotHashViewModel_.java
+++ b/epoxy-processortest/src/test/resources/DoNotHashViewModel_.java
@@ -56,9 +56,6 @@ public class DoNotHashViewModel_ extends EpoxyModel<DoNotHashView> implements Ge
   public void handlePreBind(final EpoxyViewHolder holder, final DoNotHashView object,
       int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (clickListener_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) clickListener_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -163,7 +160,7 @@ public class DoNotHashViewModel_ extends EpoxyModel<DoNotHashView> implements Ge
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/IgnoreRequireHashCodeViewModel_.java
+++ b/epoxy-processortest/src/test/resources/IgnoreRequireHashCodeViewModel_.java
@@ -40,9 +40,6 @@ public class IgnoreRequireHashCodeViewModel_ extends EpoxyModel<IgnoreRequireHas
   public void handlePreBind(final EpoxyViewHolder holder, final IgnoreRequireHashCodeView object,
       int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (clickListener_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) clickListener_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -117,7 +114,7 @@ public class IgnoreRequireHashCodeViewModel_ extends EpoxyModel<IgnoreRequireHas
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
@@ -29,9 +29,6 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
   @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (super.getClickListener() instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) super.getClickListener()).bind(holder, object);
-    }
   }
 
   @Override
@@ -84,7 +81,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
       super.setClickListener(null);
     }
     else {
-      super.setClickListener(new WrappedEpoxyModelClickListener(this, clickListener));
+      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -29,9 +29,6 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
   @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (clickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) clickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -84,7 +81,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
       super.clickListener = null;
     }
     else {
-      super.clickListener = new WrappedEpoxyModelClickListener(this, clickListener);
+      super.clickListener = new WrappedEpoxyModelClickListener(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithViewLongClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewLongClickListener_.java
@@ -29,9 +29,6 @@ public class ModelWithViewLongClickListener_ extends ModelWithViewLongClickListe
   @Override
   public void handlePreBind(final EpoxyViewHolder holder, final Object object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (clickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) clickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -84,7 +81,7 @@ public class ModelWithViewLongClickListener_ extends ModelWithViewLongClickListe
       super.clickListener = null;
     }
     else {
-      super.clickListener = new WrappedEpoxyModelClickListener(this, clickListener);
+      super.clickListener = new WrappedEpoxyModelClickListener(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
@@ -34,9 +34,6 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
   public void handlePreBind(final EpoxyViewHolder holder, final TestCallbackPropView object,
       int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (listener_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) listener_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -112,7 +109,7 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
       this.listener_OnClickListener = null;
     }
     else {
-      this.listener_OnClickListener = new WrappedEpoxyModelClickListener(this, listener);
+      this.listener_OnClickListener = new WrappedEpoxyModelClickListener(listener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropCallbackPropViewModel_.java
@@ -48,9 +48,6 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
   public void handlePreBind(final EpoxyViewHolder holder,
       final TestFieldPropCallbackPropView object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (value_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) value_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -127,7 +124,7 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(this, value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropChildViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropChildViewModel_.java
@@ -61,9 +61,6 @@ public class TestFieldPropChildViewModel_ extends EpoxyModel<TestFieldPropChildV
   public void handlePreBind(final EpoxyViewHolder holder, final TestFieldPropChildView object,
       int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (value_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) value_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -207,7 +204,7 @@ public class TestFieldPropChildViewModel_ extends EpoxyModel<TestFieldPropChildV
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(this, value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropDoNotHashOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropDoNotHashOptionViewModel_.java
@@ -54,9 +54,6 @@ public class TestFieldPropDoNotHashOptionViewModel_ extends EpoxyModel<TestField
   public void handlePreBind(final EpoxyViewHolder holder,
       final TestFieldPropDoNotHashOptionView object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (value_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) value_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -132,7 +129,7 @@ public class TestFieldPropDoNotHashOptionViewModel_ extends EpoxyModel<TestField
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(this, value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropIgnoreRequireHashCodeOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropIgnoreRequireHashCodeOptionViewModel_.java
@@ -54,9 +54,6 @@ public class TestFieldPropIgnoreRequireHashCodeOptionViewModel_ extends EpoxyMod
   public void handlePreBind(final EpoxyViewHolder holder,
       final TestFieldPropIgnoreRequireHashCodeOptionView object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (value_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) value_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -134,7 +131,7 @@ public class TestFieldPropIgnoreRequireHashCodeOptionViewModel_ extends EpoxyMod
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(this, value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropNullOnRecycleOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropNullOnRecycleOptionViewModel_.java
@@ -48,9 +48,6 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
   public void handlePreBind(final EpoxyViewHolder holder,
       final TestFieldPropNullOnRecycleOptionView object, int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (value_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) value_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -127,7 +124,7 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(this, value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
@@ -137,9 +137,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
   public void handlePreBind(final EpoxyViewHolder holder, final TestManyTypesView object,
       int position) {
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
-    if (clickListener_OnClickListener instanceof WrappedEpoxyModelClickListener) {
-      ((com.airbnb.epoxy.WrappedEpoxyModelClickListener) clickListener_OnClickListener).bind(holder, object);
-    }
   }
 
   @Override
@@ -507,7 +504,7 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(this, clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
     }
     return this;
   }


### PR DESCRIPTION
Fix for https://github.com/airbnb/epoxy/issues/379

Instead of manually needing to store the EpoxyModel with the click listener this changes the approach to dynamically look up the associated view holder and model at the time of click.

it's simpler and requires less generated code. Should also handle rebinding with no issues