### PR TITLE
Introduce partial impression visibility states

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -41,6 +41,7 @@ class EpoxyVisibilityItem {
   @Px
   private int viewportWidth;
 
+  private boolean partiallyVisible = false;
   private boolean fullyVisible = false;
   private boolean visible = false;
   private boolean focusedVisible = false;
@@ -110,6 +111,16 @@ class EpoxyVisibilityItem {
     }
   }
 
+  void handlePartialImpressionVisible(EpoxyViewHolder epoxyHolder, boolean detachEvent, int threshold) {
+    boolean previousPartiallyVisible = partiallyVisible;
+    partiallyVisible = !detachEvent && isPartiallyVisible(threshold);
+    if (partiallyVisible != previousPartiallyVisible) {
+      if (partiallyVisible) {
+        epoxyHolder.visibilityStateChanged(VisibilityState.PARTIAL_IMPRESSION_VISIBLE);
+      }
+    }
+  }
+
   void handleFullImpressionVisible(EpoxyViewHolder epoxyHolder, boolean detachEvent) {
     boolean previousFullyVisible = fullyVisible;
     fullyVisible = !detachEvent && isFullyVisible();
@@ -151,6 +162,13 @@ class EpoxyVisibilityItem {
     return (totalArea >= halfViewportArea)
         ? (visibleArea >= halfViewportArea)
         : totalArea == visibleArea;
+  }
+
+  private boolean isPartiallyVisible(int threshold) {
+    final int totalArea = height * width;
+    final int visibleArea = visibleHeight * visibleWidth;
+
+    return (visibleArea / (float)totalArea) * 100 >= threshold;
   }
 
   private boolean isFullyVisible() {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -119,6 +119,8 @@ class EpoxyVisibilityItem {
     if (partiallyVisible != previousPartiallyVisible) {
       if (partiallyVisible) {
         epoxyHolder.visibilityStateChanged(VisibilityState.PARTIAL_IMPRESSION_VISIBLE);
+      } else {
+        epoxyHolder.visibilityStateChanged(VisibilityState.PARTIAL_IMPRESSION_INVISIBLE);
       }
     }
   }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -3,6 +3,7 @@ package com.airbnb.epoxy;
 import android.graphics.Rect;
 import android.view.View;
 
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Px;
 import androidx.recyclerview.widget.RecyclerView;
@@ -111,9 +112,10 @@ class EpoxyVisibilityItem {
     }
   }
 
-  void handlePartialImpressionVisible(EpoxyViewHolder epoxyHolder, boolean detachEvent, int threshold) {
+  void handlePartialImpressionVisible(EpoxyViewHolder epoxyHolder, boolean detachEvent,
+      @IntRange(from = 0, to = 100) int thresholdPercentage) {
     boolean previousPartiallyVisible = partiallyVisible;
-    partiallyVisible = !detachEvent && isPartiallyVisible(threshold);
+    partiallyVisible = !detachEvent && isPartiallyVisible(thresholdPercentage);
     if (partiallyVisible != previousPartiallyVisible) {
       if (partiallyVisible) {
         epoxyHolder.visibilityStateChanged(VisibilityState.PARTIAL_IMPRESSION_VISIBLE);
@@ -164,11 +166,14 @@ class EpoxyVisibilityItem {
         : totalArea == visibleArea;
   }
 
-  private boolean isPartiallyVisible(int threshold) {
+  private boolean isPartiallyVisible(@IntRange(from = 0, to = 100) int thresholdPercentage) {
+    if (thresholdPercentage == 0) return false;
+
     final int totalArea = height * width;
     final int visibleArea = visibleHeight * visibleWidth;
+    final float visibleAreaPercentage = (visibleArea / (float)totalArea) * 100;
 
-    return (visibleArea / (float)totalArea) * 100 >= threshold;
+    return visibleAreaPercentage >= thresholdPercentage;
   }
 
   private boolean isFullyVisible() {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -169,7 +169,8 @@ class EpoxyVisibilityItem {
   }
 
   private boolean isPartiallyVisible(@IntRange(from = 0, to = 100) int thresholdPercentage) {
-    if (thresholdPercentage == 0) return false;
+    // special case 0%: trigger as soon as some pixels are one the screen
+    if (thresholdPercentage == 0) return isVisible();
 
     final int totalArea = height * width;
     final int visibleArea = visibleHeight * visibleWidth;

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.java
@@ -173,7 +173,7 @@ class EpoxyVisibilityItem {
 
     final int totalArea = height * width;
     final int visibleArea = visibleHeight * visibleWidth;
-    final float visibleAreaPercentage = (visibleArea / (float)totalArea) * 100;
+    final float visibleAreaPercentage = (visibleArea / (float) totalArea) * 100;
 
     return visibleAreaPercentage >= thresholdPercentage;
   }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -114,6 +114,7 @@ public class EpoxyVisibilityTracker {
       @IntRange(from = 0, to = 100) int thresholdPercentage
   ) {
     partialImpressionThresholdPercentage = thresholdPercentage;
+    String heelo = "";
   }
 
   /**
@@ -310,6 +311,7 @@ public class EpoxyVisibilityTracker {
     EpoxyVisibilityTracker tracker = getTracker(childRecyclerView);
     if (tracker == null) {
       tracker = new EpoxyVisibilityTracker();
+      tracker.setPartialImpressionThresholdPercentage(partialImpressionThresholdPercentage);
       tracker.attach(childRecyclerView);
     }
     nestedTrackers.put(childRecyclerView, tracker);

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -82,6 +82,8 @@ public class EpoxyVisibilityTracker {
 
   private boolean onChangedEnabled = true;
 
+  private int partialImpressionThreshold = 0;
+
   /** All nested visibility trackers */
   private Map<RecyclerView, EpoxyVisibilityTracker> nestedTrackers = new HashMap<>();
 
@@ -98,6 +100,15 @@ public class EpoxyVisibilityTracker {
    */
   public void setOnChangedEnabled(boolean enabled) {
     onChangedEnabled = enabled;
+  }
+
+  /**
+   * Set the threshold of percentage visible area to identify the partial impression view state.
+   *
+   * @param threshold Percentage of visible area of an element. 0..100.
+   */
+  public void setPartialImpressionThreshold(int threshold) {
+    partialImpressionThreshold = threshold;
   }
 
   /**
@@ -280,6 +291,7 @@ public class EpoxyVisibilityTracker {
       // View is measured, process events
       vi.handleVisible(epoxyHolder, detachEvent);
       vi.handleFocus(epoxyHolder, detachEvent);
+      vi.handlePartialImpressionVisible(epoxyHolder, detachEvent, partialImpressionThreshold);
       vi.handleFullImpressionVisible(epoxyHolder, detachEvent);
       changed = vi.handleChanged(epoxyHolder, onChangedEnabled);
     }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -114,7 +114,6 @@ public class EpoxyVisibilityTracker {
       @IntRange(from = 0, to = 100) int thresholdPercentage
   ) {
     partialImpressionThresholdPercentage = thresholdPercentage;
-    String heelo = "";
   }
 
   /**

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.IdRes;
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
@@ -82,7 +83,7 @@ public class EpoxyVisibilityTracker {
 
   private boolean onChangedEnabled = true;
 
-  private int partialImpressionThreshold = 0;
+  private int partialImpressionThresholdPercentage = 0;
 
   /** All nested visibility trackers */
   private Map<RecyclerView, EpoxyVisibilityTracker> nestedTrackers = new HashMap<>();
@@ -105,10 +106,14 @@ public class EpoxyVisibilityTracker {
   /**
    * Set the threshold of percentage visible area to identify the partial impression view state.
    *
-   * @param threshold Percentage of visible area of an element. 0..100.
+   * @param thresholdPercentage Percentage of visible area of an element. 0..100. A value of 0
+   *                            effectively disables
+   *                            {@link VisibilityState#PARTIAL_IMPRESSION_VISIBLE} events.
    */
-  public void setPartialImpressionThreshold(int threshold) {
-    partialImpressionThreshold = threshold;
+  public void setPartialImpressionThresholdPercentage(
+      @IntRange(from = 0, to = 100) int thresholdPercentage
+  ) {
+    partialImpressionThresholdPercentage = thresholdPercentage;
   }
 
   /**
@@ -291,7 +296,8 @@ public class EpoxyVisibilityTracker {
       // View is measured, process events
       vi.handleVisible(epoxyHolder, detachEvent);
       vi.handleFocus(epoxyHolder, detachEvent);
-      vi.handlePartialImpressionVisible(epoxyHolder, detachEvent, partialImpressionThreshold);
+      vi.handlePartialImpressionVisible(epoxyHolder, detachEvent,
+          partialImpressionThresholdPercentage);
       vi.handleFullImpressionVisible(epoxyHolder, detachEvent);
       changed = vi.handleChanged(epoxyHolder, onChangedEnabled);
     }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.java
@@ -83,7 +83,8 @@ public class EpoxyVisibilityTracker {
 
   private boolean onChangedEnabled = true;
 
-  private int partialImpressionThresholdPercentage = 0;
+  @Nullable
+  private Integer partialImpressionThresholdPercentage = null;
 
   /** All nested visibility trackers */
   private Map<RecyclerView, EpoxyVisibilityTracker> nestedTrackers = new HashMap<>();
@@ -106,12 +107,13 @@ public class EpoxyVisibilityTracker {
   /**
    * Set the threshold of percentage visible area to identify the partial impression view state.
    *
-   * @param thresholdPercentage Percentage of visible area of an element. 0..100. A value of 0
-   *                            effectively disables
-   *                            {@link VisibilityState#PARTIAL_IMPRESSION_VISIBLE} events.
+   * @param thresholdPercentage Percentage of visible area of an element in the range [0..100].
+   *                            Defaults to <code>null</code>, which disables
+   *                            {@link VisibilityState#PARTIAL_IMPRESSION_VISIBLE} and
+   *                            {@link VisibilityState#PARTIAL_IMPRESSION_INVISIBLE} events.
    */
   public void setPartialImpressionThresholdPercentage(
-      @IntRange(from = 0, to = 100) int thresholdPercentage
+      @Nullable @IntRange(from = 0, to = 100) Integer thresholdPercentage
   ) {
     partialImpressionThresholdPercentage = thresholdPercentage;
   }
@@ -295,9 +297,13 @@ public class EpoxyVisibilityTracker {
     if (vi.update(itemView, recyclerView, detachEvent)) {
       // View is measured, process events
       vi.handleVisible(epoxyHolder, detachEvent);
+
+      if (partialImpressionThresholdPercentage != null) {
+        vi.handlePartialImpressionVisible(epoxyHolder, detachEvent,
+            partialImpressionThresholdPercentage);
+      }
+
       vi.handleFocus(epoxyHolder, detachEvent);
-      vi.handlePartialImpressionVisible(epoxyHolder, detachEvent,
-          partialImpressionThresholdPercentage);
       vi.handleFullImpressionVisible(epoxyHolder, detachEvent);
       changed = vi.handleChanged(epoxyHolder, onChangedEnabled);
     }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
@@ -45,4 +45,12 @@ public final class VisibilityState {
    * become visible.
    */
   public static final int FULL_IMPRESSION_VISIBLE = 4;
+
+  /**
+   * Event triggered when a Component enters the Partial Impression Range. This happens, for
+   * instance in the case of a vertical RecyclerView, when the percentage of the visible area is
+   * greater than a specified threshold. The threshold can be set in
+   * {@link EpoxyVisibilityTracker#setPartialImpressionThreshold(int)}.
+   */
+  public static final int PARTIAL_IMPRESSION_VISIBLE = 5;
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
@@ -55,7 +55,7 @@ public final class VisibilityState {
   /**
    * Event triggered when a Component enters the Partial Impression Range. This happens, for
    * instance in the case of a vertical RecyclerView, when the percentage of the visible area is
-   * greater than a specified threshold. The threshold can be set in
+   * at least the specified threshold. The threshold can be set in
    * {@link EpoxyVisibilityTracker#setPartialImpressionThresholdPercentage(int)}.
    */
   public static final int PARTIAL_IMPRESSION_VISIBLE = 5;

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
@@ -8,7 +8,12 @@ import androidx.annotation.IntDef;
 public final class VisibilityState {
 
   @Retention(RetentionPolicy.SOURCE)
-  @IntDef({VISIBLE, INVISIBLE, FOCUSED_VISIBLE, UNFOCUSED_VISIBLE, FULL_IMPRESSION_VISIBLE})
+  @IntDef({VISIBLE,
+           INVISIBLE,
+           FOCUSED_VISIBLE,
+           UNFOCUSED_VISIBLE,
+           FULL_IMPRESSION_VISIBLE,
+           PARTIAL_IMPRESSION_VISIBLE})
   public @interface Visibility {
   }
 
@@ -50,7 +55,7 @@ public final class VisibilityState {
    * Event triggered when a Component enters the Partial Impression Range. This happens, for
    * instance in the case of a vertical RecyclerView, when the percentage of the visible area is
    * greater than a specified threshold. The threshold can be set in
-   * {@link EpoxyVisibilityTracker#setPartialImpressionThreshold(int)}.
+   * {@link EpoxyVisibilityTracker#setPartialImpressionThresholdPercentage(int)}.
    */
   public static final int PARTIAL_IMPRESSION_VISIBLE = 5;
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/VisibilityState.java
@@ -13,7 +13,8 @@ public final class VisibilityState {
            FOCUSED_VISIBLE,
            UNFOCUSED_VISIBLE,
            FULL_IMPRESSION_VISIBLE,
-           PARTIAL_IMPRESSION_VISIBLE})
+           PARTIAL_IMPRESSION_VISIBLE,
+           PARTIAL_IMPRESSION_INVISIBLE})
   public @interface Visibility {
   }
 
@@ -58,4 +59,12 @@ public final class VisibilityState {
    * {@link EpoxyVisibilityTracker#setPartialImpressionThresholdPercentage(int)}.
    */
   public static final int PARTIAL_IMPRESSION_VISIBLE = 5;
+
+  /**
+   * Event triggered when a Component exits the Partial Impression Range. This happens, for
+   * instance in the case of a vertical RecyclerView, when the percentage of the visible area is
+   * less than a specified threshold. The threshold can be set in
+   * {@link EpoxyVisibilityTracker#setPartialImpressionThresholdPercentage(int)}.
+   */
+  public static final int PARTIAL_IMPRESSION_INVISIBLE = 6;
 }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerNestedTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerNestedTest.kt
@@ -6,6 +6,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyVisibilityTracker.DEBUG_LOG
 import com.airbnb.epoxy.VisibilityState.INVISIBLE
+import com.airbnb.epoxy.VisibilityState.PARTIAL_IMPRESSION_INVISIBLE
+import com.airbnb.epoxy.VisibilityState.PARTIAL_IMPRESSION_VISIBLE
 import com.airbnb.epoxy.VisibilityState.VISIBLE
 import org.junit.After
 import org.junit.Before
@@ -98,6 +100,7 @@ class EpoxyVisibilityTrackerNestedTest {
                                 percentVisibleHeight = 0.0f,
                                 percentVisibleWidth = 0.0f,
                                 visible = false,
+                                partialImpression = false,
                                 fullImpression = false,
                                 visitedStates = EpoxyVisibilityTrackerTest.ALL_STATES
                             )
@@ -110,9 +113,12 @@ class EpoxyVisibilityTrackerNestedTest {
                                 percentVisibleHeight = 0.0f,
                                 percentVisibleWidth = 0.0f,
                                 visible = false,
+                                partialImpression = false,
                                 fullImpression = false,
                                 visitedStates = intArrayOf(
                                     VISIBLE,
+                                    PARTIAL_IMPRESSION_VISIBLE,
+                                    PARTIAL_IMPRESSION_INVISIBLE,
                                     INVISIBLE
                                 )
                             )
@@ -127,8 +133,12 @@ class EpoxyVisibilityTrackerNestedTest {
                                 visibleHeight = 50,
                                 visibleWidth = 100,
                                 visible = true,
+                                partialImpression = true,
                                 fullImpression = false,
-                                visitedStates = intArrayOf(VISIBLE)
+                                visitedStates = intArrayOf(
+                                    VISIBLE,
+                                    PARTIAL_IMPRESSION_VISIBLE
+                                )
                             )
                         }
                     }
@@ -138,8 +148,12 @@ class EpoxyVisibilityTrackerNestedTest {
                                 visibleHeight = 50,
                                 visibleWidth = 50,
                                 visible = true,
+                                partialImpression = true,
                                 fullImpression = false,
-                                visitedStates = intArrayOf(VISIBLE)
+                                visitedStates = intArrayOf(
+                                    VISIBLE,
+                                    PARTIAL_IMPRESSION_VISIBLE
+                                )
                             )
                         }
                     }
@@ -152,6 +166,7 @@ class EpoxyVisibilityTrackerNestedTest {
                                 percentVisibleHeight = 100.0f,
                                 percentVisibleWidth = 100.0f,
                                 visible = false,
+                                partialImpression = true,
                                 fullImpression = true,
                                 visitedStates = EpoxyVisibilityTrackerTest.ALL_STATES
                             )
@@ -163,8 +178,12 @@ class EpoxyVisibilityTrackerNestedTest {
                                 percentVisibleHeight = 100.0f,
                                 percentVisibleWidth = 50.0f,
                                 visible = false,
+                                partialImpression = true,
                                 fullImpression = false,
-                                visitedStates = intArrayOf(VISIBLE)
+                                visitedStates = intArrayOf(
+                                    VISIBLE,
+                                    PARTIAL_IMPRESSION_VISIBLE
+                                )
                             )
                         }
                     }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -12,6 +12,8 @@ import com.airbnb.epoxy.EpoxyVisibilityTracker.DEBUG_LOG
 import com.airbnb.epoxy.VisibilityState.FOCUSED_VISIBLE
 import com.airbnb.epoxy.VisibilityState.FULL_IMPRESSION_VISIBLE
 import com.airbnb.epoxy.VisibilityState.INVISIBLE
+import com.airbnb.epoxy.VisibilityState.PARTIAL_IMPRESSION_INVISIBLE
+import com.airbnb.epoxy.VisibilityState.PARTIAL_IMPRESSION_VISIBLE
 import com.airbnb.epoxy.VisibilityState.UNFOCUSED_VISIBLE
 import com.airbnb.epoxy.VisibilityState.VISIBLE
 import org.junit.After
@@ -54,6 +56,8 @@ class EpoxyVisibilityTrackerTest {
             INVISIBLE,
             FOCUSED_VISIBLE,
             UNFOCUSED_VISIBLE,
+            PARTIAL_IMPRESSION_VISIBLE,
+            PARTIAL_IMPRESSION_INVISIBLE,
             FULL_IMPRESSION_VISIBLE
         )
 
@@ -102,10 +106,12 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = itemHeight,
                             percentVisibleHeight = 100.0f,
                             visible = true,
+                            partialImpression = true,
                             fullImpression = true,
                             visitedStates = intArrayOf(
                                 VISIBLE,
                                 FOCUSED_VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE,
                                 FULL_IMPRESSION_VISIBLE
                             )
                         )
@@ -121,8 +127,12 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = itemHeight / 2,
                             percentVisibleHeight = 50.0f,
                             visible = true,
+                            partialImpression = true,
                             fullImpression = false,
-                            visitedStates = intArrayOf(VISIBLE)
+                            visitedStates = intArrayOf(
+                                VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE
+                            )
                         )
                     }
                 }
@@ -136,6 +146,7 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = 0,
                             percentVisibleHeight = 0.0f,
                             visible = false,
+                            partialImpression = false,
                             fullImpression = false,
                             visitedStates = intArrayOf()
                         )
@@ -170,10 +181,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight,
                 percentVisibleHeight = 100.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = true,
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
             )
@@ -184,10 +197,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight / 2,
                 percentVisibleHeight = 50.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = false,
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
                     UNFOCUSED_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
@@ -199,9 +214,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = 0,
                 percentVisibleHeight = 0.0f,
                 visible = false,
+                partialImpression = false,
                 fullImpression = false,
                 visitedStates = intArrayOf(
                     VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
+                    PARTIAL_IMPRESSION_INVISIBLE,
                     INVISIBLE
                 )
             )
@@ -228,6 +246,7 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = 0,
                 percentVisibleHeight = 0.0f,
                 visible = false,
+                partialImpression = false,
                 fullImpression = false,
                 visitedStates = ALL_STATES
             )
@@ -238,10 +257,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight,
                 percentVisibleHeight = 100.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = true,
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
             )
@@ -252,8 +273,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight / 2,
                 percentVisibleHeight = 50.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = false,
-                visitedStates = intArrayOf(VISIBLE)
+                visitedStates = intArrayOf(
+                    VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE
+                )
             )
         }
     }
