### PR TITLE
Prepare for release 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.17.0 (Sep 6, 2018)
+- **New** Add support for setting the Padding via resource or directly in dp (https://github.com/airbnb/epoxy/pull/528 Thanks to pwillmann!)
+- **Fixed** Strip kotlin metadata annotation from generated classes (https://github.com/airbnb/epoxy/pull/523)
+- **Fixed** Reflect the annotations declared in constructor params (https://github.com/airbnb/epoxy/pull/519 Thanks to Shaishav Gandhi!)
+
 # 2.16.4 (Aug 29, 2018)
 - **New** `EpoxyAsyncUtil` and `AsyncEpoxyController` make it easier to use Epoxy's async behavior out of the box
 - **New** Epoxy's background diffing posts messages back to the main thread asynchronously so they are not blocked by waiting for vsync

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.16.4
+VERSION_NAME=2.17.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/kotlinsample/src/test/java/com/airbnb/epoxy/kotlinsample/AnnotationModel.kt
+++ b/kotlinsample/src/test/java/com/airbnb/epoxy/kotlinsample/AnnotationModel.kt
@@ -9,7 +9,7 @@ import com.airbnb.epoxy.EpoxyHolder
 import com.airbnb.epoxy.EpoxyModelClass
 import com.airbnb.epoxy.EpoxyModelWithHolder
 
-@EpoxyModelClass(layout = R.layout.activity_kotlin_sample)
+@EpoxyModelClass(layout = R.layout.activity)
 abstract class AnnotationModel(
     @StringRes val resId: Int,
     @FloatRange(from = 0.0, to = 1.0) val range: Float


### PR DESCRIPTION
- **New** Add support for setting the Padding via resource or directly in dp (https://github.com/airbnb/epoxy/pull/528 Thanks to pwillmann!)
- **Fixed** Strip kotlin metadata annotation from generated classes (https://github.com/airbnb/epoxy/pull/523)
- **Fixed** Reflect the annotations declared in constructor params (https://github.com/airbnb/epoxy/pull/519 Thanks to Shaishav Gandhi!)