### PR TITLE
Return model class from model builder extension function

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/KotlinModelBuilderExtensionWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/KotlinModelBuilderExtensionWriter.kt
@@ -118,12 +118,14 @@ internal class KotlinModelBuilderExtensionWriter(
             if (constructorIsNotPublic) addModifiers(KModifier.INTERNAL)
 
             beginControlFlow(
-                "$tick%T$tick(${params.joinToString(", ") { it.name }}).apply ",
+                "val model = $tick%T$tick(${params.joinToString(", ") { it.name }}).apply ",
                 modelClass
             )
             addStatement("modelInitializer()")
             endControlFlow()
-            addStatement(".addTo(this)")
+            addStatement("model.addTo(this)")
+            addStatement("return model")
+            returns(model.getSuperClassName().toKPoet())
             return build()
         }
 


### PR DESCRIPTION
Change generated model generate extension function
**from:**
```
inline fun EpoxyController.dataBindingItem(modelInitializer: DataBindingItemBindingModelBuilder.() -> Unit) {
    DataBindingItemBindingModel_().apply  {
        modelInitializer()
    }
    .addTo(this)
}
```

**to:**
```
inline fun EpoxyController.dataBindingItem(modelInitializer: DataBindingItemBindingModelBuilder.() -> Unit): DataBindingEpoxyModel {
    val model = DataBindingItemBindingModel_().apply  {
        modelInitializer()
    }
    model.addTo(this)
    return model
}

```

Then we can get model class instance from controller
```
databindingItemModel = dataBindingItem {
    id("data binding $i")
    ...
}
```

Example use case is animating specific item from EpoxyController.