### PR TITLE
Rename ResultCallack to ResultCallback in AsyncEpoxyDiffer

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/AsyncEpoxyDiffer.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/AsyncEpoxyDiffer.java
@@ -20,22 +20,22 @@ import androidx.recyclerview.widget.DiffUtil.ItemCallback;
  */
 class AsyncEpoxyDiffer {
 
-  interface ResultCallack {
+  interface ResultCallback {
     void onResult(@NonNull DiffResult result);
   }
 
   private final Executor executor;
-  private final ResultCallack resultCallack;
+  private final ResultCallback resultCallback;
   private final ItemCallback<EpoxyModel<?>> diffCallback;
   private final GenerationTracker generationTracker = new GenerationTracker();
 
   AsyncEpoxyDiffer(
       @NonNull Handler handler,
-      @NonNull ResultCallack resultCallack,
+      @NonNull ResultCallback resultCallback,
       @NonNull ItemCallback<EpoxyModel<?>> diffCallback
   ) {
     this.executor = new HandlerExecutor(handler);
-    this.resultCallack = resultCallack;
+    this.resultCallback = resultCallback;
     this.diffCallback = diffCallback;
   }
 
@@ -170,7 +170,7 @@ class AsyncEpoxyDiffer {
       public void run() {
         final boolean dispatchResult = tryLatchList(newList, runGeneration);
         if (result != null && dispatchResult) {
-          resultCallack.onResult(result);
+          resultCallback.onResult(result);
         }
       }
     });

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -2,7 +2,7 @@ package com.airbnb.epoxy;
 
 import android.os.Handler;
 
-import com.airbnb.epoxy.AsyncEpoxyDiffer.ResultCallack;
+import com.airbnb.epoxy.AsyncEpoxyDiffer.ResultCallback;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +13,7 @@ import androidx.annotation.UiThread;
 import androidx.recyclerview.widget.DiffUtil.ItemCallback;
 import androidx.recyclerview.widget.RecyclerView;
 
-public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements ResultCallack {
+public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements ResultCallback {
   private final NotifyBlocker notifyBlocker = new NotifyBlocker();
   private final AsyncEpoxyDiffer differ;
   private final EpoxyController epoxyController;


### PR DESCRIPTION
I think `ResultCallack` is a typo.
If the word meant `call acknowledgement`, it would be right to write `ResultCallAck`.. and it seems to mean callback.