### PR TITLE
Blacklist setLifecycleOwner method in databinding field parsing, fixes #412

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-26.0.2
-  - android-26
+  - build-tools-27.0.3
+  - android-27
   - extra-google-google_play_services
   - extra-android-m2repository
   - extra-android-support

--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -10,15 +10,14 @@
 rootProject.ext.JAVA_SOURCE_VERSION = JavaVersion.VERSION_1_7
 rootProject.ext.JAVA_TARGET_VERSION = JavaVersion.VERSION_1_7
 
-rootProject.ext.TARGET_SDK_VERSION = 26
-rootProject.ext.COMPILE_SDK_VERSION = 26
+rootProject.ext.TARGET_SDK_VERSION = 27
+rootProject.ext.COMPILE_SDK_VERSION = 27
 rootProject.ext.MIN_SDK_VERSION = 14
 rootProject.ext.MIN_SDK_VERSION_LITHO = 15
 
-rootProject.ext.ANDROID_BUILD_TOOLS_VERSION = "26.0.2"
-rootProject.ext.ANDROID_SUPPORT_LIBS_VERSION = "26.1.0"
+rootProject.ext.ANDROID_SUPPORT_LIBS_VERSION = "27.1.0"
 rootProject.ext.ANDROID_DATA_BINDING = "1.3.1"
-rootProject.ext.ANDROID_PAGING = "1.0.0-alpha5"
+rootProject.ext.ANDROID_PAGING = "1.0.0-beta1"
 rootProject.ext.BUTTERKNIFE_VERSION = "8.8.1"
 rootProject.ext.SQUARE_JAVAPOET_VERSION = "1.9.0"
 rootProject.ext.SQUARE_KOTLINPOET_VERSION = "0.5.0"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
 
   ext.KOTLIN_VERSION = "1.2.21"
