### PR TITLE
Carousel - Use measured width/height if it exists.

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/Carousel.java
@@ -239,6 +239,10 @@ public class Carousel extends EpoxyRecyclerView {
       return view.getWidth();
     }
 
+    if (view.getMeasuredWidth() > 0) {
+      return view.getMeasuredWidth();
+    }
+
     // Fall back to assuming we want the full screen width
     DisplayMetrics metrics = view.getContext().getResources().getDisplayMetrics();
     return metrics.widthPixels;
@@ -248,6 +252,10 @@ public class Carousel extends EpoxyRecyclerView {
   private static int getTotalHeightPx(View view) {
     if (view.getHeight() > 0) {
       return view.getHeight();
+    }
+
+    if (view.getMeasuredHeight() > 0) {
+      return view.getMeasuredHeight();
     }
 
     // Fall back to assuming we want the full screen width


### PR DESCRIPTION
My carousel component is not full width.  The current carousel implementation was defaulting to the full screen width because layout had not completed yet.

This PR adds measured width / measured height to the getTotalWidthPx and getTotalHeightPx functions in Carousel to help prevent a situation where the carousel is not using the intending width.