### PR TITLE
Prepare for release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-# WIP 3.0.0 (TBD)
+# 3.0.0 (Nov 13, 2018)
 
-- **Breaking** Migrated to androidx packages
+- **Breaking** Migrated to androidx packages (Big thanks to jeffreydelooff!)
+
+- **Breaking** The `Carousel.Padding` class changed the ordering of its parameters to match Android's ordering of "left, top, right, bottom". (https://github.com/airbnb/epoxy/pull/536 thanks to martinbonnin)
+    
+   This change won't break compilation, so you _must_ manually change your parameter ordering, otherwise you will get unexpected padding results.
 
 # 2.19.0 (Oct 18, 2018)
 This release adds built in support for monitoring visibility of views in the RecyclerView. (https://github.com/airbnb/epoxy/pull/560)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,6 @@ Releasing
  1. Bump the VERSION_NAME property in `gradle.properties` based on Major.Minor.Patch naming scheme
  2. Update `CHANGELOG.md` for the impending release.
  3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
- 4. `./gradlew clean uploadArchives`
+ 4. `./gradlew assemble uploadArchives`
  5. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
  6. Open PR with on Github, merge, and publish release through Github UI.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.0.0-SNAPSHOT
+VERSION_NAME=3.0.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **Breaking** Migrated to androidx packages (Big thanks to jeffreydelooff!)

- **Breaking** The `Carousel.Padding` class changed the ordering of its parameters to match Android's ordering of "left, top, right, bottom". (https://github.com/airbnb/epoxy/pull/536 thanks to martinbonnin)
    
   This change won't break compilation, so you _must_ manually change your parameter ordering, otherwise you will get unexpected padding results.