### PR TITLE
Fix reading EpoxyDataBindingPattern enableDoNotHash value

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/DataBindingProcessor.kt
@@ -58,7 +58,7 @@ internal class DataBindingProcessor(
             val moduleName = rClassName.packageName()
             val layoutClassName = ClassName.get(moduleName, "R", "layout")
             val enableDoNotHash =
-                element.annotation<EpoxyDataBindingLayouts>()?.enableDoNotHash == true
+                element.annotation<EpoxyDataBindingPattern>()?.enableDoNotHash == true
 
             Utils.getElementByName(layoutClassName, elements, types)
                 .enclosedElements


### PR DESCRIPTION
The enableDoNotHash flag was incorrectly parsed as false even when it
was left at the default value (true) in the actual annotation. This looked like a copy&paste error when using the value from the annotation.

I did not update the tests because a large number of them were failing already before this change.