### PR TITLE
Fix type differentiate in default param support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.4.2 (April 18, 2019)
+- **Fixed** Kotlin default param handling had issues with overloaded functions
+
 # 3.4.1 (April 16, 2019)
 - **New** Support kotlin default parameters in @ModelView classes (https://github.com/airbnb/epoxy/pull/722)
 

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/KotlinViewWithDefaultParams.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/KotlinViewWithDefaultParams.kt
@@ -36,6 +36,20 @@ class KotlinViewWithDefaultParams(context: Context) : View(context) {
         groupValue = num
     }
 
+    // Make sure that overloads with the same function name and param name are distinguished correctly by type
+    @JvmOverloads
+    @ModelProp
+    fun setImage(image: Map<String, Int> = emptyMap()) {
+    }
+
+    @ModelProp
+    fun setImage(image: String) {
+    }
+
+    @ModelProp
+    fun somePropWithoutDefault(num: Int) {
+    }
+
     var groupValue: Int? = null
 
     companion object {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ErrorLogger.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ErrorLogger.kt
@@ -8,8 +8,15 @@ class ErrorLogger {
 
     private val loggedExceptions: MutableList<Exception> = mutableListOf()
 
+    private val warnings: MutableList<String> = mutableListOf()
+
     fun writeExceptions(messager: Messager) {
         loggedExceptions.forEach { messager.printMessage(Diagnostic.Kind.ERROR, it.toString()) }
+        warnings.forEach { messager.printMessage(Diagnostic.Kind.WARNING, it) }
+    }
+
+    fun logWarning(msg: String) {
+        warnings.add(msg)
     }
 
     fun logErrors(exceptions: List<Exception>) {
@@ -33,7 +40,8 @@ class ErrorLogger {
      * If the exception is not an [EpoxyProcessorException] then the stacktrace will be shown in
      * the output.
      */
-    @JvmOverloads fun logError(e: Exception, message: String = "") {
+    @JvmOverloads
+    fun logError(e: Exception, message: String = "") {
         logEpoxyError(e as? EpoxyProcessorException ?: EpoxyProcessorException(e, message))
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.4.1
+VERSION_NAME=3.4.2
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
Kotlin methods with default parameters were not correctly differentiated if there were overloaded methods with the same parameter name.