@@ -305,10 +330,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight,
                 percentVisibleHeight = 100.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = true,
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
             )
@@ -320,10 +347,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight,
                 percentVisibleHeight = 100.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = true,
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
             )
@@ -335,6 +364,7 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = 0,
                 percentVisibleHeight = 0.0f,
                 visible = false,
+                partialImpression = false,
                 fullImpression = false,
                 visitedStates = ALL_STATES
             )
@@ -379,10 +409,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight,
                 percentVisibleHeight = 100.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = true,
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
             )
@@ -394,10 +426,12 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = itemHeight,
                 percentVisibleHeight = 100.0f,
                 visible = true,
+                partialImpression = true,
                 fullImpression = true,
                 visitedStates = intArrayOf(
                     VISIBLE,
                     FOCUSED_VISIBLE,
+                    PARTIAL_IMPRESSION_VISIBLE,
                     FULL_IMPRESSION_VISIBLE
                 )
             )
@@ -409,6 +443,7 @@ class EpoxyVisibilityTrackerTest {
                 visibleHeight = 0,
                 percentVisibleHeight = 0.0f,
                 visible = false,
+                partialImpression = false,
                 fullImpression = false,
                 visitedStates = ALL_STATES
             )
@@ -444,6 +479,7 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = 0,
                             percentVisibleHeight = 0.0f,
                             visible = false,
