### PR TITLE
Reduce memory

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/DiffHelper.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/DiffHelper.java
@@ -189,7 +189,14 @@ class DiffHelper {
     collectMoves(updateOpHelper);
     collectChanges(updateOpHelper);
 
+    resetOldState();
+
     return updateOpHelper;
+  }
+
+  private void resetOldState() {
+    oldStateList.clear();
+    oldStateMap.clear();
   }
 
   private void prepareStateForDiff() {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -365,6 +365,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<Holder>
       // Clear the reference, because of `EpoxyController.buildModels`
       // will build new modelGroup instance during every call.
       modelGroup = null;
+      models = null;
     }
 
     /**


### PR DESCRIPTION
When I trace the number of EpoxyModel instances, I found that 3x instances hold in memory, and could't be released by GC.
This PR just want to NOTE them.