### PR TITLE
Release 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.9.0 (Dec 17, 2019)
+- Fix reading EpoxyDataBindingPattern enableDoNotHash (#837) 
+- Make EpoxyRecyclerView.setItemSpacingPx() open (#829)
+- Use same version for Mockito Core and Inline (#860)
+- Minor documentation and variable name updates. (#870)
+- Move epoxy-modelfactory tests to their own module (#834) 
+- Remove executable bit from non-executable files (#864)
+- Various repo clean ups and version bumps
+
 # 3.8.0 (Sept 16, 2019)
 - Add support for Kotlin delegation via annotated interface properties #812
 - Fix checked change crash and improve debug errors #806

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,6 @@ Releasing
  1. Bump the VERSION_NAME property in `gradle.properties` based on Major.Minor.Patch naming scheme
  2. Update `CHANGELOG.md` for the impending release.
  3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
- 4. `./gradlew clean assemble androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel`
+ 4. `./gradlew assemble sourcesJar javadocsJar androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel`
  5. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
  6. Open PR with on Github, merge, and publish release through Github UI.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,6 @@ Releasing
  1. Bump the VERSION_NAME property in `gradle.properties` based on Major.Minor.Patch naming scheme
  2. Update `CHANGELOG.md` for the impending release.
  3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
- 4. `./gradlew clean assemble uploadArchives`
+ 4. `./gradlew clean assemble androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel`
  5. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
  6. Open PR with on Github, merge, and publish release through Github UI.

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     classpath "com.android.tools.build:gradle:$ANDROID_PLUGIN_VERSION"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     // Upload with:
-    // ./gradlew clean assemble androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
+    // ./gradlew assemble sourcesJar javadocsJar androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
     // Need to use snapshot version and explicitly include javadoc/sources tasks until
     // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed
     classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,23 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-  ext.KOTLIN_VERSION = "1.3.50"
-  ext.ANDROID_PLUGIN_VERSION = "3.5.1"
+  ext.KOTLIN_VERSION = "1.3.61"
+  ext.ANDROID_PLUGIN_VERSION = '3.5.3'
 
   repositories {
     google()
     jcenter()
+    // For gradle-maven-publish-plugin snapshot
+    maven { url "https://oss.sonatype.org/service/local/repositories/snapshots/content/" }
   }
   dependencies {
     classpath "com.android.tools.build:gradle:$ANDROID_PLUGIN_VERSION"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.8.0'
+    // Upload with:
+    // ./gradlew clean assemble androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
+    // Need to use snapshot version and explicitly include javadoc/sources tasks until
+    // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed
+    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.8.0
+VERSION_NAME=3.9.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-  ktlint "com.pinterest:ktlint:0.35.0"
+  ktlint "com.pinterest:ktlint:0.36.0"
   // additional 3rd party ruleset(s) can be specified here
   // just add them to the classpath (e.g. ktlint 'groupId:artifactId:version') and
   // ktlint will pick them up


### PR DESCRIPTION
- Fix reading EpoxyDataBindingPattern enableDoNotHash (#837) 
- Make EpoxyRecyclerView.setItemSpacingPx() open (#829)
- Use same version for Mockito Core and Inline (#860)
- Minor documentation and variable name updates. (#870)
- Move epoxy-modelfactory tests to their own module (#834) 
- Remove executable bit from non-executable files (#864)
- Various repo clean ups and version bumps