+                            partialImpression = false,
                             fullImpression = false,
                             visitedStates = ALL_STATES
                         )
@@ -459,6 +495,7 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = 0,
                             percentVisibleHeight = 0.0f,
                             visible = false,
+                            partialImpression = false,
                             fullImpression = false,
                             visitedStates = ALL_STATES
                         )
@@ -474,6 +511,7 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = 0,
                             percentVisibleHeight = 0.0f,
                             visible = false,
+                            partialImpression = false,
                             fullImpression = false,
                             visitedStates = ALL_STATES
                         )
@@ -489,10 +527,12 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = itemHeight / 2,
                             percentVisibleHeight = 50.0f,
                             visible = true,
+                            partialImpression = true,
                             fullImpression = false,
                             visitedStates = intArrayOf(
                                 VISIBLE,
                                 FOCUSED_VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE,
                                 FULL_IMPRESSION_VISIBLE,
                                 UNFOCUSED_VISIBLE
                             )
@@ -509,10 +549,12 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = itemHeight,
                             percentVisibleHeight = 100.0f,
                             visible = true,
+                            partialImpression = true,
                             fullImpression = true,
                             visitedStates = intArrayOf(
                                 VISIBLE,
                                 FOCUSED_VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE,
                                 FULL_IMPRESSION_VISIBLE
                             )
                         )
