### PR TITLE
Use robolectric qualifiers in EpoxyVisibilityTrackerTest to give more control on view's height

### DIFF
--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -53,6 +53,11 @@ class EpoxyVisibilityTrackerTest {
             FULL_IMPRESSION_VISIBLE
         )
 
+        /**
+         * Tolerance used for robolectric ui assertions when comparing data in pixels
+         */
+        private const val HEIGHT_TOLERANCE_PIXELS = 1
+
         private fun log(message: String) {
             if (DEBUG_LOG) {
                 Log.d(TAG, message)
@@ -766,10 +771,11 @@ class EpoxyVisibilityTrackerTest {
                 )
             }
             visibleHeight?.let {
-                // assert with 1px precision
+                // assert using tolerance, see HEIGHT_TOLERANCE_PIXELS
+                log("assert visibleHeight, got $it, expected ${this.visibleHeight}")
                 Assert.assertTrue(
-                    "visibleHeight expected $it got ${this.visibleHeight}",
-                    Math.abs(it - this.visibleHeight) < 1
+                    "visibleHeight expected ${it}px got ${this.visibleHeight}px",
+                    Math.abs(it - this.visibleHeight) < HEIGHT_TOLERANCE_PIXELS
                 )
             }
             percentVisibleHeight?.let {

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -29,8 +29,12 @@ import java.lang.StringBuilder
  * view port height is provided by Robolectric.
  *
  * We are just controlling how many items are displayed with VISIBLE_ITEMS constant.
+ *
+ * In order to control the RecyclerView's height we are using theses qualifiers:
+ * - `mdpi` for density factor 1
+ * - `h831dp` where : 831 = 56 (ToolBar) + 775 (RecyclerView)
  */
-@Config(sdk = [21], manifest = TestRunner.MANIFEST_PATH)
+@Config(sdk = [21], manifest = TestRunner.MANIFEST_PATH, qualifiers = "h831dp-mdpi")
 @RunWith(TestRunner::class)
 class EpoxyVisibilityTrackerTest {
 


### PR DESCRIPTION
When updating to Roboletric 3.8 (from 3.4.2) some tests would break, they must have changed the default activity's window size. So in order have more control the RecyclerView's height we are using theses qualifiers: `qualifiers = "h831dp-mdpi"`
- `mdpi` for density factor 1
 - `h831dp` where : 831 = 56 (ToolBar) + 775 (RecyclerView)

This change should unblock `androidx` migration : https://github.com/airbnb/epoxy/pull/440