### PR TITLE
Enable recycling of views within groups

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -48,6 +48,9 @@
       <option name="JD_KEEP_EMPTY_RETURN" value="false" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Elements" />
   </state>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Elements" />
   </state>
 </component>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-  ext.KOTLIN_VERSION = "1.2.71"
+  ext.KOTLIN_VERSION = "1.3.11"
   ext.ANDROID_PLUGIN_VERSION = "3.2.1"
 
   repositories {
@@ -9,7 +9,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath "com.android.tools.build:gradle:3.2.1"
+    classpath "com.android.tools.build:gradle:$ANDROID_PLUGIN_VERSION"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   }
@@ -83,6 +83,6 @@ def getRepositoryPassword() {
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '4.9'
+  gradleVersion = '4.10.2'
   distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-  ext.KOTLIN_VERSION = "1.3.11"
+  ext.KOTLIN_VERSION = "1.2.71"
   ext.ANDROID_PLUGIN_VERSION = "3.2.1"
 
   repositories {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
@@ -1,0 +1,106 @@
+package com.airbnb.epoxy
+
+import android.app.Activity
+import android.content.Context
+import android.os.Build
+import androidx.core.view.ViewCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.OnLifecycleEvent
+import androidx.recyclerview.widget.RecyclerView
+import java.lang.ref.WeakReference
+import java.util.ArrayList
+
+internal class ActivityRecyclerPool {
+
+    /**
+     * Store one unique pool per activity. They are cleared out when activities are destroyed, so this
+     * only needs to hold pools for active activities.
+     */
+    private val pools = ArrayList<PoolReference>(5)
+
+    @JvmOverloads
+    fun getPool(
+        context: Context,
+        poolFactory: () -> RecyclerView.RecycledViewPool = { UnboundedViewPool() }
+    ): PoolReference {
+
+        val iterator = pools.iterator()
+        var poolToUse: PoolReference? = null
+
+        while (iterator.hasNext()) {
+            val poolReference = iterator.next()
+            when {
+                poolReference.context === context -> {
+                    if (poolToUse != null) {
+                        throw IllegalStateException("A pool was already found")
+                    }
+                    poolToUse = poolReference
+                    // finish iterating to remove any old contexts
+                }
+                poolReference.context.isActivityDestroyed() -> {
+                    // A pool from a different activity that was destroyed.
+                    // Clear the pool references to allow the activity to be GC'd
+                    poolReference.viewPool.clear()
+                    iterator.remove()
+                }
+            }
+        }
+
+        if (poolToUse == null) {
+            poolToUse = PoolReference(context, poolFactory(), this)
+            (context as? LifecycleOwner)?.lifecycle?.addObserver(poolToUse)
+            pools.add(poolToUse)
+        }
+
+        return poolToUse
+    }
+
+    fun clearIfDestroyed(pool: PoolReference) {
+        if (pool.context.isActivityDestroyed()) {
+            pool.viewPool.clear()
+            pools.remove(pool)
+        }
+    }
+}
+
+internal class PoolReference(
+    context: Context,
+    val viewPool: RecyclerView.RecycledViewPool,
+    private val parent: ActivityRecyclerPool
+) : LifecycleObserver {
+    private val contextReference: WeakReference<Context> = WeakReference(context)
+
+    val context: Context? get() = contextReference.get()
+
+    fun clearIfDestroyed() {
+        parent.clearIfDestroyed(this)
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun onContextDestroyed() {
+        clearIfDestroyed()
+    }
+}
+
+internal fun Context?.isActivityDestroyed(): Boolean {
+    if (this == null) {
+        return true
+    }
+
+    if (this !is Activity) {
+        return false
+    }
+
+    if (isFinishing) {
+        return true
+    }
+
+    return if (Build.VERSION.SDK_INT >= 17) {
+        isDestroyed
+    } else {
+        // Use this as a proxy for being destroyed on older devices
+        !ViewCompat.isAttachedToWindow(window.decorView)
+    }
+}

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -149,7 +149,7 @@ abstract class BaseEpoxyAdapter extends RecyclerView.Adapter<EpoxyViewHolder> {
 
   @Override
   public int getItemViewType(int position) {
-    return viewTypeManager.getViewType(getModelForPosition(position));
+    return viewTypeManager.getViewTypeAndRememberModel(getModelForPosition(position));
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -2,20 +2,18 @@ package com.airbnb.epoxy;
 
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewGroup.LayoutParams;
 import android.view.ViewStub;
-
-import com.airbnb.epoxy.EpoxyModelGroup.Holder;
-import com.airbnb.viewmodeladapter.R;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * An {@link EpoxyModel} that contains other models, and allows you to combine those models in
@@ -61,15 +59,9 @@ import androidx.annotation.NonNull;
  * <p>
  * By default this model inherits the same id as the first model in the list. Call {@link #id(long)}
  * to override that if needed.
- * <p>
- * The same number of models must always be used for a specific layout resource. This is because the
- * view stubs are only inflated once and then the view is recycled between groups with the same
- * layout. If you want to dynamically change what models are shown you can use {@link
- * EpoxyModel#hide()} to have the associated view be set to GONE.
  */
 @SuppressWarnings("rawtypes")
-public class EpoxyModelGroup extends EpoxyModelWithHolder<Holder>
-    implements GeneratedModel<Holder> {
+public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 
   protected final List<? extends EpoxyModel<?>> models;
   /** By default we save view state if any of the models need to save state. */
@@ -115,157 +107,103 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<Holder>
     shouldSaveViewState = saveState;
   }
 
+  @CallSuper
   @Override
-  public void handlePostBind(Holder groupHolder, final int position) {
-    iterateModels(groupHolder, new IterateModelsCallback() {
+  public void bind(@NonNull ModelGroupHolder holder) {
+    iterateModels(holder, new IterateModelsCallback() {
       @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
-        if (model instanceof GeneratedModel) {
-          //noinspection unchecked
-          ((GeneratedModel) model).handlePostBind(boundObject, position);
-        }
-      }
-    });
-  }
-
-  @Override
-  public void handlePreBind(final EpoxyViewHolder holder, Holder groupHolder, final int position) {
-    iterateModels(groupHolder, new IterateModelsCallback() {
-      @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
-        if (model instanceof GeneratedModel) {
-          //noinspection unchecked
-          ((GeneratedModel) model).handlePreBind(holder, boundObject, position);
-        }
+      public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
+        setViewVisibility(model, viewHolder);
+        viewHolder.bind(model, null, Collections.emptyList(), modelIndex);
       }
     });
   }
 
   @CallSuper
   @Override
-  public void bind(@NonNull Holder holder) {
+  public void bind(@NonNull ModelGroupHolder holder, @NonNull final List<Object> payloads) {
     iterateModels(holder, new IterateModelsCallback() {
       @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
-        setViewVisibility(model, view);
-        //noinspection unchecked
-        model.bind(boundObject);
-      }
-    });
-  }
-
-  @CallSuper
-  @Override
-  public void bind(@NonNull Holder holder, @NonNull final List<Object> payloads) {
-    iterateModels(holder, new IterateModelsCallback() {
-      @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
-        setViewVisibility(model, view);
-        //noinspection unchecked
-        model.bind(boundObject);
+      public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
+        setViewVisibility(model, viewHolder);
+        viewHolder.bind(model, null, Collections.emptyList(), modelIndex);
       }
     });
   }
 
   @Override
-  public void bind(@NonNull Holder holder, @NonNull EpoxyModel<?> previouslyBoundModel) {
+  public void bind(@NonNull ModelGroupHolder holder, @NonNull EpoxyModel<?> previouslyBoundModel) {
     if (!(previouslyBoundModel instanceof EpoxyModelGroup)) {
       bind(holder);
       return;
     }
 
     final EpoxyModelGroup previousGroup = (EpoxyModelGroup) previouslyBoundModel;
-    if (previousGroup.models.size() != models.size()) {
-      throw createInconsistentModelCountException();
-    }
 
     iterateModels(holder, new IterateModelsCallback() {
       @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
-        setViewVisibility(model, view);
+      public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
+        setViewVisibility(model, viewHolder);
 
         EpoxyModel<?> previousModel = previousGroup.models.get(modelIndex);
         if (previousModel.id() == model.id()) {
-          //noinspection unchecked
-          model.bind(boundObject, previousModel);
+          viewHolder.bind(model, previousModel, Collections.emptyList(), modelIndex);
         } else {
-          //noinspection unchecked
-          model.bind(boundObject);
+          viewHolder.bind(model, null, Collections.emptyList(), modelIndex);
         }
       }
     });
   }
 
-  private static void setViewVisibility(EpoxyModel model, View view) {
+  private static void setViewVisibility(EpoxyModel model, EpoxyViewHolder viewHolder) {
     if (model.isShown()) {
-      view.setVisibility(View.VISIBLE);
+      viewHolder.itemView.setVisibility(View.VISIBLE);
     } else {
-      view.setVisibility(View.GONE);
+      viewHolder.itemView.setVisibility(View.GONE);
     }
   }
 
   @CallSuper
   @Override
-  public void unbind(@NonNull Holder holder) {
+  public void unbind(@NonNull ModelGroupHolder holder) {
+    holder.unbindGroup();
+  }
+
+  @CallSuper
+  @Override
+  public void onViewAttachedToWindow(ModelGroupHolder holder) {
     iterateModels(holder, new IterateModelsCallback() {
       @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
+      public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
         //noinspection unchecked
-        model.unbind(boundObject);
+        model.onViewAttachedToWindow(viewHolder.objectToBind());
       }
     });
   }
 
   @CallSuper
   @Override
-  public void onViewAttachedToWindow(Holder holder) {
+  public void onViewDetachedFromWindow(ModelGroupHolder holder) {
     iterateModels(holder, new IterateModelsCallback() {
       @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
+      public void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex) {
         //noinspection unchecked
-        model.onViewAttachedToWindow(boundObject);
+        model.onViewDetachedFromWindow(viewHolder.objectToBind());
       }
     });
   }
 
-  @CallSuper
-  @Override
-  public void onViewDetachedFromWindow(Holder holder) {
-    iterateModels(holder, new IterateModelsCallback() {
-      @Override
-      public void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex) {
-        //noinspection unchecked
-        model.onViewDetachedFromWindow(boundObject);
-      }
-    });
-  }
-
-  private void iterateModels(Holder holder, IterateModelsCallback callback) {
+  private void iterateModels(ModelGroupHolder holder, IterateModelsCallback callback) {
+    holder.bindGroupIfNeeded(this);
     int modelCount = models.size();
-    if (modelCount != holder.views.size()) {
-      throw createInconsistentModelCountException();
-    }
 
     for (int i = 0; i < modelCount; i++) {
-      EpoxyModel model = models.get(i);
-      View view = holder.views.get(i);
-      EpoxyHolder epoxyHolder = holder.holders.get(i);
-      Object objectToBind = (model instanceof EpoxyModelWithHolder) ? epoxyHolder : view;
-
-      callback.onModel(model, objectToBind, view, i);
+      callback.onModel(models.get(i), holder.getViewHolders().get(i), i);
     }
-  }
-
-  private RuntimeException createInconsistentModelCountException() {
-    return new IllegalStateException(
-        "The number of models used in this group has changed. The model count must remain "
-            + "constant if the same layout resource is used. If you need to change which models"
-            + " are shown you can call EpoxyMode#hide() to have a model's view hidden, or use a"
-            + " different layout resource for the group.");
   }
 
   private interface IterateModelsCallback {
-    void onModel(EpoxyModel model, Object boundObject, View view, int modelIndex);
+    void onModel(EpoxyModel model, EpoxyViewHolder viewHolder, int modelIndex);
   }
 
   @Override
@@ -301,158 +239,8 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<Holder>
   }
 
   @Override
-  protected final Holder createNewHolder() {
-    return new Holder(this);
-  }
-
-  public static class Holder extends EpoxyHolder {
-    // We use the model group that was used to create the view holder for initializing the view.
-    // We release the reference after the viewholder is initialized.
-    private EpoxyModelGroup initializingModelGroup;
-    private List<View> views;
-    private List<EpoxyHolder> holders;
-    private ViewGroup rootView;
-
-    public Holder(@NonNull EpoxyModelGroup initializingModelGroup) {
-      this.initializingModelGroup = initializingModelGroup;
-    }
-
-    /**
-     * Get the root view group (aka
-     * {@link androidx.recyclerview.widget.RecyclerView.ViewHolder#itemView}.
-     * You can override {@link EpoxyModelGroup#bind(Holder)} and use this method to make custom
-     * changes to the root view.
-     */
-    public ViewGroup getRootView() {
-      return rootView;
-    }
-
-    @Override
-    protected void bindView(@NonNull View itemView) {
-      if (!(itemView instanceof ViewGroup)) {
-        throw new IllegalStateException(
-            "The layout provided to EpoxyModelGroup must be a ViewGroup");
-      }
-      rootView = (ViewGroup) itemView;
-      ViewGroup childContainer = findChildContainer(rootView);
-
-      List<? extends EpoxyModel<?>> models = initializingModelGroup.models;
-      int modelCount = models.size();
-
-      views = new ArrayList<>(modelCount);
-      holders = new ArrayList<>(modelCount);
-
-      boolean useViewStubs = childContainer.getChildCount() != 0;
-      for (int i = 0; i < models.size(); i++) {
-        EpoxyModel model = models.get(i);
-        View view;
-        if (useViewStubs) {
-          view = replaceNextViewStub(childContainer, model,
-              initializingModelGroup.useViewStubLayoutParams(model, i));
-        } else {
-          view = createAndAddView(childContainer, model);
-        }
-
-        if (model instanceof EpoxyModelWithHolder) {
-          EpoxyHolder holder = ((EpoxyModelWithHolder) model).createNewHolder();
-          holder.bindView(view);
-          holders.add(holder);
-        } else {
-          holders.add(null);
-        }
-
-        views.add(view);
-      }
-
-      initializingModelGroup = null;
-    }
-
-    /**
-     * By default the outermost viewgroup is used as the container that views are added to. However,
-     * users can specify a different, nested view group to use as the child container by marking it
-     * with a special id.
-     */
-    private ViewGroup findChildContainer(ViewGroup outermostRoot) {
-      View customRoot = outermostRoot.findViewById(R.id.epoxy_model_group_child_container);
-
-      if (customRoot instanceof ViewGroup) {
-        return (ViewGroup) customRoot;
-      }
-
-      return outermostRoot;
-    }
-
-    private View createAndAddView(ViewGroup groupView, EpoxyModel<?> model) {
-      View modelView = model.buildView(groupView);
-      LayoutParams modelLayoutParams = modelView.getLayoutParams();
-      if (modelLayoutParams != null) {
-        groupView.addView(modelView, modelLayoutParams);
-      } else {
-        groupView.addView(modelView);
-      }
-      return modelView;
-    }
-
-    private View replaceNextViewStub(ViewGroup groupView, EpoxyModel<?> model,
-        boolean useStubLayoutParams) {
-      ViewStubData stubData = getNextViewStubPosition(groupView);
-      if (stubData == null) {
-        throw new IllegalStateException(
-            "Your layout should provide a ViewStub for each model to be inflated into.");
-      }
-
-      stubData.viewGroup.removeView(stubData.viewStub);
-      View modelView = model.buildView(stubData.viewGroup);
-
-      // Carry over the stub id manually since we aren't inflating via the stub
-      int inflatedId = stubData.viewStub.getInflatedId();
-      if (inflatedId != View.NO_ID) {
-        modelView.setId(inflatedId);
-      }
-
-      LayoutParams modelLayoutParams = modelView.getLayoutParams();
-      if (useStubLayoutParams) {
-        stubData.viewGroup
-            .addView(modelView, stubData.position, stubData.viewStub.getLayoutParams());
-      } else if (modelLayoutParams != null) {
-        stubData.viewGroup.addView(modelView, stubData.position, modelLayoutParams);
-      } else {
-        stubData.viewGroup.addView(modelView, stubData.position);
-      }
-
-      return modelView;
-    }
-
-    private ViewStubData getNextViewStubPosition(ViewGroup viewGroup) {
-      int childCount = viewGroup.getChildCount();
-      for (int i = 0; i < childCount; i++) {
-        View child = viewGroup.getChildAt(i);
-
-        if (child instanceof ViewGroup) {
-          ViewStubData nestedResult = getNextViewStubPosition((ViewGroup) child);
-          if (nestedResult != null) {
-            return nestedResult;
-          }
-        } else if (child instanceof ViewStub) {
-          return new ViewStubData(viewGroup, (ViewStub) child, i);
-        }
-      }
-
-      return null;
-    }
-  }
-
-  private static class ViewStubData {
-
-    private final ViewGroup viewGroup;
-    private final ViewStub viewStub;
-    private final int position;
-
-    private ViewStubData(ViewGroup viewGroup, ViewStub viewStub, int position) {
-      this.viewGroup = viewGroup;
-      this.viewStub = viewStub;
-      this.position = position;
-    }
+  protected final ModelGroupHolder createNewHolder() {
+    return new ModelGroupHolder();
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -1,7 +1,6 @@
 package com.airbnb.epoxy;
 
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.ViewStub;
 
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import java.util.List;
 import androidx.annotation.CallSuper;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 
 /**
  * An {@link EpoxyModel} that contains other models, and allows you to combine those models in
@@ -33,7 +31,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * viewgroups, such as a LinearLayout inside of a CardView.
  * <p>
  * 2. Include a {@link ViewStub} for each of the models in the list. There should be at least as
- * many view stubs as models. Extra stubs will be ignored. Each model will be inflated into a view
+ * many view stubs as models. Extra stubs will be ignored. Each model will have its view replace the
  * stub in order of the view stub's position in the view group. That is, the view group's children
  * will be iterated through in order. The first view stub found will be used for the first model in
  * the models list, the second view stub will be used for the second model, and so on. A depth first
@@ -46,12 +44,6 @@ import androidx.recyclerview.widget.RecyclerView;
  * view by default. If you want a model to keep the layout params from it's own layout resource you
  * can override {@link #useViewStubLayoutParams(EpoxyModel, int)}
  * <p>
- * If an {@link EpoxyModelWithView} is used then the view created by that model will simply replace
- * its ViewStub instead of inflating the view stub with a resource. If layout params are set on the
- * view created by {@link EpoxyModelWithView#buildView(ViewGroup)} then those will be kept,
- * otherwise any layout params specified on the view stub will be transferred over as with normal
- * models.
- * <p>
  * If you want to override the id used for a model's view you can set {@link
  * ViewStub#setInflatedId(int)} via xml. That id will be transferred over to the view taking that
  * stub's place. This is necessary if you want your model to save view state, since without this the
@@ -59,6 +51,10 @@ import androidx.recyclerview.widget.RecyclerView;
  * <p>
  * By default this model inherits the same id as the first model in the list. Call {@link #id(long)}
  * to override that if needed.
+ * <p>
+ * When a model group is recycled, its child views are automatically recycled to a pool that is
+ * shared with all other model groups in the activity. This enables model groups to more efficiently
+ * manage their children. The shared pool is cleaned up when the activity is destroyed.
  */
 @SuppressWarnings("rawtypes")
 public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyRecyclerView.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyRecyclerView.java
@@ -1,22 +1,14 @@
 package com.airbnb.epoxy;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.os.Build.VERSION;
 import android.util.AttributeSet;
-import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.ViewGroup;
 
 import com.airbnb.viewmodeladapter.R;
 
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.DimenRes;
@@ -24,10 +16,12 @@ import androidx.annotation.Dimension;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
-import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import kotlin.jvm.functions.Function0;
+
+import static com.airbnb.epoxy.ActivityRecyclerPoolKt.isActivityDestroyed;
 
 /**
  * <i>This feature is in Beta - please report bugs, feature requests, or other feedback at
@@ -72,7 +66,7 @@ public class EpoxyRecyclerView extends RecyclerView {
    * Store one unique pool per activity. They are cleared out when activities are destroyed, so this
    * only needs to hold pools for active activities.
    */
-  private static final List<PoolReference> RECYCLER_POOLS = new ArrayList<>(5);
+  private static final ActivityRecyclerPool ACTIVITY_RECYCLER_POOL = new ActivityRecyclerPool();
 
   protected final EpoxyItemSpacingDecorator spacingDecorator = new EpoxyItemSpacingDecorator();
 
@@ -190,35 +184,13 @@ public class EpoxyRecyclerView extends RecyclerView {
       return;
     }
 
-    Context context = getContext();
-    Iterator<PoolReference> iterator = RECYCLER_POOLS.iterator();
-    PoolReference poolToUse = null;
-
-    while (iterator.hasNext()) {
-      PoolReference poolReference = iterator.next();
-      if (poolReference.context() == null) {
-        // Clean up entries from old activities so the list doesn't grow large
-        iterator.remove();
-      } else if (poolReference.context() == context) {
-        if (poolToUse != null) {
-          throw new IllegalStateException("A pool was already found");
-        }
-        poolToUse = poolReference;
-        // finish iterating to remove any old contexts
-      } else {
-        // A pool from a different activity, it may be removed soon once the activity reference
-        // is GC'd, but until then we can at least clear the pool references, which may
-        // be keeping the activity from getting GC'd
-        poolReference.clearIfActivityIsDestroyed();
-      }
-    }
-
-    if (poolToUse == null) {
-      poolToUse = new PoolReference(context, createViewPool());
-      RECYCLER_POOLS.add(poolToUse);
-    }
-
-    setRecycledViewPool(poolToUse.viewPool);
+    setRecycledViewPool(ACTIVITY_RECYCLER_POOL.getPool(getContext(),
+        new Function0<RecycledViewPool>() {
+          @Override
+          public RecycledViewPool invoke() {
+            return createViewPool();
+          }
+        }).getViewPool());
   }
 
   /**
@@ -564,93 +536,6 @@ public class EpoxyRecyclerView extends RecyclerView {
     // is no longer needed - the main signal we use for this is that the activity is destroyed.
     if (isActivityDestroyed(getContext())) {
       getRecycledViewPool().clear();
-    }
-  }
-
-  private static class PoolReference {
-    private final WeakReference<Context> contextReference;
-    private final RecycledViewPool viewPool;
-
-    private PoolReference(Context context,
-        RecycledViewPool viewPool) {
-      this.contextReference = new WeakReference<>(context);
-      this.viewPool = viewPool;
-    }
-
-    @Nullable
-    private Context context() {
-      return contextReference.get();
-    }
-
-    void clearIfActivityIsDestroyed() {
-      if (isActivityDestroyed(context())) {
-        viewPool.clear();
-      }
-    }
-  }
-
-  private static boolean isActivityDestroyed(@Nullable Context context) {
-    if (context == null) {
-      return true;
-    }
-
-    if (!(context instanceof Activity)) {
-      return false;
-    }
-
-    Activity activity = (Activity) context;
-    if (activity.isFinishing()) {
-      return true;
-    }
-
-    if (VERSION.SDK_INT >= 17) {
-      return activity.isDestroyed();
-    } else {
-      // Use this as a proxy for being destroyed on older devices
-      return !ViewCompat.isAttachedToWindow(activity.getWindow().getDecorView());
-    }
-  }
-
-  /**
-   * Like its parent, UnboundedViewPool lets you share Views between multiple RecyclerViews. However
-   * there is no maximum number of recycled views that it will store. This usually ends up being
-   * optimal, barring any hard memory constraints, as RecyclerViews do not recycle more Views than
-   * they need.
-   */
-  private static class UnboundedViewPool extends RecycledViewPool {
-
-    private final SparseArray<Queue<ViewHolder>> scrapHeaps = new SparseArray<>();
-
-    @Override
-    public void clear() {
-      scrapHeaps.clear();
-    }
-
-    @Override
-    public void setMaxRecycledViews(int viewType, int max) {
-      throw new UnsupportedOperationException(
-          "UnboundedViewPool does not support setting a maximum number of recycled views");
-    }
-
-    @Override
-    @Nullable
-    public ViewHolder getRecycledView(int viewType) {
-      final Queue<ViewHolder> scrapHeap = scrapHeaps.get(viewType);
-      return scrapHeap != null ? scrapHeap.poll() : null;
-    }
-
-    @Override
-    public void putRecycledView(ViewHolder viewHolder) {
-      getScrapHeapForType(viewHolder.getItemViewType()).add(viewHolder);
-    }
-
-    private Queue<ViewHolder> getScrapHeapForType(int viewType) {
-      Queue<ViewHolder> scrapHeap = scrapHeaps.get(viewType);
-      if (scrapHeap == null) {
-        scrapHeap = new LinkedList<>();
-        scrapHeaps.put(viewType, scrapHeap);
-      }
-      return scrapHeap;
     }
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
@@ -1,0 +1,250 @@
+package com.airbnb.epoxy
+
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewStub
+import androidx.recyclerview.widget.RecyclerView
+
+import com.airbnb.viewmodeladapter.R
+
+import java.util.ArrayList
+
+class ModelGroupHolder : EpoxyHolder() {
+    val viewHolders = ArrayList<EpoxyViewHolder>(4)
+    private lateinit var poolReference: PoolReference
+
+    /**
+     * Get the root view group (aka
+     * [androidx.recyclerview.widget.RecyclerView.ViewHolder.itemView].
+     * You can override [EpoxyModelGroup.bind] and use this method to make custom
+     * changes to the root view.
+     */
+    lateinit var rootView: ViewGroup
+        private set
+
+    private lateinit var childContainer: ViewGroup
+    private lateinit var stubs: List<ViewStubData>
+    private var boundGroup: EpoxyModelGroup? = null
+
+    private fun usingStubs(): Boolean = stubs.isNotEmpty()
+
+    override fun bindView(itemView: View) {
+        if (itemView !is ViewGroup) {
+            throw IllegalStateException(
+                "The layout provided to EpoxyModelGroup must be a ViewGroup"
+            )
+        }
+
+        rootView = itemView
+        childContainer = findChildContainer(rootView)
+        poolReference = ACTIVITY_RECYCLER_POOL.getPool(itemView.context)
+
+        stubs = if (childContainer.childCount != 0) {
+            createViewStubData(childContainer)
+        } else {
+            emptyList()
+        }
+    }
+
+    /**
+     * By default the outermost viewgroup is used as the container that views are added to. However,
+     * users can specify a different, nested view group to use as the child container by marking it
+     * with a special id.
+     */
+    private fun findChildContainer(outermostRoot: ViewGroup): ViewGroup {
+        val customRoot = outermostRoot.findViewById<View>(R.id.epoxy_model_group_child_container)
+
+        return customRoot as? ViewGroup ?: outermostRoot
+    }
+
+    private fun createViewStubData(viewGroup: ViewGroup): List<ViewStubData> {
+        val stubs = ArrayList<ViewStubData>(4)
+
+        while (true) {
+            val stubData = getNextViewStub(viewGroup)
+            if (stubData != null) {
+                stubs.add(stubData)
+                stubData.removeView()
+            } else {
+                break
+            }
+        }
+
+        if (stubs.isEmpty()) {
+            throw IllegalStateException(
+                "No view stubs found. If viewgroup is not empty it must contain ViewStubs."
+            )
+        }
+
+        return stubs
+    }
+
+    private fun getNextViewStub(viewGroup: ViewGroup): ViewStubData? {
+        val childCount = viewGroup.childCount
+        for (i in 0 until childCount) {
+            val child = viewGroup.getChildAt(i)
+
+            if (child is ViewGroup) {
+                getNextViewStub(child)?.let { return it }
+            } else if (child is ViewStub) {
+                return ViewStubData(viewGroup, child, i)
+            }
+        }
+
+        return null
+    }
+
+    fun bindGroupIfNeeded(group: EpoxyModelGroup) {
+        val previouslyBoundGroup = this.boundGroup
+
+        if (previouslyBoundGroup === group) {
+            return
+        } else if (previouslyBoundGroup != null) {
+            // A different group is being bound; this can happen when an onscreen model is changed.
+            // The models or their layouts could have changed, so views may need to be updated
+
+            if (previouslyBoundGroup.models.size > group.models.size) {
+                for (i in previouslyBoundGroup.models.size - 1 downTo group.models.size) {
+                    removeAndRecycleView(i)
+                }
+            }
+        }
+
+        this.boundGroup = group
+        val models = group.models
+        val modelCount = models.size
+
+        if (usingStubs() && stubs.size < modelCount) {
+            throw IllegalStateException(
+                "Insufficient view stubs for EpoxyModelGroup. " + modelCount +
+                        " models were provided but only " + stubs.size + " view stubs exist."
+            )
+        }
+        viewHolders.ensureCapacity(modelCount)
+
+        for (i in 0 until modelCount) {
+            val model = models[i]
+            val previouslyBoundModel = previouslyBoundGroup?.models?.getOrNull(i)
+            val stubData = stubs.getOrNull(i)
+            val parent = stubData?.viewGroup ?: childContainer
+
+            if (previouslyBoundModel != null) {
+                if (areSameViewType(previouslyBoundModel, model)) {
+                    continue
+                }
+
+                removeAndRecycleView(i)
+            }
+
+            val holder = getViewHolder(parent, model)
+
+            if (stubData == null) {
+                childContainer.addView(holder.itemView, i)
+            } else {
+                stubData.setView(holder.itemView, group.useViewStubLayoutParams(model, i))
+            }
+
+            viewHolders.add(i, holder)
+        }
+    }
+
+    private fun areSameViewType(model1: EpoxyModel<*>, model2: EpoxyModel<*>?): Boolean {
+        return ViewTypeManager.getViewType(model1) == ViewTypeManager.getViewType(model2)
+    }
+
+    private fun getViewHolder(parent: ViewGroup, model: EpoxyModel<*>): EpoxyViewHolder {
+        val viewType = ViewTypeManager.getViewType(model)
+        val recycledView = poolReference.viewPool.getRecycledView(viewType)
+
+        return recycledView as? EpoxyViewHolder
+            ?: HELPER_ADAPTER.createViewHolder(
+                model,
+                parent,
+                viewType
+            )
+    }
+
+    fun unbindGroup() {
+        if (boundGroup == null) {
+            throw IllegalStateException("Group is not bound")
+        }
+
+        repeat(viewHolders.size) {
+            // Remove from the end for more efficient list actions
+            removeAndRecycleView(viewHolders.size - 1)
+        }
+
+        poolReference.clearIfDestroyed()
+        boundGroup = null
+    }
+
+    private fun removeAndRecycleView(modelPosition: Int) {
+        if (usingStubs()) {
+            stubs[modelPosition].removeView()
+        } else {
+            childContainer.removeViewAt(modelPosition)
+        }
+
+        val viewHolder = viewHolders.removeAt(modelPosition)
+        viewHolder.unbind()
+        poolReference.viewPool.putRecycledView(viewHolder)
+    }
+
+    companion object {
+
+        private val HELPER_ADAPTER = HelperAdapter()
+        private val ACTIVITY_RECYCLER_POOL = ActivityRecyclerPool()
+    }
+}
+
+private class ViewStubData(
+    val viewGroup: ViewGroup,
+    val viewStub: ViewStub,
+    val position: Int
+) {
+
+    fun setView(view: View, useStubLayoutParams: Boolean) {
+        // Carry over the stub id manually since we aren't inflating via the stub
+        val inflatedId = viewStub.inflatedId
+        if (inflatedId != View.NO_ID) {
+            view.id = inflatedId
+        }
+
+        if (useStubLayoutParams) {
+            viewGroup.addView(view, position, viewStub.layoutParams)
+        } else {
+            viewGroup.addView(view, position)
+        }
+    }
+
+    fun removeView() {
+        val view = viewGroup.getChildAt(position)
+            ?: throw IllegalStateException("No view exists at position $position")
+        viewGroup.removeView(view)
+    }
+}
+
+/**
+ * A viewholder's viewtype can only be set internally in an adapter when the viewholder
+ * is created. To work around that we do the creation in an adapter.
+ */
+private class HelperAdapter : RecyclerView.Adapter<EpoxyViewHolder>() {
+
+    private var model: EpoxyModel<*>? = null
+
+    fun createViewHolder(model: EpoxyModel<*>, parent: ViewGroup, viewType: Int): EpoxyViewHolder {
+        this.model = model
+        val viewHolder = createViewHolder(parent, viewType)
+        this.model = null
+        return viewHolder
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EpoxyViewHolder {
+        return EpoxyViewHolder(model!!.buildView(parent), model!!.shouldSaveViewState())
+    }
+
+    override fun onBindViewHolder(holder: EpoxyViewHolder, position: Int) {
+    }
+
+    override fun getItemCount() = 1
+}

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/UnboundedViewPool.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/UnboundedViewPool.kt
@@ -1,0 +1,47 @@
+package com.airbnb.epoxy
+
+import android.util.SparseArray
+
+import java.util.LinkedList
+import java.util.Queue
+import androidx.recyclerview.widget.RecyclerView.RecycledViewPool
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+
+/**
+ * Like its parent, UnboundedViewPool lets you share Views between multiple RecyclerViews. However
+ * there is no maximum number of recycled views that it will store. This usually ends up being
+ * optimal, barring any hard memory constraints, as RecyclerViews do not recycle more Views than
+ * they need.
+ */
+internal class UnboundedViewPool : RecycledViewPool() {
+
+    private val scrapHeaps = SparseArray<Queue<ViewHolder>>()
+
+    override fun clear() {
+        scrapHeaps.clear()
+    }
+
+    override fun setMaxRecycledViews(viewType: Int, max: Int) {
+        throw UnsupportedOperationException(
+            "UnboundedViewPool does not support setting a maximum number of recycled views"
+        )
+    }
+
+    override fun getRecycledView(viewType: Int): ViewHolder? {
+        val scrapHeap = scrapHeaps.get(viewType)
+        return scrapHeap?.poll()
+    }
+
+    override fun putRecycledView(viewHolder: ViewHolder) {
+        getScrapHeapForType(viewHolder.itemViewType).add(viewHolder)
+    }
+
+    private fun getScrapHeapForType(viewType: Int): Queue<ViewHolder> {
+        var scrapHeap: Queue<ViewHolder>? = scrapHeaps.get(viewType)
+        if (scrapHeap == null) {
+            scrapHeap = LinkedList()
+            scrapHeaps.put(viewType, scrapHeap)
+        }
+        return scrapHeap
+    }
+}

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ViewTypeManager.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ViewTypeManager.java
@@ -24,12 +24,12 @@ class ViewTypeManager {
     VIEW_TYPE_MAP.clear();
   }
 
-  int getViewType(EpoxyModel<?> model) {
+  int getViewTypeAndRememberModel(EpoxyModel<?> model) {
     lastModelForViewTypeLookup = model;
-    return getViewTypeInternal(model);
+    return getViewType(model);
   }
 
-  private static int getViewTypeInternal(EpoxyModel<?> model) {
+  static int getViewType(EpoxyModel<?> model) {
     int defaultViewType = model.getViewType();
     if (defaultViewType != 0) {
       return defaultViewType;
@@ -66,7 +66,7 @@ class ViewTypeManager {
    */
   EpoxyModel<?> getModelForViewType(BaseEpoxyAdapter adapter, int viewType) {
     if (lastModelForViewTypeLookup != null
-        && getViewTypeInternal(lastModelForViewTypeLookup) == viewType) {
+        && getViewType(lastModelForViewTypeLookup) == viewType) {
       // We expect this to be a hit 100% of the time
       return lastModelForViewTypeLookup;
     }
@@ -76,7 +76,7 @@ class ViewTypeManager {
 
     // To be extra safe in case RecyclerView implementation details change...
     for (EpoxyModel<?> model : adapter.getCurrentModels()) {
-      if (getViewTypeInternal(model) == viewType) {
+      if (getViewType(model) == viewType) {
         return model;
       }
     }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
@@ -1,0 +1,174 @@
+package com.airbnb.epoxy
+
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewStub
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.Space
+import androidx.recyclerview.widget.RecyclerView
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@Config(sdk = [21], manifest = TestRunner.MANIFEST_PATH)
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class EpoxyModelGroupTest(val useViewStubs: Boolean) {
+
+    private lateinit var recyclerView: RecyclerView
+    private var topLevelHolder: EpoxyViewHolder? = null
+
+    private val modelGroupHolder get() = topLevelHolder!!.objectToBind() as ModelGroupHolder
+
+    @Before
+    fun init() {
+        recyclerView = RecyclerView(RuntimeEnvironment.application)
+        topLevelHolder?.unbind()
+        topLevelHolder = null
+    }
+
+    @After
+    fun unbind() {
+        topLevelHolder!!.unbind()
+        assertEquals(0, modelGroupHolder.viewHolders.size)
+    }
+
+    private fun bind(modelGroup: EpoxyModelGroup) {
+        if (topLevelHolder == null) {
+            topLevelHolder = EpoxyViewHolder(modelGroup.buildView(recyclerView), false)
+        }
+        topLevelHolder!!.bind(modelGroup, null, emptyList(), 0)
+    }
+
+    private fun assertModelsBound(modelGroup: EpoxyModelGroup) {
+        assertEquals(modelGroupHolder.viewHolders.size, modelGroup.models.size)
+        modelGroupHolder.viewHolders.forEachIndexed { index, viewHolder ->
+            assertEquals("Model at index $index", viewHolder.model, modelGroup.models[index])
+        }
+    }
+
+    @Test
+    fun bindLinearLayout() {
+        createFrameLayoutGroup(3).let {
+            bind(it)
+            assertModelsBound(it)
+        }
+    }
+
+    @Test
+    fun bind_Unbind_Rebind_LinearLayoutWithLessModels() {
+        bind(createFrameLayoutGroup(3))
+        unbind()
+        createSpaceGroup(2).let {
+            bind(it)
+            assertModelsBound(it)
+        }
+    }
+
+    @Test
+    fun bind_Unbind_Rebind_LinearLayoutWithMoreModels() {
+        bind(createFrameLayoutGroup(3))
+        unbind()
+        createSpaceGroup(4).let {
+            bind(it)
+            assertModelsBound(it)
+        }
+    }
+
+    @Test
+    fun rebind_LinearLayoutWithSameViewTypes() {
+        bind(createFrameLayoutGroup(3))
+        createFrameLayoutGroup(4).let {
+            bind(it)
+            assertModelsBound(it)
+        }
+    }
+
+    @Test
+    fun rebind_LinearLayoutWithMoreModels() {
+        bind(createFrameLayoutGroup(3))
+        createSpaceGroup(4).let {
+            bind(it)
+            assertModelsBound(it)
+        }
+    }
+
+    @Test
+    fun rebind_LinearLayoutWithLessModels() {
+        bind(createFrameLayoutGroup(3))
+        createSpaceGroup(2).let {
+            bind(it)
+            assertModelsBound(it)
+        }
+    }
+
+    @Test
+    fun viewholdersAreRecycled() {
+        bind(createFrameLayoutGroup(3))
+        val firstHolders = modelGroupHolder.viewHolders.toSet()
+
+        unbind()
+
+        bind(createFrameLayoutGroup(3))
+        val secondHolders = modelGroupHolder.viewHolders.toSet()
+
+        assertEquals(firstHolders, secondHolders)
+    }
+
+    private fun createFrameLayoutGroup(modelCount: Int): EpoxyModelGroup {
+        val models = (0 until modelCount).map { NestedModelFrameLayout().id(it) }
+        return if (useViewStubs) ViewStubsGroupModel(models) else LinerLayoutGroupModel(models)
+    }
+
+    private fun createSpaceGroup(modelCount: Int): EpoxyModelGroup {
+        val models = (0 until modelCount).map { NestedModelSpace().id(it) }
+        return if (useViewStubs) ViewStubsGroupModel(models) else LinerLayoutGroupModel(models)
+    }
+
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "Use viewstubs: {0}")
+        fun useViewStubsParameters() = listOf(
+            arrayOf(true),
+            arrayOf(false)
+        )
+    }
+}
+
+private class LinerLayoutGroupModel(models: List<EpoxyModel<*>>) : EpoxyModelGroup(0, models) {
+    public override fun buildView(parent: ViewGroup): View {
+        return LinearLayout(parent.context)
+    }
+}
+
+private class ViewStubsGroupModel(models: List<EpoxyModel<*>>) : EpoxyModelGroup(0, models) {
+    public override fun buildView(parent: ViewGroup): View {
+        fun LinearLayout.addStubLayer(): LinearLayout {
+            addView(ViewStub(parent.context))
+
+            LinearLayout(parent.context).let {
+                addView(it)
+                return it
+            }
+        }
+
+        return (0 until models.size).fold(LinearLayout(parent.context)) { linearLayout, _ -> linearLayout.addStubLayer() }
+    }
+}
+
+private class NestedModelFrameLayout : EpoxyModelWithView<FrameLayout>() {
+    override fun buildView(parent: ViewGroup): FrameLayout {
+        return FrameLayout(parent.context)
+    }
+}
+
+private class NestedModelSpace : EpoxyModelWithView<Space>() {
+    override fun buildView(parent: ViewGroup): Space {
+        return Space(parent.context)
+    }
+}

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelGroupWithAnnotation.java
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ModelGroupWithAnnotation.java
@@ -4,6 +4,7 @@ import com.airbnb.epoxy.EpoxyAttribute;
 import com.airbnb.epoxy.EpoxyModel;
 import com.airbnb.epoxy.EpoxyModelClass;
 import com.airbnb.epoxy.EpoxyModelGroup;
+import com.airbnb.epoxy.ModelGroupHolder;
 
 import java.util.List;
 
@@ -18,7 +19,7 @@ public abstract class ModelGroupWithAnnotation extends EpoxyModelGroup {
   }
 
   @Override
-  public void bind(@NonNull Holder holder) {
+  public void bind(@NonNull ModelGroupHolder holder) {
     super.bind(holder);
     holder.getRootView().setBackgroundColor(backgroundColor);
   }

--- a/epoxy-processortest/src/test/resources/EpoxyModelGroupWithAnnotations_.java
+++ b/epoxy-processortest/src/test/resources/EpoxyModelGroupWithAnnotations_.java
@@ -11,14 +11,14 @@ import java.util.Collection;
 
 /**
  * Generated file. Do not modify! */
-public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotations implements GeneratedModel<EpoxyModelGroup.Holder>, EpoxyModelGroupWithAnnotationsBuilder {
-  private OnModelBoundListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> onModelBoundListener_epoxyGeneratedModel;
+public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotations implements GeneratedModel<ModelGroupHolder>, EpoxyModelGroupWithAnnotationsBuilder {
+  private OnModelBoundListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> onModelBoundListener_epoxyGeneratedModel;
 
-  private OnModelUnboundListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> onModelUnboundListener_epoxyGeneratedModel;
+  private OnModelUnboundListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> onModelUnboundListener_epoxyGeneratedModel;
 
-  private OnModelVisibilityStateChangedListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> onModelVisibilityStateChangedListener_epoxyGeneratedModel;
+  private OnModelVisibilityStateChangedListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> onModelVisibilityStateChangedListener_epoxyGeneratedModel;
 
-  private OnModelVisibilityChangedListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> onModelVisibilityChangedListener_epoxyGeneratedModel;
+  private OnModelVisibilityChangedListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
   public EpoxyModelGroupWithAnnotations_(int layoutRes,
       Collection<? extends EpoxyModel<?>> models) {
@@ -32,14 +32,14 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
   }
 
   @Override
-  public void handlePreBind(final EpoxyViewHolder holder, final EpoxyModelGroup.Holder object,
+  public void handlePreBind(final EpoxyViewHolder holder, final ModelGroupHolder object,
       final int position) {
     super.handlePreBind(holder, object, position);
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
-  public void handlePostBind(final EpoxyModelGroup.Holder object, int position) {
+  public void handlePostBind(final ModelGroupHolder object, int position) {
     super.handlePostBind(object, position);
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
@@ -55,14 +55,14 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public EpoxyModelGroupWithAnnotations_ onBind(
-      OnModelBoundListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> listener) {
+      OnModelBoundListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> listener) {
     onMutation();
     this.onModelBoundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
-  public void unbind(EpoxyModelGroup.Holder object) {
+  public void unbind(ModelGroupHolder object) {
     super.unbind(object);
     if (onModelUnboundListener_epoxyGeneratedModel != null) {
       onModelUnboundListener_epoxyGeneratedModel.onModelUnbound(this, object);
@@ -77,14 +77,14 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public EpoxyModelGroupWithAnnotations_ onUnbind(
-      OnModelUnboundListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> listener) {
+      OnModelUnboundListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> listener) {
     onMutation();
     this.onModelUnboundListener_epoxyGeneratedModel = listener;
     return this;
   }
 
   @Override
-  public void onVisibilityStateChanged(int visibilityState, final EpoxyModelGroup.Holder object) {
+  public void onVisibilityStateChanged(int visibilityState, final ModelGroupHolder object) {
     if (onModelVisibilityStateChangedListener_epoxyGeneratedModel != null) {
       onModelVisibilityStateChangedListener_epoxyGeneratedModel.onVisibilityStateChanged(this, object, visibilityState);
     }
@@ -99,7 +99,7 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public EpoxyModelGroupWithAnnotations_ onVisibilityStateChanged(
-      OnModelVisibilityStateChangedListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> listener) {
+      OnModelVisibilityStateChangedListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> listener) {
     onMutation();
     this.onModelVisibilityStateChangedListener_epoxyGeneratedModel = listener;
     return this;
@@ -107,7 +107,7 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
 
   @Override
   public void onVisibilityChanged(float percentVisibleHeight, float percentVisibleWidth,
-      int visibleHeight, int visibleWidth, final EpoxyModelGroup.Holder object) {
+      int visibleHeight, int visibleWidth, final ModelGroupHolder object) {
     if (onModelVisibilityChangedListener_epoxyGeneratedModel != null) {
       onModelVisibilityChangedListener_epoxyGeneratedModel.onVisibilityChanged(this, object, percentVisibleHeight, percentVisibleWidth, visibleHeight, visibleWidth);
     }
@@ -122,7 +122,7 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
    * <p>
    * You may clear the listener by setting a null value, or by calling {@link #reset()} */
   public EpoxyModelGroupWithAnnotations_ onVisibilityChanged(
-      OnModelVisibilityChangedListener<EpoxyModelGroupWithAnnotations_, EpoxyModelGroup.Holder> listener) {
+      OnModelVisibilityChangedListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> listener) {
     onMutation();
     this.onModelVisibilityChangedListener_epoxyGeneratedModel = listener;
     return this;

--- a/epoxy-processortest/src/test/resources/EpoxyModelGroupWithAnnotations_.java
+++ b/epoxy-processortest/src/test/resources/EpoxyModelGroupWithAnnotations_.java
@@ -34,13 +34,11 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
   @Override
   public void handlePreBind(final EpoxyViewHolder holder, final ModelGroupHolder object,
       final int position) {
-    super.handlePreBind(holder, object, position);
     validateStateHasNotChangedSinceAdded("The model was changed between being added to the controller and being bound.", position);
   }
 
   @Override
   public void handlePostBind(final ModelGroupHolder object, int position) {
-    super.handlePostBind(object, position);
     if (onModelBoundListener_epoxyGeneratedModel != null) {
       onModelBoundListener_epoxyGeneratedModel.onModelBound(this, object, position);
     }
@@ -96,8 +94,7 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
    * <p>
    * The listener will contribute to this model's hashCode state per the {@link
    * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
-   * <p>
-   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+   */
   public EpoxyModelGroupWithAnnotations_ onVisibilityStateChanged(
       OnModelVisibilityStateChangedListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> listener) {
     onMutation();
@@ -119,8 +116,7 @@ public class EpoxyModelGroupWithAnnotations_ extends EpoxyModelGroupWithAnnotati
    * <p>
    * The listener will contribute to this model's hashCode state per the {@link
    * com.airbnb.epoxy.EpoxyAttribute.Option#DoNotHash} rules.
-   * <p>
-   * You may clear the listener by setting a null value, or by calling {@link #reset()} */
+   */
   public EpoxyModelGroupWithAnnotations_ onVisibilityChanged(
       OnModelVisibilityChangedListener<EpoxyModelGroupWithAnnotations_, ModelGroupHolder> listener) {
     onMutation();


### PR DESCRIPTION
There has been a limitation in EpoxyModelGroup that groups with the same view type had to contain the same number of models. This made it very inflexible for dynamically changing group size. Additionally, groups couldn't share subviews between each other, so view recycling was not as effective.

This changes groups to recycle child views into a shared pool among all groups - which also enables groups to have dynamic amounts of models.

This also adds kotlin to the project for the first time 🎉 

This works in the sample app, but I still need to write quite a few tests for it.

@ngsilverman @gpeal 