### PR TITLE
Release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.6.0 (June 18, 2019)
+- **New** Preloader system with glide extensions https://github.com/airbnb/epoxy/pull/766
+- **Fixed** model click listener crashing on nested model https://github.com/airbnb/epoxy/pull/767
+
 # 3.5.1 (May 21, 2019)
 - Bumped Kotlin to 1.3.31
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.5.1
+VERSION_NAME=3.6.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- **New** Preloader system with glide extensions https://github.com/airbnb/epoxy/pull/766
  - Docs at https://github.com/airbnb/epoxy/wiki/Image-Preloading
- **Fixed** model click listener crashing on nested model https://github.com/airbnb/epoxy/pull/767