### PR TITLE
Prepare for 2.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.13.0 (June 19, 2018)
+- **Fix** Reduce memory usage in model groups and differ (#433)
+- **Fix** Support for wildcards in private epoxy attributes (#451)
+- **Fix** Generated Kotlin Extensions Don't Adhere to Constructor Nullability (#449)
+- **Fix** Infinite loop in annotation processor (#447)
+
 # 2.12.0 (April 18, 2018)
 
 - **Breaking** Several updates to the Paging Library integration were made (https://github.com/airbnb/epoxy/pull/421)

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Gradle is the only supported build configuration, so just add the dependency to 
 
 ```groovy
 dependencies {
-  compile 'com.airbnb.android:epoxy:2.12.0'
+  compile 'com.airbnb.android:epoxy:2.13.0'
   // Add the annotation processor if you are using Epoxy's annotations (recommended)
-  annotationProcessor 'com.airbnb.android:epoxy-processor:2.12.0'
+  annotationProcessor 'com.airbnb.android:epoxy-processor:2.13.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.12.0
+VERSION_NAME=2.13.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **Fix** Reduce memory usage in model groups and differ (#433)
- **Fix** Support for wildcards in private epoxy attributes (#451)
- **Fix** Generated Kotlin Extensions Don't Adhere to Constructor Nullability (#449)
- **Fix** Infinite loop in annotation processor (#447)