### PR TITLE
Release 2.16.4 with updated async handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.16.4 (Aug 23, 2018)
+- **New** `EpoxyAsyncUtil` and `AsyncEpoxyController` make it easier to use Epoxy's async behavior out of the box
+- **New** Epoxy's background diffing posts messages back to the main thread asynchronously so they are not blocked by waiting for vsync
+
 # 2.16.2 (Aug 23, 2018)
 - **Fix** Kotlin lambdas can be used in model constructors (https://github.com/airbnb/epoxy/pull/501)
 - **New** Added function to check whether a model build is pending (https://github.com/airbnb/epoxy/pull/506)

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/MainThreadExecutor.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/MainThreadExecutor.java
@@ -1,15 +1,14 @@
 package com.airbnb.epoxy;
 
-import android.os.Looper;
-
-import static com.airbnb.epoxy.EpoxyAsyncUtil.createHandler;
+import static com.airbnb.epoxy.EpoxyAsyncUtil.AYSNC_MAIN_THREAD_HANDLER;
+import static com.airbnb.epoxy.EpoxyAsyncUtil.MAIN_THREAD_HANDLER;
 
 class MainThreadExecutor extends HandlerExecutor {
   static final MainThreadExecutor INSTANCE = new MainThreadExecutor(false);
   static final MainThreadExecutor ASYNC_INSTANCE = new MainThreadExecutor(true);
 
   MainThreadExecutor(boolean async) {
-    super(createHandler(Looper.getMainLooper(), async));
+    super(async ? AYSNC_MAIN_THREAD_HANDLER : MAIN_THREAD_HANDLER);
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.16.2
+VERSION_NAME=2.16.4
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **New** `EpoxyAsyncUtil` and `AsyncEpoxyController` make it easier to use Epoxy's async behavior out of the box
- **New** Epoxy's background diffing posts messages back to the main thread asynchronously so they are not blocked by waiting for vsync