-  ext.ANDROID_PLUGIN_VERSION = "3.0.1"
+  ext.ANDROID_PLUGIN_VERSION = "3.1.0"
 
   repositories {
     google()
@@ -70,6 +70,6 @@ def getRepositoryPassword() {
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '3.3'
+  gradleVersion = '4.4'
   distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }

--- a/epoxy-adapter/build.gradle
+++ b/epoxy-adapter/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion rootProject.MIN_SDK_VERSION

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/QuantityStringResAttribute.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/QuantityStringResAttribute.java
@@ -13,11 +13,6 @@ public class QuantityStringResAttribute {
 
   public QuantityStringResAttribute(@PluralsRes int id, int quantity,
       @Nullable Object[] formatArgs) {
-    if (id < 0) {
-      // A 0 value is ignored since the generated code handles 0 as null/default
-      throw new IllegalArgumentException("Id cannot be negative");
-    }
-
     this.quantity = quantity;
     this.id = id;
     this.formatArgs = formatArgs;

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/StringAttributeData.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/StringAttributeData.java
@@ -49,41 +49,37 @@ public class StringAttributeData {
   }
 
   public void setValue(@StringRes int stringRes, @Nullable Object[] formatArgs) {
-    if (stringRes > 0) {
+    if (stringRes != 0) {
       this.stringRes = stringRes;
       this.formatArgs = formatArgs;
       string = null;
       pluralRes = 0;
     } else {
-      handleInvalidStringRes(stringRes);
+      handleInvalidStringRes();
     }
   }
 
-  private void handleInvalidStringRes(int stringRes) {
-    if (stringRes == 0) {
-      if (hasDefault) {
-        if (defaultStringRes > 0) {
-          setValue(defaultStringRes);
-        } else {
-          setValue(defaultString);
-        }
+  private void handleInvalidStringRes() {
+    if (hasDefault) {
+      if (defaultStringRes > 0) {
+        setValue(defaultStringRes);
       } else {
-        throw new IllegalArgumentException("0 is an invalid value for required strings.");
+        setValue(defaultString);
       }
     } else {
-      throw new IllegalArgumentException("String resource cannot be negative: " + stringRes);
+      throw new IllegalArgumentException("0 is an invalid value for required strings.");
     }
   }
 
   public void setValue(@PluralsRes int pluralRes, int quantity, @Nullable Object[] formatArgs) {
-    if (pluralRes > 0) {
+    if (pluralRes != 0) {
       this.pluralRes = pluralRes;
       this.quantity = quantity;
       this.formatArgs = formatArgs;
       string = null;
       stringRes = 0;
     } else {
-      handleInvalidStringRes(pluralRes);
+      handleInvalidStringRes();
     }
   }
 

--- a/epoxy-databinding/build.gradle
+++ b/epoxy-databinding/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion rootProject.MIN_SDK_VERSION

--- a/epoxy-integrationtest/build.gradle
+++ b/epoxy-integrationtest/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'kotlin-kapt'
 android {
 
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   defaultConfig {
     applicationId "com.airbnb.epoxy.integrationtest"

--- a/epoxy-integrationtest/src/main/res/layout/view_holder_nested_databinding_test.xml
+++ b/epoxy-integrationtest/src/main/res/layout/view_holder_nested_databinding_test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This layout contains a nested databinding layout which causes the generated ViewDataBinding
+    class to override the "setLifecycleOwner" method. Since single parameter methods prefixed with
+    "set" are parsed as model properties, this layout and the ensuing generated Epoxy model class
+    act as a test by ensuring the module still builds successfully.
+-->
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="40dp">
+
+        <include layout="@layout/view_holder_databinding_test" />
+
+    </LinearLayout>
+
+</layout>

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ViewAnnotationsStringOverloadsIntegrationTest.java
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ViewAnnotationsStringOverloadsIntegrationTest.java
@@ -138,30 +138,6 @@ public class ViewAnnotationsStringOverloadsIntegrationTest {
         .requiredTextQuantityRes(0, 23, "args");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void nullableTextThrowsOnNegativeString() {
-    new ViewWithAnnotationsForIntegrationTestModel_()
-        .nullableText(-1, "args");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void requiredTextThrowsOnNegativeString() {
-    new ViewWithAnnotationsForIntegrationTestModel_()
-        .nullableText(-1, "args");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void nullableTextThrowsOnNegativeQuantityString() {
-    new ViewWithAnnotationsForIntegrationTestModel_()
-        .nullableTextQuantityRes(-1, 1, "args");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void requiredTextThrowsOnNegativeQuantityString() {
-    new ViewWithAnnotationsForIntegrationTestModel_()
-        .requiredTextQuantityRes(-1, 1, "args");
-  }
-
   @Test
   public void nullableTextSetsNullWhenNotSet() {
     ViewWithAnnotationsForIntegrationTestModel_ model =

--- a/epoxy-litho/build.gradle
+++ b/epoxy-litho/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion rootProject.MIN_SDK_VERSION_LITHO

--- a/epoxy-paging/build.gradle
+++ b/epoxy-paging/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion rootProject.MIN_SDK_VERSION

--- a/epoxy-pagingsample/build.gradle
+++ b/epoxy-pagingsample/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
 
   defaultConfig {

--- a/epoxy-pagingsample/src/main/java/com/airbnb/epoxy/pagingsample/PagingSampleActivity.kt
+++ b/epoxy-pagingsample/src/main/java/com/airbnb/epoxy/pagingsample/PagingSampleActivity.kt
@@ -51,8 +51,8 @@ class PagingSampleActivity : AppCompatActivity() {
                             setPrefetchDistance(50)
                             build()
                         }).run {
-                    setMainThreadExecutor(UiThreadExecutor)
-                    setBackgroundThreadExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
+                    setNotifyExecutor(UiThreadExecutor)
+                    setFetchExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
                     build()
                 }
             }

--- a/epoxy-pagingsample/src/main/java/com/airbnb/epoxy/pagingsample/PagingSampleActivity.kt
+++ b/epoxy-pagingsample/src/main/java/com/airbnb/epoxy/pagingsample/PagingSampleActivity.kt
@@ -8,9 +8,9 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.AppCompatTextView
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
-import android.widget.TextView
 import com.airbnb.epoxy.ModelView
 import com.airbnb.epoxy.TextProp
 import com.airbnb.epoxy.paging.PagingEpoxyController
@@ -80,7 +80,7 @@ class TestController : PagingEpoxyController<User>() {
 }
 
 @ModelView(autoLayout = ModelView.Size.MATCH_WIDTH_WRAP_HEIGHT)
-class PagingView(context: Context) : TextView(context) {
+class PagingView(context: Context) : AppCompatTextView(context) {
 
     @TextProp
     fun name(name: CharSequence) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingModelInfo.kt
@@ -16,7 +16,7 @@ internal class DataBindingModelInfo(
     private val dataBindingClassName: ClassName
 
     private val dataBindingClassElement: TypeElement?
-        get() = getElementByName(dataBindingClassName, elementUtils, typeUtils) as TypeElement?
+        get() = getElementByName(dataBindingClassName, elementUtils, typeUtils)
 
     init {
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.kt
@@ -79,10 +79,8 @@ internal class DataBindingProcessor(
 
     private fun resolveDataBindingClassesAndWriteJava(): List<DataBindingModelInfo> {
         return modelsToWrite
-                .filter { it.dataBindingClassElement != null }
+                .filter { it.parseDataBindingClass() }
                 .onEach {
-                    it.parseDataBindingClass()
-
                     try {
                         modelWriter.generateClassForModel(it)
                     } catch (e: Exception) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/Utils.java
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/Utils.java
@@ -85,9 +85,9 @@ class Utils {
     }
   }
 
-  static Element getElementByName(ClassName name, Elements elements, Types types) {
+  static TypeElement getElementByName(ClassName name, Elements elements, Types types) {
     String canonicalName = name.reflectionName().replace("$", ".");
-    return getElementByName(canonicalName, elements, types);
+    return (TypeElement) getElementByName(canonicalName, elements, types);
   }
 
   static Element getElementByName(String name, Elements elements, Types types) {

--- a/epoxy-processortest/build.gradle
+++ b/epoxy-processortest/build.gradle
@@ -7,7 +7,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion rootProject.MIN_SDK_VERSION

--- a/epoxy-processortest2/build.gradle
+++ b/epoxy-processortest2/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion rootProject.MIN_SDK_VERSION

--- a/epoxy-sample/build.gradle
+++ b/epoxy-sample/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
   // For java 8 lambdas
   compileOptions {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/kotlinsample/build.gradle
+++ b/kotlinsample/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'kotlin-android-extensions'
 android {
 
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ANDROID_BUILD_TOOLS_VERSION
 
 
 


### PR DESCRIPTION
ViewDataBinding subclasses can now override the setLifecycleOwner method causing it to be erroneously detected as a model field. This fix introduces a field blacklist to ignore this method and possibly others in the future.

To reproduce the issue and create a test for it I had to update the Android plugin version which forced me to also update Gradle, the target SDK, and the paging library. I removed the buildToolsVersion declarations to remove a warning (the build tools version is now provided by the Android plugin from what I understand).