### PR TITLE
Follow-up for visibility tracking : react to adapter data changes

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -173,5 +173,9 @@ class EpoxyVisibilityItem {
   private boolean checkAndUpdateFullImpressionVisible() {
     return fullyVisible = visibleSize == sizeInScrollingDirection;
   }
+
+  void shiftBy(int offsetPosition) {
+    adapterPosition += offsetPosition;
+  }
 }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -271,6 +271,9 @@ public class EpoxyVisibilityTracker {
      */
     @Override
     public void onChanged() {
+      if (DEBUG_LOG) {
+        Log.d(TAG, "onChanged()");
+      }
       visibilityIdToItemMap.clear();
       visibilityIdToItems.clear();
     }
@@ -281,6 +284,9 @@ public class EpoxyVisibilityTracker {
      */
     @Override
     public void onItemRangeInserted(int positionStart, int itemCount) {
+      if (DEBUG_LOG) {
+        Log.d(TAG, String.format("onItemRangeInserted(%d, %d)", positionStart, itemCount));
+      }
       for (EpoxyVisibilityItem item : visibilityIdToItems) {
         if (item.getAdapterPosition() >= positionStart) {
           item.shiftBy(itemCount);
@@ -294,6 +300,9 @@ public class EpoxyVisibilityTracker {
      */
     @Override
     public void onItemRangeRemoved(int positionStart, int itemCount) {
+      if (DEBUG_LOG) {
+        Log.d(TAG, String.format("onItemRangeRemoved(%d, %d)", positionStart, itemCount));
+      }
       for (EpoxyVisibilityItem item : visibilityIdToItems) {
         if (item.getAdapterPosition() >= positionStart) {
           item.shiftBy(-itemCount);
@@ -303,6 +312,16 @@ public class EpoxyVisibilityTracker {
 
     @Override
     public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
+      if (DEBUG_LOG) {
+        Log.d(TAG,
+            String.format("onItemRangeMoved(%d, %d, %d)", fromPosition, toPosition, itemCount));
+      }
+      for (EpoxyVisibilityItem item : visibilityIdToItems) {
+        int position = item.getAdapterPosition();
+        if (position == fromPosition) {
+          item.shiftBy(toPosition - fromPosition);
+        }
+      }
     }
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -3,12 +3,17 @@ package com.airbnb.epoxy;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.Adapter;
+import android.support.v7.widget.RecyclerView.AdapterDataObserver;
 import android.support.v7.widget.RecyclerView.OnChildAttachStateChangeListener;
 import android.support.v7.widget.RecyclerView.OnScrollListener;
 import android.support.v7.widget.RecyclerView.ViewHolder;
 import android.util.SparseArray;
 import android.view.View;
 import android.view.View.OnLayoutChangeListener;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A simple way to track visibility events on {@link com.airbnb.epoxy.EpoxyModel} within a {@link
@@ -21,6 +26,7 @@ import android.view.View.OnLayoutChangeListener;
  * Note regarding nested lists: The visibility event tracking is not properly handled yet. This is
  * on the todo.
  * <p>
+ *
  * @see OnVisibilityChanged
  * @see OnVisibilityStateChanged
  * @see OnModelVisibilityChangedListener
@@ -30,12 +36,18 @@ public class EpoxyVisibilityTracker {
 
   /** Maintain visibility item indexed by view id (identity hashcode) */
   private final SparseArray<EpoxyVisibilityItem> visibilityIdToItemMap = new SparseArray<>();
+  private final List<EpoxyVisibilityItem> visibilityIdToItems = new ArrayList<>();
 
   /** listener used to process scroll, layout and attach events */
   private final Listener listener = new Listener();
 
+  /** listener used to process data events */
+  private final DataObserver observer = new DataObserver();
+
   @Nullable
   private RecyclerView attachedRecyclerView = null;
+  @Nullable
+  private Adapter lastAdapterSeen = null;
 
   private boolean onChangedEnabled = true;
 
@@ -74,48 +86,86 @@ public class EpoxyVisibilityTracker {
     attachedRecyclerView = null;
   }
 
-  private void processChildren() {
+  private void processChangeEvent(String debug) {
+    processChildren(null, debug);
+  }
+
+  private void processChangeEventWithDetachedView(@Nullable View detachedView, String debug) {
+    processChildren(detachedView, debug);
+  }
+
+  private void processChildren(@Nullable View detachedView, String debug) {
+    processNewAdapterInNecessary();
     final RecyclerView recyclerView = attachedRecyclerView;
     if (recyclerView != null) {
       for (int i = 0; i < recyclerView.getChildCount(); i++) {
         final View child = recyclerView.getChildAt(i);
         if (child != null) {
-          processChild(child);
+          processChild(child, child == detachedView, debug);
         }
       }
     }
   }
 
-  private void processChild(@NonNull View child) {
-    processChild(child, false);
+  /**
+   * If there is a new adapter on the attached RecyclerView it will resister the data observer and
+   * clear the current visibility states
+   */
+  private void processNewAdapterInNecessary() {
+    if (attachedRecyclerView != null && attachedRecyclerView.getAdapter() != null) {
+      if (lastAdapterSeen != attachedRecyclerView.getAdapter()) {
+        if (lastAdapterSeen != null) {
+          // Unregister the old adapter
+          lastAdapterSeen.unregisterAdapterDataObserver(this.observer);
+        }
+        // Register the new adapter
+        attachedRecyclerView.getAdapter().registerAdapterDataObserver(this.observer);
+        lastAdapterSeen = attachedRecyclerView.getAdapter();
+        // Clear our visibility items
+        visibilityIdToItemMap.clear();
+        visibilityIdToItems.clear();
+        System.out.println("attached on " + lastAdapterSeen);
+      }
+    }
   }
 
-  private void processChild(@NonNull View child, boolean detachEvent) {
+  private void processChild(@NonNull View child, boolean detachEvent, String debug) {
     final RecyclerView recyclerView = attachedRecyclerView;
     if (recyclerView != null) {
       recyclerView.getChildViewHolder(child);
       final ViewHolder holder = recyclerView.getChildViewHolder(child);
       if (holder instanceof EpoxyViewHolder) {
         processVisibilityEvents(recyclerView, (EpoxyViewHolder) holder,
-            recyclerView.getLayoutManager().canScrollVertically(), detachEvent);
-      } else throw new IllegalEpoxyUsage(
-          "`EpoxyVisibilityTracker` cannot be used with non-epoxy view holders."
-      );
+            recyclerView.getLayoutManager().canScrollVertically(), detachEvent, debug);
+      } else {
+        throw new IllegalEpoxyUsage(
+            "`EpoxyVisibilityTracker` cannot be used with non-epoxy view holders."
+        );
+      }
     }
   }
 
   private void processVisibilityEvents(
       @NonNull RecyclerView recyclerView,
       @NonNull EpoxyViewHolder epoxyHolder,
-      boolean vertical, boolean detachEvent
+      boolean vertical, boolean detachEvent, String debug
   ) {
 
     // TODO EpoxyVisibilityTrackerTest testInsertData / testInsertData are disabled as they fail as
     // insert/delete not properly handled in the tracker
 
-    if (epoxyHolder.getAdapterPosition() == RecyclerView.NO_POSITION) {
-      return;
-    }
+    System.out.println(String.format(debug +
+            ".processVisibilityEvents %s, %s, %s",
+        System.identityHashCode(epoxyHolder),
+        detachEvent,
+        epoxyHolder.getAdapterPosition()
+    ));
+//    new Throwable(String.format(
+//        "processVisibilityEvents %s, %s, %s",
+//        System.identityHashCode(epoxyHolder),
+//        detachEvent,
+//        epoxyHolder.getAdapterPosition()
+//    )).printStackTrace();
 
     final View itemView = epoxyHolder.itemView;
     final int id = System.identityHashCode(itemView);
@@ -124,11 +174,18 @@ public class EpoxyVisibilityTracker {
     if (vi == null) {
       vi = new EpoxyVisibilityItem();
       visibilityIdToItemMap.put(id, vi);
+      visibilityIdToItems.add(vi);
+    }
+
+    if (epoxyHolder.getAdapterPosition() == RecyclerView.NO_POSITION) {
+      System.out.println("no position vs " + vi.getAdapterPosition());
+      return;
     }
 
     if (vi.getAdapterPosition() != epoxyHolder.getAdapterPosition()) {
       // EpoxyVisibilityItem being re-used for a different position
       vi.reset(epoxyHolder.getAdapterPosition());
+      System.out.println("reset");
     }
 
     if (vi.update(itemView, recyclerView, vertical, detachEvent)) {
@@ -155,22 +212,58 @@ public class EpoxyVisibilityTracker {
         int left, int top, int right, int bottom,
         int oldLeft, int oldTop, int oldRight, int oldBottom
     ) {
-      processChildren();
+      processChangeEvent("onLayoutChange");
     }
 
     @Override
     public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
-      processChildren();
+      processChangeEvent("onScrolled");
     }
 
     @Override
     public void onChildViewAttachedToWindow(View child) {
-      processChild(child);
+      processChangeEvent("onChildViewAttachedToWindow");
     }
 
     @Override
     public void onChildViewDetachedFromWindow(View child) {
-      processChild(child, true);
+      // On detach event send the detached view
+      processChangeEventWithDetachedView(child, "onChildViewDetachedFromWindow");
+    }
+  }
+
+  class DataObserver extends AdapterDataObserver {
+
+    @Override
+    public void onChanged() {
+      // Clear the current visibility states
+      visibilityIdToItemMap.clear();
+      visibilityIdToItems.clear();
+    }
+
+    @Override
+    public void onItemRangeInserted(int positionStart, int itemCount) {
+      // For all items after the inserted range shift the adapter position by item count
+      for (EpoxyVisibilityItem item : visibilityIdToItems) {
+        if (item.getAdapterPosition() >= positionStart) {
+          item.shiftBy(itemCount);
+        }
+      }
+    }
+
+    @Override
+    public void onItemRangeRemoved(int positionStart, int itemCount) {
+      // For all items after the inserted range shift the adapter position by item count
+      for (EpoxyVisibilityItem item : visibilityIdToItems) {
+        if (item.getAdapterPosition() >= positionStart) {
+          item.shiftBy(-itemCount);
+        }
+      }
+    }
+
+    @Override
+    public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
+      System.out.println("onItemRangeMoved");
     }
   }
 }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.TextView
+import com.airbnb.epoxy.EpoxyVisibilityTracker.DEBUG_LOG
 import com.airbnb.epoxy.VisibilityState.FOCUSED_VISIBLE
 import com.airbnb.epoxy.VisibilityState.FULL_IMPRESSION_VISIBLE
 import com.airbnb.epoxy.VisibilityState.INVISIBLE
@@ -48,7 +49,6 @@ class EpoxyVisibilityTrackerTest {
             FULL_IMPRESSION_VISIBLE
         )
 
-        private const val DEBUG_LOG = true
         private fun log(message: String) {
             if (DEBUG_LOG) System.out.println(message)
         }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -137,7 +137,7 @@ class EpoxyVisibilityTrackerTest {
     /**
      * Test visibility events when loading a recycler view
      */
-    // @Test TODO make insert works
+    @Test
     fun testInsertData() {
 
         // Build initial list
@@ -173,6 +173,7 @@ class EpoxyVisibilityTrackerTest {
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    UNFOCUSED_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
             )
@@ -195,7 +196,7 @@ class EpoxyVisibilityTrackerTest {
     /**
      * Test visibility events when loading a recycler view
      */
-    // @Test TODO make delete works
+    @Test
     fun testDeleteData() {
 
         // Build initial list


### PR DESCRIPTION
Follow-up for visibility tracking (#560). This fix the case where item get added, removed or moved from the adapter. For doing it it require to add a `AdapterDataObserver` on the current adapter. The idea is to shift the adapter position maintained in the visibility item.

This chance activate `testInsertData` / `testDeleteData` tests  and add  a new test : `testMoveData`.