### PR TITLE
Refactor EpoxyItemspacingDecorator getItemOffsets 

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyItemSpacingDecorator.java
@@ -61,29 +61,18 @@ public class EpoxyItemSpacingDecorator extends RecyclerView.ItemDecoration {
     calculatePositionDetails(parent, position, layout);
 
     boolean left = useLeftPadding();
-    boolean right = useRightPadding();
     boolean top = useTopPadding();
-    boolean bottom = useBottomPadding();
 
     if (shouldReverseLayout(layout, horizontallyScrolling)) {
       if (horizontallyScrolling) {
-        boolean temp = left;
-        left = right;
-        right = temp;
+        left = useRightPadding();
       } else {
-        boolean temp = top;
-        top = bottom;
-        bottom = temp;
+        top = useBottomPadding();
       }
     }
 
-    // Divided by two because it is applied to the left side of one item and the right of another
-    // to add up to the total desired space
-    int padding = pxBetweenItems / 2;
-    outRect.right = right ? padding : 0;
-    outRect.left = left ? padding : 0;
-    outRect.top = top ? padding : 0;
-    outRect.bottom = bottom ? padding : 0;
+    outRect.left = left ? pxBetweenItems : 0;
+    outRect.top = top ? pxBetweenItems : 0;
   }
 
   private void calculatePositionDetails(RecyclerView parent, int position, LayoutManager layout) {


### PR DESCRIPTION
Refactor `EpoxyItemspacingDecorator.getItemOffsets(...)`
```
Current implementation 
- padding = pxBetweenItems / 2
- set padding on left, right, top and bottom

Which can be reduced to
- set pxBetweenItems on left and top
```
This will reduce the amount of statements executed by half.