### PR TITLE
Changed the section name for the timer class to be in the start method

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/DebugTimer.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/DebugTimer.java
@@ -6,6 +6,7 @@ class DebugTimer implements Timer {
 
   private final String tag;
   private long startTime;
+  private String sectionName;
 
   DebugTimer(String tag) {
     this.tag = tag;
@@ -14,10 +15,11 @@ class DebugTimer implements Timer {
 
   private void reset() {
     startTime = -1;
+    sectionName = null;
   }
 
   @Override
-  public void start() {
+  public void start(String sectionName) {
     if (startTime != -1) {
       throw new IllegalStateException("Timer was already started");
     }
@@ -26,13 +28,13 @@ class DebugTimer implements Timer {
   }
 
   @Override
-  public void stop(String message) {
+  public void stop() {
     if (startTime == -1) {
       throw new IllegalStateException("Timer was not started");
     }
 
     float durationMs = (System.nanoTime() - startTime) / 1000000f;
-    Log.d(tag, String.format(message + ": %.3fms", durationMs));
+    Log.d(tag, String.format(sectionName + ": %.3fms", durationMs));
     reset();
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/DebugTimer.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/DebugTimer.java
@@ -25,6 +25,7 @@ class DebugTimer implements Timer {
     }
 
     startTime = System.nanoTime();
+    this.sectionName = sectionName;
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyController.java
@@ -264,19 +264,19 @@ public abstract class EpoxyController {
 
       modelsBeingBuilt = new ControllerModelList(getExpectedModelCount());
 
-      timer.start();
+      timer.start("Models built");
       buildModels();
       addCurrentlyStagedModelIfExists();
-      timer.stop("Models built");
+      timer.stop();
 
       runInterceptors();
       filterDuplicatesIfNeeded(modelsBeingBuilt);
       modelsBeingBuilt.freeze();
 
-      timer.start();
+      timer.start("Models diffed");
       adapter.setModels(modelsBeingBuilt);
       // This timing is only right if diffing and model building are on the same thread
-      timer.stop("Models diffed");
+      timer.stop();
 
       modelsBeingBuilt = null;
       hasBuiltModelsEver = true;
@@ -359,13 +359,13 @@ public abstract class EpoxyController {
         }
       }
 
-      timer.start();
+      timer.start("Interceptors executed");
 
       for (Interceptor interceptor : interceptors) {
         interceptor.intercept(modelsBeingBuilt);
       }
 
-      timer.stop("Interceptors executed");
+      timer.stop();
 
       if (modelInterceptorCallbacks != null) {
         for (ModelInterceptorCallback callback : modelInterceptorCallbacks) {
@@ -537,7 +537,7 @@ public abstract class EpoxyController {
       return;
     }
 
-    timer.start();
+    timer.start("Duplicates filtered");
     Set<Long> modelIds = new HashSet<>(models.size());
 
     ListIterator<EpoxyModel<?>> modelIterator = models.listIterator();
@@ -562,7 +562,7 @@ public abstract class EpoxyController {
       }
     }
 
-    timer.stop("Duplicates filtered");
+    timer.stop();
   }
 
   private int findPositionOfDuplicate(List<EpoxyModel<?>> models, EpoxyModel<?> duplicateModel) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/NoOpTimer.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/NoOpTimer.java
@@ -2,12 +2,12 @@ package com.airbnb.epoxy;
 
 class NoOpTimer implements Timer {
   @Override
-  public void start() {
+  public void start(String sectionName) {
 
   }
 
   @Override
-  public void stop(String message) {
+  public void stop() {
 
   }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Timer.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Timer.java
@@ -1,6 +1,6 @@
 package com.airbnb.epoxy;
 
 interface Timer {
-  void start();
-  void stop(String message);
+  void start(String sectionName);
+  void stop();
 }


### PR DESCRIPTION
This follows the more standard android.os.Trace class which allows to make traces or also use Firebase performance monitoring with an overrode DebugTimer class in a local project.