### PR TITLE
Fix leak in ActivityRecyclerPool when EpoxyRecyclerView is created with a ContextWrapper

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
@@ -64,6 +64,18 @@ internal class ActivityRecyclerPool {
             pools.remove(pool)
         }
     }
+
+    private fun Context.lifecycle(): Lifecycle? {
+        if (this is LifecycleOwner) {
+            return lifecycle
+        }
+
+        if (this is ContextWrapper) {
+            return baseContext.lifecycle()
+        }
+
+        return null
+    }
 }
 
 internal class PoolReference(
@@ -104,16 +116,4 @@ internal fun Context?.isActivityDestroyed(): Boolean {
         // Use this as a proxy for being destroyed on older devices
         !ViewCompat.isAttachedToWindow(window.decorView)
     }
-}
-
-private fun Context.lifecycle(): Lifecycle? {
-    if (this is LifecycleOwner) {
-        return lifecycle
-    }
-
-    if (this is ContextWrapper) {
-        return baseContext.lifecycle()
-    }
-
-    return null
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
@@ -90,12 +90,8 @@ internal fun Context?.isActivityDestroyed(): Boolean {
         return true
     }
 
-    if (this is ContextWrapper) {
-        return baseContext.isActivityDestroyed()
-    }
-
     if (this !is Activity) {
-        return false
+        return (this as? ContextWrapper)?.baseContext?.isActivityDestroyed() ?: false
     }
 
     if (isFinishing) {
@@ -111,9 +107,13 @@ internal fun Context?.isActivityDestroyed(): Boolean {
 }
 
 private fun Context.lifecycle(): Lifecycle? {
+    if (this is LifecycleOwner) {
+        return lifecycle
+    }
+
     if (this is ContextWrapper) {
         return baseContext.lifecycle()
     }
 
-    return (this as? LifecycleOwner)?.lifecycle
+    return null
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
@@ -2,6 +2,7 @@ package com.airbnb.epoxy
 
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.Lifecycle
@@ -87,6 +88,10 @@ internal class PoolReference(
 internal fun Context?.isActivityDestroyed(): Boolean {
     if (this == null) {
         return true
+    }
+
+    if (this is ContextWrapper) {
+        return baseContext.isActivityDestroyed()
     }
 
     if (this !is Activity) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ActivityRecyclerPool.kt
@@ -51,7 +51,7 @@ internal class ActivityRecyclerPool {
 
         if (poolToUse == null) {
             poolToUse = PoolReference(context, poolFactory(), this)
-            (context as? LifecycleOwner)?.lifecycle?.addObserver(poolToUse)
+            context.lifecycle()?.addObserver(poolToUse)
             pools.add(poolToUse)
         }
 
@@ -108,4 +108,12 @@ internal fun Context?.isActivityDestroyed(): Boolean {
         // Use this as a proxy for being destroyed on older devices
         !ViewCompat.isAttachedToWindow(window.decorView)
     }
+}
+
+private fun Context.lifecycle(): Lifecycle? {
+    if (this is ContextWrapper) {
+        return baseContext.lifecycle()
+    }
+
+    return (this as? LifecycleOwner)?.lifecycle
 }


### PR DESCRIPTION
Fixes https://github.com/airbnb/epoxy/issues/886 by unwrapping `Context`s to find the `LifecycleOwner` / `Activity` as appropriate.