### PR TITLE
RFC: WIP: Rough version of paging and multiplexed models

### DIFF
--- a/epoxy-paging/src/main/java/com/airbnb/epoxy/paging/PagedListEpoxyController.kt
+++ b/epoxy-paging/src/main/java/com/airbnb/epoxy/paging/PagedListEpoxyController.kt
@@ -85,7 +85,7 @@ abstract class PagedListEpoxyController<T>(
    * If the `item` is `null`, you should provide the placeholder. If your [PagedList] is configured
    * without placeholders, you don't need to handle the `null` case.
    */
-  abstract fun buildItemModel(currentPosition: Int, item: T?): EpoxyModel<*>
+  abstract fun buildItemModel(currentPosition: Int, item: T?): List<EpoxyModel<*>>
 
   override fun onModelBound(
     holder: EpoxyViewHolder,
@@ -94,7 +94,7 @@ abstract class PagedListEpoxyController<T>(
     previouslyBoundModel: EpoxyModel<*>?
   ) {
     // TODO the position may not be a good value if there are too many injected items.
-    modelCache.loadAround(position)
+    modelCache.loadAround(boundModel)
   }
 
   /**

--- a/epoxy-pagingsample/src/main/java/com/airbnb/epoxy/pagingsample/PagingSampleActivity.kt
+++ b/epoxy-pagingsample/src/main/java/com/airbnb/epoxy/pagingsample/PagingSampleActivity.kt
@@ -14,6 +14,7 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.AppCompatTextView
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
+import android.util.Log
 import com.airbnb.epoxy.EpoxyAsyncUtil
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.ModelView
@@ -39,21 +40,36 @@ class PagingSampleActivity : AppCompatActivity() {
         viewModel.pagedList.observe(this, Observer {
           pagingController.submitList(it)
         })
+
+        recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    Log.d("rdhruva", "Items in RV: ${recyclerView.adapter.itemCount}")
+                }
+            }
+        })
     }
 }
 
 class TestController : PagedListEpoxyController<User>(
     modelBuildingHandler = EpoxyAsyncUtil.getAsyncBackgroundHandler()
 ) {
-    override fun buildItemModel(currentPosition: Int, item: User?): EpoxyModel<*> {
+    override fun buildItemModel(currentPosition: Int, item: User?): List<EpoxyModel<*>> {
         return if (item == null) {
-            PagingViewModel_()
-                .id(-currentPosition)
-                .name("loading ${currentPosition}")
+            listOf(
+                PagingViewModel_()
+                    .id(-currentPosition)
+                    .name("loading ${currentPosition}")
+            )
         } else {
-            PagingViewModel_()
-                .id(item.uid)
-                .name("${item.uid}: ${item.firstName} / ${item.lastName}")
+            listOf(
+                PagingViewModel_()
+                    .id(item.uid)
+                    .name("${item.uid}: ${item.firstName} / ${item.lastName}"),
+                PagingViewModel_()
+                    .id(Int.MAX_VALUE - item.uid)
+                    .name("Second model for ${item.uid}")
+            )
         }
     }
 
@@ -67,6 +83,9 @@ class TestController : PagedListEpoxyController<User>(
 
     init {
         isDebugLoggingEnabled = true
+        addInterceptor {
+            Log.d("rdhruva", "Items in model list: ${it.size}")
+        }
     }
 
     override fun onExceptionSwallowed(exception: RuntimeException) {


### PR DESCRIPTION
This is a first, very very WIP take at #566. Working off of @yigit 's comment on the issue, this PR changes the `modelCache` to be a linked map of epoxy model to item position. 

I'd love to get thoughts and comments on the approach, however there is a lot to do before this can be finalized. This is also a good opportunity to discuss the API that we want to expose for something like this. 

In its current form, this implementation has crashes (out of bounds and concurrent modification) and I've not cleaned up the log statements. However, if the approach looks good, I can work further on cleaning it up and making the hashmap operations more solid. 