@@ -553,12 +595,15 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = 0,
                             percentVisibleHeight = 0.0f,
                             visible = false,
+                            partialImpression = false,
                             fullImpression = false,
                             visitedStates = intArrayOf(
                                 VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE,
                                 FOCUSED_VISIBLE,
                                 FULL_IMPRESSION_VISIBLE,
                                 UNFOCUSED_VISIBLE,
+                                PARTIAL_IMPRESSION_INVISIBLE,
                                 INVISIBLE
                             )
                         )
@@ -574,8 +619,14 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = 0,
                             percentVisibleHeight = 0.0f,
                             visible = false,
+                            partialImpression = false,
                             fullImpression = false,
-                            visitedStates = intArrayOf(VISIBLE, INVISIBLE)
+                            visitedStates = intArrayOf(
+                                VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE,
+                                PARTIAL_IMPRESSION_INVISIBLE,
+                                INVISIBLE
+                            )
                         )
                     }
                 }
@@ -589,6 +640,7 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = 0,
                             percentVisibleHeight = 0.0f,
                             visible = false,
+                            partialImpression = false,
                             fullImpression = false,
                             visitedStates = intArrayOf()
                         )
@@ -604,8 +656,12 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = itemHeight / 2,
                             percentVisibleHeight = 50.0f,
                             visible = true,
