### PR TITLE
Prepare for 2.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.15.0 (July 29, 2018)
+- **New** Added kotlin sample code for building models. Updated wiki with info (https://github.com/airbnb/epoxy/wiki/Kotlin-Model-Examples)
+
+- **Fix**  Generated kotlin extension functions now work with Models with type variables (https://github.com/airbnb/epoxy/pull/478)
+- **Fix**  Backup is not enabled in manifest now (https://github.com/airbnb/epoxy/pull/481)
+- **Fix**  Click listener setter on generated model has correct nullability annotation (https://github.com/airbnb/epoxy/pull/458)
+- **Fix**  Avoid kotlin crash using toString on lambdas (https://github.com/airbnb/epoxy/pull/482)
+- **Fix**  If EpoxyModelGroup has annotations the generated class now calls super methods correctly.  (https://github.com/airbnb/epoxy/pull/483)
+
 # 2.14.0 (June 27, 2018)
 - **New** Experimental support for creating Epoxy models from arbitrary data formats (#450)
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Gradle is the only supported build configuration, so just add the dependency to 
 
 ```groovy
 dependencies {
-  compile 'com.airbnb.android:epoxy:2.14.0'
+  compile 'com.airbnb.android:epoxy:2.15.0'
   // Add the annotation processor if you are using Epoxy's annotations (recommended)
-  annotationProcessor 'com.airbnb.android:epoxy-processor:2.14.0'
+  annotationProcessor 'com.airbnb.android:epoxy-processor:2.15.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.14.0
+VERSION_NAME=2.15.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **New** Added kotlin sample code for building models. Updated wiki with info (https://github.com/airbnb/epoxy/wiki/Kotlin-Model-Examples)

- **Fix**  Generated kotlin extension functions now work with Models with type variables (https://github.com/airbnb/epoxy/pull/478)
- **Fix**  Backup is not enabled in manifest now (https://github.com/airbnb/epoxy/pull/481)
- **Fix**  Click listener setter on generated model has correct nullability annotation (https://github.com/airbnb/epoxy/pull/458)
- **Fix**  Avoid kotlin crash using toString on lambdas (https://github.com/airbnb/epoxy/pull/482)
- **Fix**  If EpoxyModelGroup has annotations the generated class now calls super methods correctly.  (https://github.com/airbnb/epoxy/pull/483)