### PR TITLE
[integrationtest] Add KotlinViewWithDefaultParamsSubclass

### DIFF
--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/KotlinViewWithDefaultParams.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/KotlinViewWithDefaultParams.kt
@@ -7,7 +7,7 @@ import com.airbnb.epoxy.ModelView
 import com.airbnb.epoxy.TextProp
 
 @ModelView(autoLayout = ModelView.Size.WRAP_WIDTH_MATCH_HEIGHT)
-class KotlinViewWithDefaultParams(context: Context) : View(context) {
+open class KotlinViewWithDefaultParams(context: Context) : View(context) {
 
     @JvmOverloads
     @ModelProp

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/KotlinViewWithDefaultParamsSubclass.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/KotlinViewWithDefaultParamsSubclass.kt
@@ -1,0 +1,12 @@
+package com.airbnb.epoxy.integrationtest
+
+import android.content.Context
+import android.view.View
+import com.airbnb.epoxy.ModelProp
+import com.airbnb.epoxy.ModelView
+import com.airbnb.epoxy.TextProp
+
+@ModelView(autoLayout = ModelView.Size.WRAP_WIDTH_MATCH_HEIGHT)
+class KotlinViewWithDefaultParamsSubclass(context: Context) : KotlinViewWithDefaultParams(context) {
+
+}


### PR DESCRIPTION
@elihart found what looks like a bug. Using Kotlin default params on a property of a parent class of a model causes the following crash:

```kotlin
e: error: Epoxy Processor Exception:  Caused by IndexOutOfBoundsException: Index: 0, Size: 0       Stacktrace:      
com.airbnb.epoxy.ViewAttributeInfo.<init>(ViewAttributeInfo.kt:60)       
com.airbnb.epoxy.ModelViewInfo.addPropIfNotExists(ModelViewInfo.kt:225)       
com.airbnb.epoxy.ModelViewProcessor$updateViewsForInheritedViewAnnotations$1$2.invoke(ModelViewProcessor.kt:431)       
com.airbnb.epoxy.ModelViewProcessor$updateViewsForInheritedViewAnnotations$1$2.invoke(ModelViewProcessor.kt:24)       
com.airbnb.epoxy.ModelViewProcessor$updateViewsForInheritedViewAnnotations$1$1.invoke(ModelViewProcessor.kt:418)       
com.airbnb.epoxy.ModelViewProcessor$updateViewsForInheritedViewAnnotations$1.invoke(ModelViewProcessor.kt:426)       
com.airbnb.epoxy.ModelViewProcessor$updateViewsForInheritedViewAnnotations$1.invoke(ModelViewProcessor.kt:24)       
com.airbnb.epoxy.KotlinUtilsKt$iterateSuperClasses$1.invoke(KotlinUtils.kt:158)       
com.airbnb.epoxy.KotlinUtilsKt$iterateSuperClasses$1.invoke(KotlinUtils.kt)       
com.airbnb.epoxy.KotlinUtilsKt.iterateClassHierarchy(KotlinUtils.kt:144)       
com.airbnb.epoxy.KotlinUtilsKt.iterateSuperClasses(KotlinUtils.kt:155)       
com.airbnb.epoxy.ModelViewProcessor.updateViewsForInheritedViewAnnotations(ModelViewProcessor.kt:399)       
com.airbnb.epoxy.ModelViewProcessor.process(ModelViewProcessor.kt:52)       
com.airbnb.epoxy.EpoxyProcessor.processRound(EpoxyProcessor.java:193)       
com.airbnb.epoxy.EpoxyProcessor.process(EpoxyProcessor.java:165)
```

Running `./gradlew test` on this branch will repro. I'm happy to take a crack at fixing it if you give me a few pointers.