### PR TITLE
Prepare for 2.16.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.16.1 (Aug 22, 2018)
+# 2.16.2 (Aug 23, 2018)
+- **Fix** Kotlin lambdas can be used in model constructors (https://github.com/airbnb/epoxy/pull/501)
+- **New** Added function to check whether a model build is pending (https://github.com/airbnb/epoxy/pull/506)
+
+# 2.16.1 (Aug 15, 2018)
 - **Fix** Update EpoxyController async model building so threading works with tests (https://github.com/airbnb/epoxy/pull/504)
 
 # 2.16.0 (Aug 7, 2018)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,9 +3,7 @@ Releasing
 
  1. Bump the VERSION_NAME property in `gradle.properties` based on Major.Minor.Patch naming scheme
  2. Update `CHANGELOG.md` for the impending release.
- 3. Update the `README.md` with the new version.
- 4. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
- 5. `git tag -a X.Y.X -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 6. `./gradlew clean uploadArchives`
- 9. `git push && git push --tags`
- 10. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+ 3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
+ 4. `./gradlew clean uploadArchives`
+ 5. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+ 6. Open PR with on Github, merge, and publish release through Github UI.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.16.1
+VERSION_NAME=2.16.2
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **Fix** Kotlin lambdas can be used in model constructors (https://github.com/airbnb/epoxy/pull/501)
- **New** Added function to check whether a model build is pending (https://github.com/airbnb/epoxy/pull/506)