+                            partialImpression = true,
                             fullImpression = false,
-                            visitedStates = intArrayOf(VISIBLE)
+                            visitedStates = intArrayOf(
+                                VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE
+                            )
                         )
                     }
                 }
@@ -619,9 +675,11 @@ class EpoxyVisibilityTrackerTest {
                             visibleHeight = itemHeight,
                             percentVisibleHeight = 100.0f,
                             visible = true,
+                            partialImpression = true,
                             fullImpression = true,
                             visitedStates = intArrayOf(
                                 VISIBLE,
+                                PARTIAL_IMPRESSION_VISIBLE,
                                 FOCUSED_VISIBLE,
                                 FULL_IMPRESSION_VISIBLE
                             )
@@ -687,6 +745,7 @@ class EpoxyVisibilityTrackerTest {
     fun setup() {
         Robolectric.setupActivity(Activity::class.java).apply {
             setContentView(EpoxyRecyclerView(this).apply {
+                epoxyVisibilityTracker.setPartialImpressionThresholdPercentage(50)
                 epoxyVisibilityTracker.attach(this)
                 recyclerView = this
                 // Plug an epoxy controller
@@ -713,6 +772,7 @@ class EpoxyVisibilityTrackerTest {
 
     @After
     fun tearDown() {
+        epoxyVisibilityTracker.setPartialImpressionThresholdPercentage(0)
         epoxyVisibilityTracker.detach(recyclerView)
     }
 
@@ -746,10 +806,14 @@ class EpoxyVisibilityTrackerTest {
             log("onVisibilityStateChanged[$itemPosition](id=${helper.id})=${state.description()}")
             helper.visitedStates.add(state)
             when (state) {
-                VISIBLE, INVISIBLE -> helper.visible = state == VISIBLE
-                FOCUSED_VISIBLE, UNFOCUSED_VISIBLE -> helper.focused = state == FOCUSED_VISIBLE
-                FULL_IMPRESSION_VISIBLE -> helper.fullImpression = state ==
-                    FULL_IMPRESSION_VISIBLE
+                VISIBLE, INVISIBLE ->
+                    helper.visible = state == VISIBLE
+                FOCUSED_VISIBLE, UNFOCUSED_VISIBLE ->
+                    helper.focused = state == FOCUSED_VISIBLE
+                PARTIAL_IMPRESSION_VISIBLE, PARTIAL_IMPRESSION_INVISIBLE ->
+                    helper.partialImpression = state == PARTIAL_IMPRESSION_VISIBLE
+                FULL_IMPRESSION_VISIBLE ->
+                    helper.fullImpression = state == FULL_IMPRESSION_VISIBLE
             }
         }
     }
@@ -767,6 +831,7 @@ class EpoxyVisibilityTrackerTest {
         var percentVisibleWidth = 0.0f
         var visible = false
         var focused = false
+        var partialImpression = false
         var fullImpression = false
 
         fun assert(
@@ -776,6 +841,7 @@ class EpoxyVisibilityTrackerTest {
             percentVisibleHeight: Float? = null,
             percentVisibleWidth: Float? = null,
             visible: Boolean? = null,
+            partialImpression: Boolean? = null,
             fullImpression: Boolean? = null,
             visitedStates: IntArray? = null
         ) {
@@ -821,6 +887,13 @@ class EpoxyVisibilityTrackerTest {
                     "visible expected $it got ${this.visible}",
                     it,
                     this.visible
+                )
+            }
+            partialImpression?.let {
+                Assert.assertEquals(
+                    "partialImpression expected $it got ${this.partialImpression}",
+                    it,
+                    this.partialImpression
                 )
             }
             fullImpression?.let {
@@ -888,6 +961,8 @@ private fun Int.description(): String {
         INVISIBLE -> "INVISIBLE"
         FOCUSED_VISIBLE -> "FOCUSED_VISIBLE"
         UNFOCUSED_VISIBLE -> "UNFOCUSED_VISIBLE"
+        PARTIAL_IMPRESSION_VISIBLE -> "PARTIAL_IMPRESSION_VISIBLE"
+        PARTIAL_IMPRESSION_INVISIBLE -> "PARTIAL_IMPRESSION_INVISIBLE"
         FULL_IMPRESSION_VISIBLE -> "FULL_IMPRESSION_VISIBLE"
         else -> throw IllegalStateException("Please declare new state here")
     }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -909,7 +909,6 @@ class EpoxyVisibilityTrackerTest {
 
     @After
     fun tearDown() {
-        epoxyVisibilityTracker.setPartialImpressionThresholdPercentage(0)
         epoxyVisibilityTracker.detach(recyclerView)
     }
 

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -166,7 +166,7 @@ class EpoxyVisibilityTrackerTest {
     @Test
     fun testDataAttachedToRecyclerView_WithoutPartial() {
         // disable partial visibility states
-        epoxyVisibilityTracker.setPartialImpressionThresholdPercentage(0)
+        epoxyVisibilityTracker.setPartialImpressionThresholdPercentage(null)
 
         val testHelper = buildTestData(10, TWO_AND_HALF_VISIBLE)
 

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
@@ -24,6 +24,7 @@ class MainActivity : AppCompatActivity() {
 
         // Attach the visibility tracker to the RecyclerView. This will enable visibility events.
         val epoxyVisibilityTracker = EpoxyVisibilityTracker()
+        epoxyVisibilityTracker.setPartialImpressionThresholdPercentage(75)
         epoxyVisibilityTracker.attach(recyclerView)
 
         recyclerView.withModels {

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/CarouselItemCustomView.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/CarouselItemCustomView.kt
@@ -66,6 +66,10 @@ class CarouselItemCustomView @JvmOverloads constructor(
                 Log.d(TAG, "$title PartialImpressionVisible")
                 onVisibilityEventDrawable.partialImpression = true
             }
+            VisibilityState.PARTIAL_IMPRESSION_INVISIBLE -> {
+                Log.d(TAG, "$title PartialImpressionInVisible")
+                onVisibilityEventDrawable.partialImpression = false
+            }
             VisibilityState.FULL_IMPRESSION_VISIBLE -> {
                 Log.d(TAG, "$title FullImpressionVisible")
                 onVisibilityEventDrawable.fullImpression = true

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/CarouselItemCustomView.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/CarouselItemCustomView.kt
@@ -62,6 +62,10 @@ class CarouselItemCustomView @JvmOverloads constructor(
                 Log.d(TAG, "$title UnfocusedVisible")
                 onVisibilityEventDrawable.focusedVisible = false
             }
+            VisibilityState.PARTIAL_IMPRESSION_VISIBLE -> {
+                Log.d(TAG, "$title PartialImpressionVisible")
+                onVisibilityEventDrawable.partialImpression = true
+            }
             VisibilityState.FULL_IMPRESSION_VISIBLE -> {
                 Log.d(TAG, "$title FullImpressionVisible")
                 onVisibilityEventDrawable.fullImpression = true

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/ItemCustomView.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/ItemCustomView.kt
@@ -92,6 +92,10 @@ class ItemCustomView @JvmOverloads constructor(
                 Log.d(TAG, "$title PartialImpressionVisible")
                 onVisibilityEventDrawable.partialImpression = true
             }
+            VisibilityState.PARTIAL_IMPRESSION_INVISIBLE -> {
+                Log.d(TAG, "$title PartialImpressionInVisible")
+                onVisibilityEventDrawable.partialImpression = false
+            }
             VisibilityState.FULL_IMPRESSION_VISIBLE -> {
                 Log.d(TAG, "$title FullImpressionVisible")
                 onVisibilityEventDrawable.fullImpression = true

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/ItemCustomView.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/ItemCustomView.kt
@@ -88,6 +88,10 @@ class ItemCustomView @JvmOverloads constructor(
                 Log.d(TAG, "$title UnfocusedVisible")
                 onVisibilityEventDrawable.focusedVisible = false
             }
+            VisibilityState.PARTIAL_IMPRESSION_VISIBLE -> {
+                Log.d(TAG, "$title PartialImpressionVisible")
+                onVisibilityEventDrawable.partialImpression = true
+            }
             VisibilityState.FULL_IMPRESSION_VISIBLE -> {
                 Log.d(TAG, "$title FullImpressionVisible")
                 onVisibilityEventDrawable.fullImpression = true

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/OnVisibilityEventDrawable.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/OnVisibilityEventDrawable.kt
@@ -87,11 +87,11 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
         canvas.drawCircle(x, y, diameter / 2, paint)
 
         x += diameter + padding
-        paint.style = if (focusedVisible) Paint.Style.FILL_AND_STROKE else Paint.Style.STROKE
+        paint.style = if (partialImpression) Paint.Style.FILL_AND_STROKE else Paint.Style.STROKE
         canvas.drawCircle(x, y, diameter / 2, paint)
 
         x += diameter + padding
-        paint.style = if (partialImpression) Paint.Style.FILL_AND_STROKE else Paint.Style.STROKE
+        paint.style = if (focusedVisible) Paint.Style.FILL_AND_STROKE else Paint.Style.STROKE
         canvas.drawCircle(x, y, diameter / 2, paint)
 
         x += diameter + padding

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/OnVisibilityEventDrawable.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/OnVisibilityEventDrawable.kt
@@ -12,7 +12,8 @@ import android.graphics.drawable.Drawable
  * Drawable for sample app that draw the current visibility state :
  * - circle #1 : visible
  * - circle #2 : focused
- * - circle #3 : full impression
+ * - circle #3 : partial impression
+ * - circle #4 : full impression
  * - rectangle : visibility percentage
  */
 class OnVisibilityEventDrawable(context: Context) : Drawable() {
@@ -25,9 +26,10 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
         isAntiAlias = true
         strokeWidth = density
     }
+    private val circleCount = 4
 
     init {
-        setBounds(0, 0, padding.toInt() * 4 + diameter.toInt() * 3, diameter.toInt())
+        setBounds(0, 0, padding.toInt() * (circleCount + 1) + diameter.toInt() * circleCount, diameter.toInt())
     }
 
     var visible = false
@@ -37,6 +39,12 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
         }
 
     var focusedVisible = false
+        set(value) {
+            field = value
+            invalidateSelf()
+        }
+
+    var partialImpression = false
         set(value) {
             field = value
             invalidateSelf()
@@ -63,6 +71,7 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
     fun reset() {
         visible = false
         focusedVisible = false
+        partialImpression = false
         fullImpression = false
         percentHeight = 0.0f
         percentWidth = 0.0f
@@ -79,6 +88,10 @@ class OnVisibilityEventDrawable(context: Context) : Drawable() {
 
         x += diameter + padding
         paint.style = if (focusedVisible) Paint.Style.FILL_AND_STROKE else Paint.Style.STROKE
+        canvas.drawCircle(x, y, diameter / 2, paint)
+
+        x += diameter + padding
+        paint.style = if (partialImpression) Paint.Style.FILL_AND_STROKE else Paint.Style.STROKE
         canvas.drawCircle(x, y, diameter / 2, paint)
 
         x += diameter + padding


### PR DESCRIPTION
fixes #838

- introduces `PARTIAL_IMPRESSION_VISIBLE` and `PARTIAL_IMPRESSION_INVISIBLE` visibility states
- threshold for partial impression can be set via `EpoxyVisibilityTracker#setPartialImpressionThresholdPercentage`
- the threshold will be automatically applied to nested trackers as well if they do not have their own tracker set
- no event is fired if the threshold cannot be met due to the element being larger than the view port and the set threshold too high to trigger. This is consistent with the behavior of `FULL_IMPRESSION_VISIBLE`
- updated `:kotlinsample` to reflect the addition

### Tests
- I added some tolerance to the AssertHelper:
- TOLERANCE_PIXELS (value=1) was currently not being tolerant, as it was compared using `<` instead of `<=`
- for visibleHeight and visibleWidth I added a delta to cover the 49% case to test for an element that got VISIBLE, but not PARTIAL_IMPRESSION_VISIBLE

As for tests, since setting the threshold will add a new dimension to the test matrix, I was not sure if I should adjust the whole testsuite to cope for this. Basically all of

testDataAttachedToRecyclerView, testScrollToPosition, testMoveDataDown, testInsertData, testScrollBy, testDeleteData, testMoveDataUp

could be tested once with a threshold set, and once without.
Please let me know if I should cope for this.

### Wiki Content Suggestion
Visibility Events

- **Partial Impression Visible**: Triggered when the percentage of the visible area of a view is
   at least the specified threshold. This threshold can be set via `EpoxyVisibilityTracker#setPartialImpressionThresholdPercentage`. This event does not fire if the threshold is set to `null` or if the threshold cannot be met due to the element being larger than the viewport and the set threshold too high.
- **Partial Impression Invisible**: Triggered when the percentage of the visible area of a view is
   no longer at least the specified threshold. Also see **Partial Impression Visible**.