### PR TITLE
Release 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 3.4.0 (April 10, 2019)
+# 3.4.1 (April 16, 2019)
 - **New** Support kotlin default parameters in @ModelView classes (https://github.com/airbnb/epoxy/pull/722)
+
+# 3.4.0 (April 10, 2019)
 - **New** Generate OnModelCheckedChangeListener override for props of type `CompoundButton.OnCheckedChangeListener` (https://github.com/airbnb/epoxy/pull/725)
 - **New** Extract ID generation methods to new public IdUtils class (https://github.com/airbnb/epoxy/pull/724)
 - **Changed** Reset controller state on failed model build (https://github.com/airbnb/epoxy/pull/720)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.4.0
+VERSION_NAME=3.4.1
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
The previous 3.4.0 release was supposed to include the Kotlin default param change, but it was mistakenly excluded. This includes it as intended.