### PR TITLE
Update documentation for Kotlin sample

### DIFF
--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/helpers/KotlinEpoxyHolder.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/helpers/KotlinEpoxyHolder.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KProperty
 /**
  * A pattern for easier view binding with an [EpoxyHolder]
  *
- * See [SampleKotlinModelWithHolder] for a usage example.
+ * See [com.airbnb.epoxy.kotlinsample.models.ItemEpoxyHolder] for a usage example.
  */
 abstract class KotlinEpoxyHolder : EpoxyHolder() {
     private lateinit var view: View


### PR DESCRIPTION
I was playing around with the Kotlin sample and noticed [SampleKotlinModelWithHolder] wasn't referenced anywhere. I updated the sample documentation to be inline with current usage.