### PR TITLE
Make EpoxyRecyclerView.setItemSpacingPx() open

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyRecyclerView.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyRecyclerView.kt
@@ -364,7 +364,7 @@ open class EpoxyRecyclerView @JvmOverloads constructor(
      * @see .setItemSpacingDp
      * @see .setItemSpacingRes
      */
-    fun setItemSpacingPx(@Px spacingPx: Int) {
+    open fun setItemSpacingPx(@Px spacingPx: Int) {
         removeItemDecoration(spacingDecorator)
         spacingDecorator.pxBetweenItems = spacingPx
 


### PR DESCRIPTION
Fix for https://github.com/airbnb/epoxy/issues/782.

I considered adding a new method to our internal subclass, but `setItemSpacingPx()` is called internally by `Carousel` in a number of places (particularly relating to padding), making it difficult to do so without causing other issues.