### PR TITLE
Disabled the auto-detach behavior on Carousels by default.

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
@@ -494,18 +494,6 @@ public class Carousel extends EpoxyRecyclerView {
     super.setModels(models);
   }
 
-  @ModelProp
-  @Override
-  public void setRemoveAdapterWhenDetachedFromWindow(boolean removeAdapterWhenDetachedFromWindow) {
-    super.setRemoveAdapterWhenDetachedFromWindow(removeAdapterWhenDetachedFromWindow);
-  }
-
-  @ModelProp
-  @Override
-  public void setDelayMsWhenRemovingAdapterOnDetach(int delayMsWhenRemovingAdapterOnDetach) {
-    super.setDelayMsWhenRemovingAdapterOnDetach(delayMsWhenRemovingAdapterOnDetach);
-  }
-
   @OnViewRecycled
   public void clear() {
     super.clear();

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
@@ -500,6 +500,12 @@ public class Carousel extends EpoxyRecyclerView {
     super.setRemoveAdapterWhenDetachedFromWindow(removeAdapterWhenDetachedFromWindow);
   }
 
+  @ModelProp
+  @Override
+  public void setDelayMsWhenRemovingAdapterOnDetach(int delayMsWhenRemovingAdapterOnDetach) {
+    super.setDelayMsWhenRemovingAdapterOnDetach(delayMsWhenRemovingAdapterOnDetach);
+  }
+
   @OnViewRecycled
   public void clear() {
     super.clear();

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
@@ -102,6 +102,9 @@ public class Carousel extends EpoxyRecyclerView {
     if (snapHelperFactory != null) {
       snapHelperFactory.buildSnapHelper(getContext()).attachToRecyclerView(this);
     }
+    
+    // Carousels will be detached when their parent recyclerview is
+    setRemoveAdapterWhenDetachedFromWindow(false);
   }
 
   /**

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
@@ -494,6 +494,11 @@ public class Carousel extends EpoxyRecyclerView {
     super.setModels(models);
   }
 
+  @ModelProp
+  public void setRemoveAdapterWhenCarouselDetachedFromWindow(boolean removeAdapterWhenDetachedFromWindow) {
+    super.setRemoveAdapterWhenDetachedFromWindow(removeAdapterWhenDetachedFromWindow);
+  }
+
   @OnViewRecycled
   public void clear() {
     super.clear();

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
@@ -102,7 +102,7 @@ public class Carousel extends EpoxyRecyclerView {
     if (snapHelperFactory != null) {
       snapHelperFactory.buildSnapHelper(getContext()).attachToRecyclerView(this);
     }
-    
+
     // Carousels will be detached when their parent recyclerview is
     setRemoveAdapterWhenDetachedFromWindow(false);
   }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
@@ -495,7 +495,8 @@ public class Carousel extends EpoxyRecyclerView {
   }
 
   @ModelProp
-  public void setRemoveAdapterWhenCarouselDetachedFromWindow(boolean removeAdapterWhenDetachedFromWindow) {
+  @Override
+  public void setRemoveAdapterWhenDetachedFromWindow(boolean removeAdapterWhenDetachedFromWindow) {
     super.setRemoveAdapterWhenDetachedFromWindow(removeAdapterWhenDetachedFromWindow);
   }
 


### PR DESCRIPTION
Hey @elihart, I was implementing some SharedElementTransition's on a Carousel and found out under certain conditions some may fail due to its adapter being detached, causing models to be unbound and hence failing to execute the exit part of a SharedElementTransition properly (adapter is reattached, scroll position reset). 

I solved this by extending Carousel and calling `setRemoveAdapterWhenDetachedFromWindow` on `init`, but I guess exposing a ModelProp for it on the Carousel itself shouldn't cause any side effects.

Edit:
Also exposed `setDelayMsWhenRemovingAdapterOnDetach` to keep consistency with `EpoxyRecyclerView`