### PR TITLE
Remove app_name

### DIFF
--- a/epoxy-adapter/src/main/res/values/strings.xml
+++ b/epoxy-adapter/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Epoxy</string>
-</resources>

--- a/epoxy-databinding/src/main/AndroidManifest.xml
+++ b/epoxy-databinding/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
 
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application
+        android:supportsRtl="true"/>
 
 </manifest>

--- a/epoxy-databinding/src/main/res/values/strings.xml
+++ b/epoxy-databinding/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Epoxy DataBinding</string>
-</resources>

--- a/epoxy-litho/src/main/AndroidManifest.xml
+++ b/epoxy-litho/src/main/AndroidManifest.xml
@@ -3,9 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+        android:supportsRtl="true"/>
 
 </manifest>

--- a/epoxy-litho/src/main/res/values/strings.xml
+++ b/epoxy-litho/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Epoxy Litho</string>
-</resources>

--- a/epoxy-modelfactory/src/main/res/values/strings.xml
+++ b/epoxy-modelfactory/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Epoxy Model Factory</string>
-</resources>

--- a/epoxy-paging/src/main/res/values/strings.xml
+++ b/epoxy-paging/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Epoxy Paging</string>
-</resources>


### PR DESCRIPTION
Thank you for response:) 
This is PR for #542 .

## What does this change?
- I removed `app_name` from epoxy libraries.
- I fixed `AndroidManifest`.

## What is the value of this and can you measure success?
- When you build to aar, libraries don't have `app_name`.

## Screenshots
When import `epoxy-adapter`, `epoxy-databinding` into my app, I was sure that does not contain. (epoxy-adapter)

|Before res(epoxy-adapter)|After res(build in debug aar)|
|-|-|
|<img width="800" alt="2018-09-20 10 24 24" src="https://user-images.githubusercontent.com/17718156/45790461-efa2cf00-bcbf-11e8-8f2f-f274bbe0b38b.png">|<img width="465" alt="2018-09-20 10 23 56" src="https://user-images.githubusercontent.com/17718156/45790549-414b5980-bcc0-11e8-8765-5df7073c6b37.png">|