### PR TITLE
New system for keying listeners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ allprojects {
     google()
     jcenter()
   }
+  tasks.withType(Javadoc) {
+    options.addStringOption('Xdoclint:none', '-quiet')
+    options.addStringOption('encoding', 'UTF-8')
+  }
 }
 
 subprojects { project ->

--- a/epoxy-adapter/build.gradle
+++ b/epoxy-adapter/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion rootProject.COMPILE_SDK_VERSION
@@ -17,13 +19,14 @@ configurations.all { strategy ->
 }
 
 dependencies {
+  implementation rootProject.deps.kotlin
   compile rootProject.deps.androidAnnotations
   compile rootProject.deps.androidRecyclerView
   compile rootProject.deps.androidDesignLibrary
   compile rootProject.deps.androidSupportLibrary
   compile project(':epoxy-annotations')
 
-  annotationProcessor project(':epoxy-processor')
+  kapt project(':epoxy-processor')
 
   testCompile rootProject.deps.junit
   testCompile rootProject.deps.robolectric

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -32,6 +32,8 @@ public abstract class EpoxyModel<T> {
   private long id;
   @LayoutRes private int layout;
   private boolean shown = true;
+  boolean inKeyedListenerEquals;
+
   /**
    * Set to true once this model is diffed in an adapter. Used to ensure that this model's id
    * doesn't change after being diffed.

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -69,7 +69,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     epoxyModel = model;
   }
 
-  Object objectToBind() {
+  public Object objectToBind() {
     return epoxyHolder != null ? epoxyHolder : itemView;
   }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/KeyedListeners.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/KeyedListeners.kt
@@ -1,0 +1,163 @@
+package com.airbnb.epoxy
+
+import android.support.v7.widget.RecyclerView
+import android.util.Log
+import android.view.View
+import android.widget.CompoundButton
+
+// todo only apply DONotHash in callback prop if equals/hashcode does not exist on type?
+// Big refactor to remove DoNotHash completely and enforce keyed listeners everywhere?
+// Only apply if a build flag is passed?
+
+// Generate a kotlin extension function on builder interfaces for easily passing keyed listeners?
+//inline fun CarouselModelBuilder.onClickListener(crossinline onClick: ClickContext<View, Carousel, CarouselModel_>.() -> Unit) {
+//    onClickListener((this as CarouselModel_).keyedClickListener(onClick))
+//}
+
+// Generate keyed subclass of any type annotated with callback prop?
+
+inline fun <reified V : View, reified P : Any, reified T : EpoxyModel<P>> T.clickContext(
+    clickedView: V
+): ClickContext<V, P, T>? = ClickContext.from(clickedView)
+
+inline fun <reified V : Any, reified T : EpoxyModel<V>, Listener> T.keyedListener(
+    key: Any = this,
+    listener: Listener
+) = KeyedListener(key, listener)
+
+inline fun <reified V : Any, reified T : EpoxyModel<V>> T.keyedLongClickListener(
+    crossinline listener: ClickContext<View, V, T>.() -> Boolean
+) = KeyedLongClickListener(this, View.OnLongClickListener { v ->
+    val context = ClickContext.from<View, V, T>(v) ?: return@OnLongClickListener false
+    return@OnLongClickListener context.listener()
+})
+
+class KeyedLongClickListener(
+    key: Any,
+    listener: View.OnLongClickListener
+) : KeyedListener<View.OnLongClickListener>(key, listener), View.OnLongClickListener {
+
+    override fun onLongClick(v: View) = listener.onLongClick(v)
+}
+
+inline fun <reified V : Any, reified T : EpoxyModel<V>> T.keyedCheckedChangeListener(
+    crossinline listener: ClickContext<CompoundButton, V, T>.(isChecked: Boolean) -> Unit
+) = KeyedCheckedChangedListener(this, CompoundButton.OnCheckedChangeListener { v, isChecked ->
+    ClickContext.from<CompoundButton, V, T>(v)?.apply {
+        listener(isChecked)
+    }
+})
+
+class KeyedCheckedChangedListener(
+    key: Any,
+    listener: CompoundButton.OnCheckedChangeListener
+) : KeyedListener<CompoundButton.OnCheckedChangeListener>(key, listener),
+    CompoundButton.OnCheckedChangeListener {
+
+    override fun onCheckedChanged(buttonView: CompoundButton, isChecked: Boolean) {
+        listener.onCheckedChanged(buttonView, isChecked)
+    }
+}
+
+inline fun <reified V : Any, reified T : EpoxyModel<V>> T.keyedClickListener(
+    crossinline listener: ClickContext<View, V, T>.() -> Unit
+) = KeyedClickListener(this, View.OnClickListener { v ->
+    ClickContext.from<View, V, T>(v)?.apply(listener)
+})
+
+class KeyedClickListener(
+    key: Any,
+    listener: View.OnClickListener
+) : KeyedListener<View.OnClickListener>(key, listener), View.OnClickListener {
+
+    override fun onClick(v: View) = listener.onClick(v)
+}
+
+open class KeyedListener<Listener>(private val key: Any, val listener: Listener) {
+
+    // Only include the key, and not the listener, in equals/hashcode
+    override fun equals(other: Any?): Boolean {
+        val model = key as? EpoxyModel<*>
+        if (model?.inKeyedListenerEquals == true) return true
+        model?.inKeyedListenerEquals = true
+
+
+        if (this === other) return true
+        if (other !is KeyedListener<*>) return false
+        val isEqual = key == other.key
+
+        model?.inKeyedListenerEquals = false
+        return isEqual
+    }
+
+    override fun hashCode(): Int {
+        val model = key as? EpoxyModel<*>
+        if (model?.inKeyedListenerEquals == true) return 0
+        model?.inKeyedListenerEquals = true
+
+        val result = key.hashCode()
+
+        model?.inKeyedListenerEquals = false
+        return result
+    }
+}
+
+data class ClickContext<V : View, P : Any, T : EpoxyModel<P>>(
+    val model: T,
+    val parentView: P,
+    val clickedView: V,
+    val position: Int
+) {
+
+    companion object {
+        inline fun <reified V : View, reified P : Any, reified T : EpoxyModel<P>> from(clickedView: V): ClickContext<V, P, T>? {
+            val epoxyHolder = getEpoxyHolderForChildView(clickedView)
+                ?: throw IllegalStateException("Could not find RecyclerView holder for clicked view ${V::class.java.simpleName}")
+
+            val adapterPosition = epoxyHolder.adapterPosition
+            if (adapterPosition == RecyclerView.NO_POSITION) {
+                // View is being removed, ignore the click.
+                return null
+            }
+
+            val model = epoxyHolder.model as? T ?: run {
+                Log.e(
+                    "Epoxy",
+                    "Failed to cast ${epoxyHolder.model::class.java.simpleName} to model ${T::class.java.simpleName}"
+                )
+                return null
+            }
+
+            val parentView = epoxyHolder.objectToBind() as? P ?: run {
+                Log.e(
+                    "Epoxy",
+                    "Failed to cast ${epoxyHolder.objectToBind()::class.java.simpleName} to view ${V::class.java.simpleName}"
+                )
+                return null
+            }
+
+            return ClickContext(
+                model,
+                parentView,
+                clickedView,
+                adapterPosition
+            )
+        }
+    }
+}
+
+fun getEpoxyHolderForChildView(v: View): EpoxyViewHolder? {
+    val recyclerView = findParentRecyclerView(v) ?: return null
+    val viewHolder = recyclerView.findContainingViewHolder(v) ?: return null
+    return viewHolder as? EpoxyViewHolder
+}
+
+fun findParentRecyclerView(v: View?): RecyclerView? {
+    val parent = v?.parent ?: return null
+
+    return when (parent) {
+        is RecyclerView -> parent
+        is View -> findParentRecyclerView(parent)
+        else -> null
+    }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewInfo.kt
@@ -13,7 +13,6 @@ import javax.lang.model.type.MirroredTypeException
 import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
-import javax.tools.Diagnostic
 
 internal class ModelViewInfo(
     val viewElement: TypeElement,
@@ -21,7 +20,8 @@ internal class ModelViewInfo(
     val elements: Elements,
     val errorLogger: ErrorLogger,
     private val configManager: ConfigManager,
-    private val resourceProcessor: ResourceProcessor
+    private val resourceProcessor: ResourceProcessor,
+    private val hashCodeValidator: HashCodeValidator
 ) : GeneratedModelInfo() {
     val resetMethodNames = mutableListOf<String>()
     val afterPropsSetMethodNames = mutableListOf<String>()
@@ -179,7 +179,7 @@ internal class ModelViewInfo(
         addAttribute(
             ViewAttributeInfo(
                 this, prop, typeUtils, elements, errorLogger,
-                resourceProcessor
+                resourceProcessor, hashCodeValidator
             )
         )
     }
@@ -188,7 +188,7 @@ internal class ModelViewInfo(
         addAttributeIfNotExists(
             ViewAttributeInfo(
                 this, prop, typeUtils, elements, errorLogger,
-                resourceProcessor
+                resourceProcessor, hashCodeValidator
             )
         )
     }


### PR DESCRIPTION
There has been a lot of issues and confusion, both within airbnb and externally, because of the `DoNotHash` option and how to deal with callbacks that capture state that may change.

This PR takes the approach suggested in this issue: https://github.com/airbnb/epoxy/issues/414

There is a `KeyedListener` class that wraps any kind of callback, and implements equals/hashcode with the value of a given key.

To make this easy to use I've written several helper functions in kotlin - java would make dealing with the generics a big pain, and kotlin also lets us do some nice things with reified type checking and extension functions. This is the first time I'm adding kotlin to the core module, but I think it's about time :P 

Note, I haven't written much code comments yet to avoid wasting time if the design changes, so consider it a WIP.

Usage for creating the listeners looks like this:
```kotlin
CarouselModel_().apply {

        // Click listener keyed on model
        onClickListener(keyedClickListener {

        })

        // Long click listener keyed on model
        keyedLongClickListener {
            return@keyedLongClickListener false
        }

        // Custom listener type, keyed on model
        keyedListener {
            4
        }

        // Custom listener type, keyed on user defined key
        keyedListener("custom key") {

        }

        // Custom interface callback, keyed on custom key
        keyedListener("some key", object : MyCustomInterface {
            override fun doSomething(view: View) {

                // Get details on the model and view
                val (model, parentView, clickedView, position) = clickContext(view) ?: return
            }
        })
    }
```

**High level points**
- Helpers like `keyedClickListener` create a click listener that is keyed on the model value, excluding listeners. So if the model changes at all the click listener is considered different and will be updated
- There are other helpers for using custom lambdas or interfaces as keyed callbacks.
- A custom key can be used if you don't want to key on the model
- Keyed listeners can access the `ClickContext` to get the most up to date model object, view, and adapter position. This can be accessed via the clicked view, or for default click listeners it is the lambda receiver for easy access
- I've updated the `@CallbackProp` annotation to only apply DoNotHash behavior if the type does not have equals/hashcode. This means you can use a KeyedListener with CallbackProp and it will be updated as expected


**Issues**
- This adds another way to handle click listeners, on top of the previous `OnModelClickListener` support. This is a bit confusing.
- If `@CallbackProp` is used you still need to explicitly define the listener type as KeyedClickListener for the hashing to work (same for databinding)
- The extension functions currently operate on the EpoxyModel as a receiver, so they won't work with the model builder extension functions. I would need to generate other methods for those to work

In general there is a lot of knowledge and overhead required to choose the right option and make sure your code has the right behavior. I think the only way to solve this is with a fairly drastic breaking change of how the generated models use listeners - that is maybe possible in the future, but this seems like a good step for now.

@ngsilverman @chrisbanes 