### PR TITLE
make isBuildingModels public

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
@@ -425,7 +425,7 @@ public abstract class EpoxyController {
     stagedModel = null;
   }
 
-  boolean isBuildingModels() {
+  public boolean isBuildingModels() {
     return modelsBeingBuilt != null;
   }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
@@ -425,7 +425,7 @@ public abstract class EpoxyController {
     stagedModel = null;
   }
 
-  public boolean isBuildingModels() {
+  protected boolean isBuildingModels() {
     return modelsBeingBuilt != null;
   }
 


### PR DESCRIPTION
make isBuildingModels public instead of package access to create custom TypedEpoxyController.

when creating custom Typed5EpoxyController that should accept five objects I ran into a compiler error
"isBuildingModels" Cannot be accessed from outside package