### PR TITLE
Fix for #818 - visibility tracking with recycling

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -327,7 +327,6 @@ public class EpoxyVisibilityTracker {
       if (child instanceof RecyclerView) {
         processChildRecyclerViewAttached((RecyclerView) child);
       }
-      processChild(child, false, "onChildViewAttachedToWindow");
     }
 
     @Override

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -636,6 +636,7 @@ class EpoxyVisibilityTrackerTest {
 
     /**
      * Test case for https://github.com/airbnb/epoxy/issues/818
+     * The data set used are taken from the sample app attached on the issue
      */
     @Test
     fun testRebuildData() {
@@ -652,6 +653,7 @@ class EpoxyVisibilityTrackerTest {
                     in 0..5 -> {
                         with(helper) {
                             assert(
+                                // If called then it should be only once
                                 onVisibilityChangedCount = 1
                             )
                         }
@@ -659,6 +661,7 @@ class EpoxyVisibilityTrackerTest {
                     else -> {
                         with(helper) {
                             assert(
+                                // 6th items and after should never be visible on current view port
                                 onVisibilityChangedCount = 0
                             )
                         }
@@ -671,13 +674,19 @@ class EpoxyVisibilityTrackerTest {
         for (i in 0..3) {
 
             log("buildTestData $i-1")
-            validateFivePlusPeek(buildTestData(24, fivePlusPeek))
+            validateFivePlusPeek(
+                buildTestData(24, fivePlusPeek)
+            )
 
             log("buildTestData $i-2")
-            validateFivePlusPeek(buildTestData(2, fivePlusPeek))
+            validateFivePlusPeek(
+                buildTestData(2, fivePlusPeek)
+            )
 
             log("buildTestData $i-3")
-            validateFivePlusPeek(buildTestData(10, fivePlusPeek))
+            validateFivePlusPeek(
+                buildTestData(10, fivePlusPeek)
+            )
         }
     }
 

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -635,6 +635,25 @@ class EpoxyVisibilityTrackerTest {
     }
 
     /**
+     * Test case for https://github.com/airbnb/epoxy/issues/818
+     */
+    @Test
+    fun testRebuildData() {
+
+        log("buildTestData 1")
+        buildTestData(4, TWO_AND_HALF_VISIBLE).let {
+        }
+
+        log("buildTestData 2")
+        buildTestData(3, TWO_AND_HALF_VISIBLE).let {
+        }
+
+        log("buildTestData 3")
+        buildTestData(5, TWO_AND_HALF_VISIBLE).let {
+        }
+    }
+
+    /**
      * Attach an EpoxyController on the RecyclerView
      */
     private fun buildTestData(


### PR DESCRIPTION
The bug is because, when a view is recycled, the `onChildViewAttachedToWindow` was send an event right away. On some recycling use case it happen before the view get laid out to the new data making the event is wrong as it still contains attributes of the recycled view.

I was able to reproduce the issue in unit test (Robolectric) by removing the item animator. That makes the recycler poll also used during tests. The idea of the new test is to rebuild the data set several time and make sure than always 1 visibility changed event is sent (as no scroll).

This should fix https://github.com/airbnb/epoxy/issues/818