### PR TITLE
Remove extra space in Kotlin extensions

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/KotlinModelBuilderExtensionWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/KotlinModelBuilderExtensionWriter.kt
@@ -118,7 +118,7 @@ internal class KotlinModelBuilderExtensionWriter(
             if (constructorIsNotPublic) addModifiers(KModifier.INTERNAL)
 
             beginControlFlow(
-                "$tick%T$tick(${params.joinToString(", ") { it.name }}).apply ",
+                "$tick%T$tick(${params.joinToString(", ") { it.name }}).apply",
                 modelClass
             )
             addStatement("modelInitializer()")


### PR DESCRIPTION
This was generating code like:
```kotlin
DataBindingItemBindingModel_().apply  {
        modelInitializer()
    }
```
Notice the extra space after `apply`. This was causing ktlint errors. 