### PR TITLE
Add non-nullable annotation to EpoxyHolder.

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyHolder.java
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy;
 
+import android.support.annotation.NonNull;
 import android.view.View;
 
 /**
@@ -15,5 +16,5 @@ public abstract class EpoxyHolder {
    * @param itemView A view inflated from the layout provided by
    * {@link EpoxyModelWithHolder#getLayout()}
    */
-  protected abstract void bindView(View itemView);
+  protected abstract void bindView(@NonNull View itemView);
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -327,7 +327,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<Holder>
     }
 
     @Override
-    protected void bindView(View itemView) {
+    protected void bindView(@NonNull View itemView) {
       if (!(itemView instanceof ViewGroup)) {
         throw new IllegalStateException(
             "The layout provided to EpoxyModelGroup must be a ViewGroup");

--- a/epoxy-databinding/src/main/java/com/airbnb/epoxy/DataBindingEpoxyModel.java
+++ b/epoxy-databinding/src/main/java/com/airbnb/epoxy/DataBindingEpoxyModel.java
@@ -106,7 +106,7 @@ public abstract class DataBindingEpoxyModel extends EpoxyModelWithHolder<DataBin
     }
 
     @Override
-    protected void bindView(View itemView) {
+    protected void bindView(@NonNull View itemView) {
       dataBinding = (ViewDataBinding) itemView.getTag();
     }
   }

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder.java
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy;
 
+import android.support.annotation.NonNull;
 import android.view.View;
 
 @EpoxyModelClass
@@ -14,7 +15,7 @@ public abstract class AbstractModelWithHolder
 
   static class Holder extends EpoxyHolder {
 
-    protected void bindView(View itemView) {
+    protected void bindView(@NonNull View itemView) {
 
     }
   }

--- a/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/BaseEpoxyHolder.java
+++ b/epoxy-sample/src/main/java/com/airbnb/epoxy/sample/models/BaseEpoxyHolder.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy.sample.models;
 
 import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
 import android.view.View;
 
 import com.airbnb.epoxy.EpoxyHolder;
@@ -14,7 +15,7 @@ import butterknife.ButterKnife;
 public abstract class BaseEpoxyHolder extends EpoxyHolder {
   @CallSuper
   @Override
-  protected void bindView(View itemView) {
+  protected void bindView(@NonNull View itemView) {
     ButterKnife.bind(this, itemView);
   }
 }


### PR DESCRIPTION
This makes it more clear when inheriting from the base class in kotlin
that thie parameter should not be null.