### PR TITLE
Add support for Kotlin delegation via annotated interface properties

### DIFF
--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithDelegate.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/ViewWithDelegate.kt
@@ -1,0 +1,23 @@
+package com.airbnb.epoxy.integrationtest
+
+import android.content.Context
+import android.view.View
+import com.airbnb.epoxy.ModelProp
+import com.airbnb.epoxy.ModelView
+
+@ModelView(autoLayout = ModelView.Size.WRAP_WIDTH_MATCH_HEIGHT)
+class ViewWithDelegate @JvmOverloads constructor(
+    context: Context,
+    implementation: InterfaceImplementation = InterfaceImplementation()
+) : View(context), InterfaceWithModelProp by implementation
+
+interface InterfaceWithModelProp {
+
+    @set:ModelProp
+    var flag: Boolean
+}
+
+class InterfaceImplementation : InterfaceWithModelProp {
+
+    override var flag: Boolean = false
+}

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewDelegateTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/ModelViewDelegateTest.kt
@@ -1,0 +1,19 @@
+package com.airbnb.epoxy
+
+import com.airbnb.epoxy.integrationtest.BuildConfig
+import com.airbnb.epoxy.integrationtest.ViewWithDelegateModel_
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(21))
+class ModelViewDelegateTest {
+
+    @Test
+    fun propMethodIsOnModel() {
+        val model = ViewWithDelegateModel_()
+        model.flag(true)
+    }
+}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/ModelViewProcessor.kt
@@ -129,6 +129,16 @@ internal class ModelViewProcessor(
 
         for (propAnnotation in modelPropAnnotations) {
             for (prop in roundEnv.getElementsAnnotatedWith(propAnnotation)) {
+
+                // Interfaces can use model property annotations freely, they will be processed if
+                // and when implementors of that interface are processed. This is particularly
+                // useful for Kotlin delegation where the model view class may not be overriding
+                // the interface properties directly, and so doesn't have an opportunity to annotate
+                // them with Epoxy model property annotations.
+                if (prop.enclosingElement.kind == ElementKind.INTERFACE) {
+                    continue
+                }
+
                 val info = getModelInfoForPropElement(prop)
                 if (info == null) {
                     errorLogger.logError(


### PR DESCRIPTION
Usually when implementing an interface its properties have to be overridden and can be annotated as Epoxy properties in the implementing class.

With Kotlin delegation however, classes can delegate the implementation of an interface to another object, which can reduce boilerplate substantially and avoids redundant code.

Currently, if properties of a delegated interface are meant to be used with Epoxy, they would have to be overridden, despite the delegation, so that they can be annotated, thus losing the benefits of delegation. With this change, the interface properties can be annotated as Epoxy properties, and will carry over to the delegating class.

The test illustrates this use case well.

@elihart