### PR TITLE
IllegalEpoxyUsage in EpoxyVisibilityTracker: Remove throws because nested visibility

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -217,10 +217,6 @@ public class EpoxyVisibilityTracker {
             }
           }
         }
-      } else {
-        throw new IllegalEpoxyUsage(
-            "`EpoxyVisibilityTracker` cannot be used with non-epoxy view holders."
-        );
       }
     }
   }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -29,10 +29,6 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder;
  * {@link EpoxyVisibilityTracker} works with any {@link androidx.recyclerview.widget.RecyclerView}
  * backed by an Epoxy controller. Once attached the events will be forwarded to the Epoxy model (or
  * to the Epoxy view when using annotations).
- * <p>
- * Note regarding nested lists: The visibility event tracking is not properly handled yet. This is
- * on the todo.
- * <p>
  *
  * @see OnVisibilityChanged
  * @see OnVisibilityStateChanged


### PR DESCRIPTION
Fix for this crash we had recently. It happen when an epoxy controller contain a model which is a `RecyclerView` not backed by Epoxy. We used this strategy when the `RecyclerView` / `Adapter` was too costly to rewrite on Epoxy.

This exception do not make a lot of sense now and should have been removed when nested visibility tracker had been added (I also removed the related todo).

```
com.airbnb.epoxy.IllegalEpoxyUsage: 
  at com.airbnb.epoxy.EpoxyVisibilityTracker.processChild (EpoxyVisibilityTracker.java:221)
  at com.airbnb.epoxy.EpoxyVisibilityTracker.access$300 (EpoxyVisibilityTracker.java:42)
  at com.airbnb.epoxy.EpoxyVisibilityTracker.access$800 (EpoxyVisibilityTracker.java:42)
  at com.airbnb.epoxy.EpoxyVisibilityTracker$Listener.onChildViewAttachedToWindow (EpoxyVisibilityTracker.java:322)
  at androidx.recyclerview.widget.RecyclerView.dispatchChildAttached (RecyclerView.java:7275)
  at androidx.recyclerview.widget.RecyclerView$5.addView (RecyclerView.java:855)
  at androidx.recyclerview.widget.ChildHelper.addView (ChildHelper.java:107)
  at androidx.recyclerview.widget.RecyclerView$LayoutManager.addViewInt (RecyclerView.java:8336)
  at androidx.recyclerview.widget.RecyclerView$LayoutManager.addView (RecyclerView.java:8294)
  at androidx.recyclerview.widget.RecyclerView$LayoutManager.addView (RecyclerView.java:8282)
  at androidx.recyclerview.widget.LinearLayoutManager.layoutChunk (LinearLayoutManager.java:1571)
  at androidx.recyclerview.widget.LinearLayoutManager.fill (LinearLayoutManager.java:1517)
  at androidx.recyclerview.widget.LinearLayoutManager.onLayoutChildren (LinearLayoutManager.java:612)
```