### PR TITLE
Fix visibility tracking during RecyclerView animations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     // ./gradlew assemble sourcesJar javadocsJar androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
     // Need to use snapshot version and explicitly include javadoc/sources tasks until
     // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'
+    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.10.0'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     // ./gradlew assemble sourcesJar javadocsJar androidSourcesJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
     // Need to use snapshot version and explicitly include javadoc/sources tasks until
     // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.10.0'
+    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'
   }
 }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -52,8 +52,10 @@ public class EpoxyVisibilityTracker {
       new ItemAnimatorFinishedListener() {
         @Override
         public void onAnimationsFinished() {
-          // Process change event without checking the ItemAnimator
-          processChangeEvent("ItemAnimatorFinishedListener.onAnimationsFinished", false);
+          processChangeEvent(
+              "ItemAnimatorFinishedListener.onAnimationsFinished",
+              /* don't check item animator to prevent recursion */ false
+          );
         }
       };
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -18,6 +18,8 @@ import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.RecyclerView.Adapter;
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver;
+import androidx.recyclerview.widget.RecyclerView.ItemAnimator;
+import androidx.recyclerview.widget.RecyclerView.ItemAnimator.ItemAnimatorFinishedListener;
 import androidx.recyclerview.widget.RecyclerView.OnChildAttachStateChangeListener;
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener;
 import androidx.recyclerview.widget.RecyclerView.ViewHolder;
@@ -41,6 +43,19 @@ public class EpoxyVisibilityTracker {
 
   @IdRes
   private static final int TAG_ID = R.id.epoxy_visibility_tracker;
+
+  /**
+   * Used to listen to {@link RecyclerView.ItemAnimator} ending animations.
+   */
+  @NonNull
+  private final ItemAnimatorFinishedListener itemAnimatorFinishedListener =
+      new ItemAnimatorFinishedListener() {
+        @Override
+        public void onAnimationsFinished() {
+          // Process change event without checking the ItemAnimator
+          processChangeEvent("ItemAnimatorFinishedListener.onAnimationsFinished", false);
+        }
+      };
 
   /**
    * @param recyclerView the view.
@@ -151,8 +166,32 @@ public class EpoxyVisibilityTracker {
     processChangeEvent("requestVisibilityCheck");
   }
 
+  /**
+   * Process a change event. It will also check the itemAnimator
+   * @param debug: string for debug usually the source of the call
+   */
   private void processChangeEvent(String debug) {
-    processChangeEventWithDetachedView(null, debug);
+    processChangeEvent(debug, true);
+  }
+
+  /**
+   * Process a change event.
+   * @param debug: string for debug usually the source of the call
+   * @param checkItemAnimator: true if it need to check if ItemAnimator is running
+   */
+  private void processChangeEvent(String debug, boolean checkItemAnimator) {
+    final RecyclerView recyclerView = attachedRecyclerView;
+    if (recyclerView != null) {
+      if (checkItemAnimator) {
+        final ItemAnimator itemAnimator = recyclerView.getItemAnimator();
+        if (itemAnimator != null) {
+          // Call `isRunning` and pass the `itemAnimatorFinishedListener`. If the animations are
+          // running the listener will trigger a visibility check on animations end.
+          itemAnimator.isRunning(itemAnimatorFinishedListener);
+        }
+      }
+      processChangeEventWithDetachedView(null, debug);
+    }
   }
 
   private void processChangeEventWithDetachedView(@Nullable View detachedView, String debug) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -184,15 +184,15 @@ public class EpoxyVisibilityTracker {
   private void processChangeEvent(String debug, boolean checkItemAnimator) {
     final RecyclerView recyclerView = attachedRecyclerView;
     if (recyclerView != null) {
-      if (checkItemAnimator) {
-        final ItemAnimator itemAnimator = recyclerView.getItemAnimator();
-        if (itemAnimator != null) {
-          // Call `isRunning` and pass the `itemAnimatorFinishedListener`. If the animations are
-          // running the listener will trigger a visibility check on animations end.
-          itemAnimator.isRunning(itemAnimatorFinishedListener);
-        }
+      final ItemAnimator itemAnimator = recyclerView.getItemAnimator();
+      if (checkItemAnimator && itemAnimator != null) {
+        // `itemAnimatorFinishedListener.onAnimationsFinished` will request a visibility check
+        // - If the animations are running `onAnimationsFinished` will be invoked on animations end.
+        // - If the animations are not running `onAnimationsFinished` will be invoked right away.
+        itemAnimator.isRunning(itemAnimatorFinishedListener);
+      } else {
+        processChangeEventWithDetachedView(null, debug);
       }
-      processChangeEventWithDetachedView(null, debug);
     }
   }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -186,10 +186,13 @@ public class EpoxyVisibilityTracker {
     if (recyclerView != null) {
       final ItemAnimator itemAnimator = recyclerView.getItemAnimator();
       if (checkItemAnimator && itemAnimator != null) {
-        // `itemAnimatorFinishedListener.onAnimationsFinished` will request a visibility check
+        // `itemAnimatorFinishedListener.onAnimationsFinished` will process visibility check
         // - If the animations are running `onAnimationsFinished` will be invoked on animations end.
         // - If the animations are not running `onAnimationsFinished` will be invoked right away.
-        itemAnimator.isRunning(itemAnimatorFinishedListener);
+        if (itemAnimator.isRunning(itemAnimatorFinishedListener)) {
+          // If running process visibility now as `onAnimationsFinished` was not yet called
+          processChangeEventWithDetachedView(null, debug);
+        }
       } else {
         processChangeEventWithDetachedView(null, debug);
       }


### PR DESCRIPTION
This will fix this bug : #958

The visibility tracker could miss event in case there is a running animation in the `RecyclerView.ItemAnimator`. 

The fix is simple, we need to check is the animator is running. The `isRunning` method require a [callback](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView.ItemAnimator.ItemAnimatorFinishedListener) that is call instantly if not running or at the end the animation.

I could not find a way to explicitly test the animator however there is already a good test coverage on thee modified code path.

