### PR TITLE
Add support for nested RecyclerView to EpoxyVisibilityTracker - Part 1

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -31,9 +31,6 @@ class EpoxyVisibilityItem {
   @Px
   private int width;
 
-  private float percentVisibleHeight = 0.f;
-  private float percentVisibleWidth = 0.f;
-
   @Px
   private int visibleHeight;
   @Px
@@ -66,15 +63,13 @@ class EpoxyVisibilityItem {
   boolean update(@NonNull View view, @NonNull RecyclerView parent, boolean detachEvent) {
     // Clear the rect before calling getLocalVisibleRect
     localVisibleRect.setEmpty();
-    boolean visibleRect = view.getLocalVisibleRect(localVisibleRect);
-    height = view.getMeasuredHeight();
-    width = view.getMeasuredWidth();
-    viewportHeight = parent.getMeasuredHeight();
-    viewportWidth = parent.getMeasuredWidth();
-    visibleHeight = detachEvent || !visibleRect ? 0 : localVisibleRect.height();
-    visibleWidth = detachEvent || !visibleRect ? 0 : localVisibleRect.width();
-    percentVisibleHeight = detachEvent || !visibleRect ? 0 : 100.f / height * visibleHeight;
-    percentVisibleWidth = detachEvent || !visibleRect ? 0 : 100.f / width * visibleWidth;
+    boolean viewDrawn = view.getLocalVisibleRect(localVisibleRect) && !detachEvent;
+    height = view.getHeight();
+    width = view.getWidth();
+    viewportHeight = parent.getHeight();
+    viewportWidth = parent.getWidth();
+    visibleHeight = viewDrawn ? localVisibleRect.height() : 0;
+    visibleWidth = viewDrawn ? localVisibleRect.width() : 0;
     if (visibleHeight != height || visibleWidth != width) {
       fullyVisible = false;
     }
@@ -119,8 +114,11 @@ class EpoxyVisibilityItem {
 
   void handleChanged(EpoxyViewHolder epoxyHolder) {
     if (visibleHeight != lastVisibleHeightNotified || visibleWidth != lastVisibleWidthNotified) {
-        epoxyHolder.visibilityChanged(percentVisibleHeight, percentVisibleWidth, visibleHeight,
-            visibleWidth);
+      epoxyHolder.visibilityChanged(
+          100.f / height * visibleHeight,
+          100.f / width * visibleWidth,
+          visibleHeight, visibleWidth
+      );
       lastVisibleHeightNotified = visibleHeight;
       lastVisibleWidthNotified = visibleWidth;
     }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -148,11 +148,8 @@ class EpoxyVisibilityItem {
    * component is smaller than half the viewport, when it is fully visible.
    */
   private boolean checkAndUpdateFocusedVisible() {
-    boolean focusedVisibleHeight = height >= viewportHeight / 2 || (visibleHeight == height
-        && height < viewportHeight / 2);
-    boolean focusedVisibleWidth = width >= viewportWidth / 2 || (visibleWidth == width
-        && width < viewportWidth / 2);
-    return focusedVisible = focusedVisibleHeight && focusedVisibleWidth;
+    focusedVisible = isInFocusVisible();
+    return focusedVisible;
   }
 
   /**
@@ -161,15 +158,23 @@ class EpoxyVisibilityItem {
    * not occupy at least half the viewport.
    */
   private boolean checkAndUpdateUnfocusedVisible(boolean detachEvent) {
-    boolean unfocusedVisibleHeight = !(height >= viewportHeight / 2 || (
-        visibleHeight == height && height < viewportHeight / 2));
-    boolean unfocusedVisibleWidth = !(width >= viewportWidth / 2 || (
-        viewportWidth == width && width < viewportWidth / 2));
-    boolean unfocusedVisible = detachEvent || unfocusedVisibleHeight || unfocusedVisibleWidth;
+    boolean unfocusedVisible = detachEvent || !isInFocusVisible();
     if (unfocusedVisible) {
       focusedVisible = false;
     }
     return !focusedVisible;
+  }
+
+  private boolean isInFocusVisible() {
+    final int halfViewportArea = viewportHeight * viewportWidth / 2;
+    final int totalArea = height * width;
+    final int visibleArea = visibleHeight * visibleWidth;
+    // The model has entered the focused range either if it is larger than half of the viewport
+    // and it occupies at least half of the viewport or if it is smaller than half of the viewport
+    // and it is fully visible.
+    return focusedVisible = (totalArea >= halfViewportArea)
+        ? (visibleArea >= halfViewportArea)
+        : totalArea == visibleArea;
   }
 
   /**

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -114,7 +114,9 @@ class EpoxyVisibilityItem {
     boolean previousFullyVisible = fullyVisible;
     fullyVisible = !detachEvent && isFullyVisible();
     if (fullyVisible != previousFullyVisible) {
-      epoxyHolder.visibilityStateChanged(VisibilityState.FULL_IMPRESSION_VISIBLE);
+      if (fullyVisible) {
+        epoxyHolder.visibilityStateChanged(VisibilityState.FULL_IMPRESSION_VISIBLE);
+      }
     }
   }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -75,7 +75,7 @@ class EpoxyVisibilityItem {
     visibleWidth = detachEvent || !visibleRect ? 0 : localVisibleRect.width();
     percentVisibleHeight = detachEvent || !visibleRect ? 0 : 100.f / height * visibleHeight;
     percentVisibleWidth = detachEvent || !visibleRect ? 0 : 100.f / width * visibleWidth;
-    if (visibleHeight != height || visibleWidth != width ) {
+    if (visibleHeight != height || visibleWidth != width) {
       fullyVisible = false;
     }
     return height > 0 && width > 0;
@@ -165,7 +165,7 @@ class EpoxyVisibilityItem {
   private boolean checkAndUpdateUnfocusedVisible(boolean detachEvent) {
     boolean unfocusedVisibleHeight = !(height >= viewportHeight / 2 || (
         visibleHeight == height && height < viewportHeight / 2));
-    boolean unfocusedVisibleWidth= !(width >= viewportWidth / 2 || (
+    boolean unfocusedVisibleWidth = !(width >= viewportWidth / 2 || (
         viewportWidth == width && width < viewportWidth / 2));
     boolean unfocusedVisible = detachEvent || unfocusedVisibleHeight || unfocusedVisibleWidth;
     if (unfocusedVisible) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -172,7 +172,6 @@ public class EpoxyVisibilityTracker {
         processVisibilityEvents(
             recyclerView,
             (EpoxyViewHolder) holder,
-            recyclerView.getLayoutManager().canScrollVertically(),
             detachEvent,
             eventOriginForDebug
         );
@@ -190,7 +189,6 @@ public class EpoxyVisibilityTracker {
    *
    * @param recyclerView        the recycler view
    * @param epoxyHolder         the {@link RecyclerView}
-   * @param vertical            true if the scrolling is vertical
    * @param detachEvent         true if the event originated from a view detached from the
    *                            recycler view
    * @param eventOriginForDebug a debug strings used for logs
@@ -198,7 +196,7 @@ public class EpoxyVisibilityTracker {
   private void processVisibilityEvents(
       @NonNull RecyclerView recyclerView,
       @NonNull EpoxyViewHolder epoxyHolder,
-      boolean vertical, boolean detachEvent,
+      boolean detachEvent,
       String eventOriginForDebug
   ) {
 
@@ -226,7 +224,7 @@ public class EpoxyVisibilityTracker {
       vi.reset(epoxyHolder.getAdapterPosition());
     }
 
-    if (vi.update(itemView, recyclerView, vertical, detachEvent)) {
+    if (vi.update(itemView, recyclerView, detachEvent)) {
       // View is measured, process events
       vi.handleVisible(epoxyHolder, detachEvent);
       vi.handleFocus(epoxyHolder, detachEvent);

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
@@ -8,10 +8,11 @@ import androidx.appcompat.app.AppCompatActivity
 import com.airbnb.epoxy.EpoxyController
 import com.airbnb.epoxy.EpoxyRecyclerView
 import com.airbnb.epoxy.EpoxyVisibilityTracker
-import com.airbnb.epoxy.OnModelVisibilityStateChangedListener
+import com.airbnb.epoxy.kotlinsample.models.CarouselItemCustomViewModel_
 import com.airbnb.epoxy.kotlinsample.models.ItemDataClass
 import com.airbnb.epoxy.kotlinsample.models.itemCustomView
 import com.airbnb.epoxy.kotlinsample.models.itemEpoxyHolder
+import com.airbnb.epoxy.kotlinsample.views.carouselNoSnap
 
 class MainActivity : AppCompatActivity() {
     private lateinit var recyclerView: EpoxyRecyclerView
@@ -56,6 +57,20 @@ class MainActivity : AppCompatActivity() {
                         Toast.makeText(this@MainActivity, "clicked", Toast.LENGTH_LONG)
                             .show()
                     }
+                }
+
+                carouselNoSnap {
+                    id("carousel $i")
+                    models(mutableListOf<CarouselItemCustomViewModel_>().apply {
+                        val lastPage = 10
+                        for (j in 0 until lastPage) {
+                            add(
+                                CarouselItemCustomViewModel_()
+                                    .id("carousel $i-$j")
+                                    .title("Page $j / $lastPage")
+                            )
+                        }
+                    })
                 }
 
                 // Since data classes do not use code generation, there's no extension generated here

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/CarouselItemCustomView.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/CarouselItemCustomView.kt
@@ -3,13 +3,9 @@ package com.airbnb.epoxy.kotlinsample.models
 import android.content.Context
 import android.util.AttributeSet
 import android.util.Log
-import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.annotation.ColorInt
 import com.airbnb.epoxy.AfterPropsSet
-import com.airbnb.epoxy.CallbackProp
-import com.airbnb.epoxy.ModelProp
 import com.airbnb.epoxy.ModelView
 import com.airbnb.epoxy.OnViewRecycled
 import com.airbnb.epoxy.OnVisibilityChanged
@@ -18,10 +14,8 @@ import com.airbnb.epoxy.TextProp
 import com.airbnb.epoxy.VisibilityState
 import com.airbnb.epoxy.kotlinsample.R
 
-// The ModelView annotation is used on Views to have models generated from those views.
-// This is pretty straightforward with Kotlin, but properties need some special handling.
-@ModelView(autoLayout = ModelView.Size.MATCH_WIDTH_WRAP_HEIGHT)
-class ItemCustomView @JvmOverloads constructor(
+@ModelView(autoLayout = ModelView.Size.WRAP_WIDTH_WRAP_HEIGHT)
+class CarouselItemCustomView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
@@ -32,34 +26,19 @@ class ItemCustomView @JvmOverloads constructor(
     private val textView: TextView
 
     init {
-        inflate(context, R.layout.custom_view_item, this)
+        inflate(context, R.layout.carousel_custom_view_item, this)
         orientation = VERTICAL
         textView = (findViewById(R.id.title))
-        textView.setCompoundDrawables(null, null, onVisibilityEventDrawable, null)
+        textView.setCompoundDrawables(null, null, null, onVisibilityEventDrawable)
         textView.compoundDrawablePadding = (4 * resources.displayMetrics.density).toInt()
     }
 
-    // You can annotate your methods with @ModelProp
-    @ModelProp
-    fun color(@ColorInt color: Int) {
-        textView.setTextColor(color)
-    }
-
-    // Or if you need to store data in properties there are two options
-
-    // 1.You can make it nullable like this and annotate the setter
-    var listener: View.OnClickListener? = null
-        @CallbackProp set
-
-    // 2. Or you can use lateinit
-    @TextProp lateinit var title: CharSequence
+    @TextProp
+    lateinit var title: CharSequence
 
     @AfterPropsSet
     fun useProps() {
-        // This is optional, and is called after the annotated properties above are set.
-        // This is useful for using several properties in one method to guarantee they are all set first.
         textView.text = title
-        textView.setOnClickListener(listener)
     }
 
     @OnVisibilityStateChanged
@@ -116,6 +95,6 @@ class ItemCustomView @JvmOverloads constructor(
     }
 
     companion object {
-        private const val TAG = "ItemCustomView"
+        private const val TAG = "CarouselItemCustomView"
     }
 }

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/OnVisibilityEventDrawable.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/OnVisibilityEventDrawable.kt
@@ -48,7 +48,13 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
             invalidateSelf()
         }
 
-    var percent = 0.0f
+    var percentHeight = 0.0f
+        set(value) {
+            field = value
+            invalidateSelf()
+        }
+
+    var percentWidth = 0.0f
         set(value) {
             field = value
             invalidateSelf()
@@ -58,7 +64,8 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
         visible = false
         focusedVisible = false
         fullImpression = false
-        percent = 0.0f
+        percentHeight = 0.0f
+        percentWidth = 0.0f
         invalidateSelf()
     }
 
@@ -82,8 +89,8 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
         canvas.drawRect(
             0.0f,
             0.0f,
-            bounds.width() * percent / 100,
-            bounds.height().toFloat(),
+            bounds.width() * percentWidth / 100,
+            bounds.height().toFloat() * percentHeight / 100,
             paint
         )
     }

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/views/CarouselNoSnap.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/views/CarouselNoSnap.kt
@@ -1,0 +1,18 @@
+package com.airbnb.epoxy.kotlinsample.views
+
+import android.content.Context
+
+import com.airbnb.epoxy.Carousel
+import com.airbnb.epoxy.EpoxyVisibilityTracker
+import com.airbnb.epoxy.ModelView
+import com.airbnb.epoxy.ModelView.Size
+
+@ModelView(saveViewState = true, autoLayout = Size.MATCH_WIDTH_WRAP_HEIGHT)
+class CarouselNoSnap(context: Context) : Carousel(context) {
+
+    init {
+        EpoxyVisibilityTracker().attach(this)
+    }
+
+    override fun getSnapHelperFactory(): Nothing? = null
+}

--- a/kotlinsample/src/main/res/layout/carousel_custom_view_item.xml
+++ b/kotlinsample/src/main/res/layout/carousel_custom_view_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:padding="20dp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#80000000" />
+</merge>


### PR DESCRIPTION
The goal here is to add support for nested `RecyclerView`(epoxy managed, ex with `Carousel`) in `EpoxyVisibilityTracker`. No new features here, just internal changes validated by exiting unit tests. I preferred do send multiple smaller pull request for this big change.

So this first change update `EpoxyVisibilityTracker` and `EpoxyVisibilityItem` to support tracking in both direction : width and height. The tracker do not need to know about the scrolling direction.

