### PR TITLE
Use same version for Mockito Core and Inline

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -76,7 +76,7 @@ rootProject.ext.deps = [
     googleTestingCompile  : "com.google.testing.compile:compile-testing:$GOOGLE_TESTING_COMPILE_VERSION",
     junit                 : "junit:junit:$JUNIT_VERSION",
     mockito               : "org.mockito:mockito-core:$MOCKITO_VERSION",
-    mockito_inline        : "org.mockito:mockito-inline:+",
+    mockito_inline        : "org.mockito:mockito-inline:$MOCKITO_VERSION",
     robolectric           : "org.robolectric:robolectric:$ROBOLECTRIC_VERSION",
     lottie                : "com.airbnb.android:lottie:$LOTTIE_VERSION",
     lithoProcessor        : "com.facebook.litho:litho-processor:$LITHO_VERSION",


### PR DESCRIPTION
Both libraries are updated together on maven and hence we can track the same version for both. 

The release cycles can be verified here
https://mvnrepository.com/artifact/org.mockito