### PR TITLE
Prevent IllegalArgumentException during EpoxyVisibilityTracker child processing

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -199,7 +199,7 @@ public class EpoxyVisibilityTracker {
    */
   private void processChild(@NonNull View child, boolean detachEvent, String eventOriginForDebug) {
     final RecyclerView recyclerView = attachedRecyclerView;
-    if (recyclerView != null) {
+    if (recyclerView != null && child.getParent() == recyclerView) {
       final ViewHolder holder = recyclerView.getChildViewHolder(child);
       if (holder instanceof EpoxyViewHolder) {
         boolean changed = processVisibilityEvents(

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -199,8 +199,11 @@ public class EpoxyVisibilityTracker {
    */
   private void processChild(@NonNull View child, boolean detachEvent, String eventOriginForDebug) {
     final RecyclerView recyclerView = attachedRecyclerView;
-    if (recyclerView != null && child.getParent() == recyclerView) {
-      final ViewHolder holder = recyclerView.getChildViewHolder(child);
+    if (recyclerView != null) {
+      // Preemptive check for child's parent validity to prevent `IllegalArgumentException` in
+      // `getChildViewHolder`.
+      final boolean isParentValid = child.getParent() == null || child.getParent() == recyclerView;
+      final ViewHolder holder = isParentValid ? recyclerView.getChildViewHolder(child) : null;
       if (holder instanceof EpoxyViewHolder) {
         boolean changed = processVisibilityEvents(
             recyclerView,


### PR DESCRIPTION
I could not reproduce bug #700 but this additional condition should prevent the `IllegalArgumentException` from happening when `recyclerView.getChildViewHolder(child)` is called.