### PR TITLE
Prepare for release 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.11.0 (April 7, 2018)
+
+- **Fix** Make databinding work with Android Studio 3.1 (https://github.com/airbnb/epoxy/pull/418)
+- Make `EpoxyController#isBuildingModels` public (https://github.com/airbnb/epoxy/pull/406
+
+
 # 2.10.0 (February 25, 2018)
 
 - **Improved** Allow the `Model_` class suffix for models generated via `@ModelView` to be customized (https://github.com/airbnb/epoxy/pull/402 Big thanks to geralt-encore!)

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Gradle is the only supported build configuration, so just add the dependency to 
 
 ```groovy
 dependencies {
-  compile 'com.airbnb.android:epoxy:2.10.0'
+  compile 'com.airbnb.android:epoxy:2.11.0'
   // Add the annotation processor if you are using Epoxy's annotations (recommended)
-  annotationProcessor 'com.airbnb.android:epoxy-processor:2.10.0'
+  annotationProcessor 'com.airbnb.android:epoxy-processor:2.11.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.10.0
+VERSION_NAME=2.11.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **Fix** Make databinding work with Android Studio 3.1 (https://github.com/airbnb/epoxy/pull/418)
- Make `EpoxyController#isBuildingModels` public (https://github.com/airbnb/epoxy/pull/406