### PR TITLE
Optimize generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ Parallel processing can greatly speed up processing time (moreso than the increm
 Please report any issues or crashes that you notice.
 (We are currently using parallel mode in our large project at Airbnb with no problems.)
 
+## Breaking
+In order to enable incremental annotation processing a change had to be made in how the processor of
+`@AutoModel` annotations work. If you use `@AutoModel` in an EpoxyController the annotated Model types
+must be either declared in a different module from the EpoxyController, or in the same module in the same java package.
+
+Also make sure you have kapt error types enabled.
+
+However, generally `@AutoModel` is considered legacy and is not recommended. It is a relic of Java Epoxy usage
+and instead the current best practice is to use Kotlin with the Kotlin model extension functions to build models.
+ 
 # 3.11.0 (May 20, 2020)
 - Introduce partial impression visibility states (#973)
 - Fix sticky header crash (#976)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 4.0.0-beta3 (May 27, 2020)
+- Sort functions in generated kotlin extension function files deterministically to prevent generated sources from changing
+- Avoid generating bitset checks in models when not needed
+- Add options to skip generation of functions for getters, reset, and method overloads to reduce generated code
+
+New annotation processor options are:
+- epoxyDisableGenerateOverloads
+- epoxyDisableGenerateGetters
+- epoxyDisableGenerateReset
+
+These can also be controlled (and overridden) on a per package level with the `PackageModelViewConfig` package annotation.
+
 # 4.0.0-beta1 (May 22, 2020)
 - Support for incremental annotation processing as an Aggregating processor (#972)
 - Removed Litho support

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageModelViewConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageModelViewConfig.java
@@ -45,4 +45,46 @@ public @interface PackageModelViewConfig {
    * Suffix, which will be appended to generated model's names. "Model_" is a default value.
    */
   String generatedModelSuffix() default "Model_";
+
+  /**
+   * Controls whether "builder" setter functions that returns the model type will be duplicated
+   * from super model classes with the function return type updated to use the generated model name.
+   * This helps make all setters (such as id(...) ) return the same generated model so they can be
+   * chained in a builder pattern. This is mainly intended for Java usage and is generally unnecessary
+   * when using models in kotlin, especially if the generated kotlin model build extension functions
+   * are used. Disabling this can greatly reduce the number of methods generated on models.
+   *
+   * Default is false. This may also be set project wide with an annotation processor option.
+   */
+  Option disableGenerateBuilderOverloads() default Option.Default;
+
+  /**
+   * Controls whether getter functions (that return the value of each attribute) are generated
+   * on models.
+   *
+   * Disabling this can greatly reduce the number of methods generated on models.
+   *
+   * Default is false. This may also be set project wide with an annotation processor option.
+   */
+  Option disableGenerateGetters() default Option.Default;
+
+  /**
+   * Controls whether the "reset" function (that clears all attribute values) are generated
+   * on models. This function is generally legacy and is not recommended to be used with the modern
+   * immutable model approach of EpoxyControllers.
+   *
+   * Disabling this reduces the amount of generated code.
+   *
+   * Default is false. This may also be set project wide with an annotation processor option.
+   */
+  Option disableGenerateReset() default Option.Default;
+
+  /**
+   * Enable or Disable an option, or inherit the default.
+   */
+  enum Option {
+    Default,
+    Enabled,
+    Disabled
+  }
 }

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageModelViewConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageModelViewConfig.java
@@ -50,9 +50,10 @@ public @interface PackageModelViewConfig {
    * Controls whether "builder" setter functions that returns the model type will be duplicated
    * from super model classes with the function return type updated to use the generated model name.
    * This helps make all setters (such as id(...) ) return the same generated model so they can be
-   * chained in a builder pattern. This is mainly intended for Java usage and is generally unnecessary
-   * when using models in kotlin, especially if the generated kotlin model build extension functions
-   * are used. Disabling this can greatly reduce the number of methods generated on models.
+   * chained in a builder pattern. This is mainly intended for Java usage and is generally
+   * unnecessary when using models in kotlin, especially if the generated kotlin model
+   * build extension functions are used. Disabling this can greatly reduce the number of
+   * methods generated on models.
    *
    * Default is false. This may also be set project wide with an annotation processor option.
    */

--- a/epoxy-modelfactorytest/src/test/resources/AllTypesModelViewModel_.java
+++ b/epoxy-modelfactorytest/src/test/resources/AllTypesModelViewModel_.java
@@ -33,8 +33,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
 
   private OnModelVisibilityChangedListener<AllTypesModelViewModel_, AllTypesModelView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private boolean booleanValue_Boolean = false;
 
   /**
@@ -52,12 +50,8 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
   @NonNull
   private Double boxedDoubleValue_Double;
 
-  /**
-   * Bitset index: 4 */
   private double doubleValue_Double = 0.0d;
 
-  /**
-   * Bitset index: 5 */
   @DrawableRes
   private int drawableRes_Int = 0;
 
@@ -66,8 +60,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
   @NonNull
   private List<? extends EpoxyModel<?>> epoxyModelList_List;
 
-  /**
-   * Bitset index: 7 */
   private int intValue_Int = 0;
 
   /**
@@ -75,8 +67,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
   @NonNull
   private Integer boxedIntValue_Integer;
 
-  /**
-   * Bitset index: 9 */
   private long longValue_Long = 0L;
 
   /**
@@ -89,8 +79,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
   @NonNull
   private View.OnClickListener onClickListener_OnClickListener;
 
-  /**
-   * Bitset index: 12 */
   @RawRes
   private int rawRes_Int = 0;
 
@@ -326,7 +314,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
    * @see AllTypesModelView#setBooleanValue(boolean)
    */
   public AllTypesModelViewModel_ booleanValue(boolean booleanValue) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.booleanValue_Boolean = booleanValue;
     return this;
@@ -402,7 +389,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
    * @see AllTypesModelView#setDoubleValue(double)
    */
   public AllTypesModelViewModel_ doubleValue(double doubleValue) {
-    assignedAttributes_epoxyGeneratedModel.set(4);
     onMutation();
     this.doubleValue_Double = doubleValue;
     return this;
@@ -418,7 +404,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
    * @see AllTypesModelView#setDrawableRes(int)
    */
   public AllTypesModelViewModel_ drawableRes(@DrawableRes int drawableRes) {
-    assignedAttributes_epoxyGeneratedModel.set(5);
     onMutation();
     this.drawableRes_Int = drawableRes;
     return this;
@@ -456,7 +441,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
    * @see AllTypesModelView#setIntValue(int)
    */
   public AllTypesModelViewModel_ intValue(int intValue) {
-    assignedAttributes_epoxyGeneratedModel.set(7);
     onMutation();
     this.intValue_Int = intValue;
     return this;
@@ -492,7 +476,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
    * @see AllTypesModelView#setLongValue(long)
    */
   public AllTypesModelViewModel_ longValue(long longValue) {
-    assignedAttributes_epoxyGeneratedModel.set(9);
     onMutation();
     this.longValue_Long = longValue;
     return this;
@@ -563,7 +546,6 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
    * @see AllTypesModelView#setRawRes(int)
    */
   public AllTypesModelViewModel_ rawRes(@RawRes int rawRes) {
-    assignedAttributes_epoxyGeneratedModel.set(12);
     onMutation();
     this.rawRes_Int = rawRes;
     return this;

--- a/epoxy-modelfactorytest/src/test/resources/CallbackPropModelViewModel_.java
+++ b/epoxy-modelfactorytest/src/test/resources/CallbackPropModelViewModel_.java
@@ -8,13 +8,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class CallbackPropModelViewModel_ extends EpoxyModel<CallbackPropModelView> implements GeneratedModel<CallbackPropModelView>, CallbackPropModelViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<CallbackPropModelViewModel_, CallbackPropModelView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<CallbackPropModelViewModel_, CallbackPropModelView> onModelUnboundListener_epoxyGeneratedModel;
@@ -23,8 +20,6 @@ public class CallbackPropModelViewModel_ extends EpoxyModel<CallbackPropModelVie
 
   private OnModelVisibilityChangedListener<CallbackPropModelViewModel_, CallbackPropModelView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   @Nullable
   private View.OnClickListener onClickListener_OnClickListener = (View.OnClickListener) null;
 
@@ -152,7 +147,6 @@ public class CallbackPropModelViewModel_ extends EpoxyModel<CallbackPropModelVie
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public CallbackPropModelViewModel_ onClickListener(
       @Nullable final OnModelClickListener<CallbackPropModelViewModel_, CallbackPropModelView> onClickListener) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     if (onClickListener == null) {
       this.onClickListener_OnClickListener = null;
@@ -170,7 +164,6 @@ public class CallbackPropModelViewModel_ extends EpoxyModel<CallbackPropModelVie
    */
   public CallbackPropModelViewModel_ onClickListener(
       @Nullable View.OnClickListener onClickListener) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.onClickListener_OnClickListener = onClickListener;
     return this;
@@ -261,7 +254,6 @@ public class CallbackPropModelViewModel_ extends EpoxyModel<CallbackPropModelVie
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.onClickListener_OnClickListener = (View.OnClickListener) null;
     super.reset();
     return this;

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BaseProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BaseProcessor.kt
@@ -1,5 +1,15 @@
 package com.airbnb.epoxy.processor
 
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_DISABLE_GENERATE_BUILDER_OVERLOADS
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_DISABLE_GENERATE_GETTERS
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_DISABLE_GENERATE_RESET
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_DISABLE_KOTLIN_EXTENSION_GENERATION
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_ENABLE_PARALLEL
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_IMPLICITLY_ADD_AUTO_MODELS
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_LOG_TIMINGS
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_REQUIRE_HASHCODE
+import com.airbnb.epoxy.processor.ConfigManager.Companion.PROCESSOR_OPTION_VALIDATE_MODEL_USAGE
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
@@ -77,13 +87,16 @@ abstract class BaseProcessor : AbstractProcessor(), Asyncable {
     abstract fun supportedAnnotations(): List<KClass<*>>
 
     override fun getSupportedOptions(): Set<String> = setOf(
-        ConfigManager.PROCESSOR_OPTION_IMPLICITLY_ADD_AUTO_MODELS,
-        ConfigManager.PROCESSOR_OPTION_VALIDATE_MODEL_USAGE,
-        ConfigManager.PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS,
-        ConfigManager.PROCESSOR_OPTION_REQUIRE_HASHCODE,
-        ConfigManager.PROCESSOR_OPTION_DISABLE_KOTLIN_EXTENSION_GENERATION,
-        ConfigManager.PROCESSOR_OPTION_LOG_TIMINGS,
-        ConfigManager.PROCESSOR_OPTION_ENABLE_PARALLEL
+        PROCESSOR_OPTION_IMPLICITLY_ADD_AUTO_MODELS,
+        PROCESSOR_OPTION_VALIDATE_MODEL_USAGE,
+        PROCESSOR_OPTION_REQUIRE_ABSTRACT_MODELS,
+        PROCESSOR_OPTION_REQUIRE_HASHCODE,
+        PROCESSOR_OPTION_DISABLE_KOTLIN_EXTENSION_GENERATION,
+        PROCESSOR_OPTION_LOG_TIMINGS,
+        PROCESSOR_OPTION_ENABLE_PARALLEL,
+        PROCESSOR_OPTION_DISABLE_GENERATE_RESET,
+        PROCESSOR_OPTION_DISABLE_GENERATE_GETTERS,
+        PROCESSOR_OPTION_DISABLE_GENERATE_BUILDER_OVERLOADS
     )
 
     override fun init(processingEnv: ProcessingEnvironment) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ConfigManager.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ConfigManager.kt
@@ -27,6 +27,9 @@ class ConfigManager internal constructor(
     private val globalRequireAbstractModels: Boolean
     private val globalImplicitlyAddAutoModels: Boolean
     private val disableKotlinExtensionGeneration: Boolean
+    private val disableGenerateReset: Boolean
+    private val disableGenerateGetters: Boolean
+    private val disableGenerateBuilderOverloads: Boolean
     val logTimings: Boolean
     val enableCoroutines: Boolean
 
@@ -69,6 +72,24 @@ class ConfigManager internal constructor(
         enableCoroutines = getBooleanOption(
             options,
             PROCESSOR_OPTION_ENABLE_PARALLEL,
+            defaultValue = false
+        )
+
+        disableGenerateReset = getBooleanOption(
+            options,
+            PROCESSOR_OPTION_DISABLE_GENERATE_RESET,
+            defaultValue = false
+        )
+
+        disableGenerateGetters = getBooleanOption(
+            options,
+            PROCESSOR_OPTION_DISABLE_GENERATE_GETTERS,
+            defaultValue = false
+        )
+
+        disableGenerateBuilderOverloads = getBooleanOption(
+            options,
+            PROCESSOR_OPTION_DISABLE_GENERATE_BUILDER_OVERLOADS,
             defaultValue = false
         )
     }
@@ -185,6 +206,11 @@ class ConfigManager internal constructor(
      */
     fun shouldValidateModelUsage(): Boolean = validateModelUsage
 
+    fun getModelViewConfig(modelViewInfo: ModelViewInfo?): PackageModelViewSettings? {
+        if (modelViewInfo == null) return null
+        return getModelViewConfig(modelViewInfo.viewElement)
+    }
+
     fun getModelViewConfig(viewElement: Element): PackageModelViewSettings? {
         val packageName = elementUtils.getPackageOf(viewElement).qualifiedName.toString()
         return getObjectFromPackageMap(
@@ -207,6 +233,21 @@ class ConfigManager internal constructor(
             ?: GeneratedModelInfo.GENERATED_MODEL_SUFFIX
     }
 
+    fun disableGenerateBuilderOverloads(modelInfo: GeneratedModelInfo): Boolean {
+        return getModelViewConfig(modelInfo as? ModelViewInfo)?.disableGenerateBuilderOverloads
+            ?: disableGenerateBuilderOverloads
+    }
+
+    fun disableGenerateReset(modelInfo: GeneratedModelInfo): Boolean {
+        return getModelViewConfig(modelInfo as? ModelViewInfo)?.disableGenerateReset
+            ?: disableGenerateReset
+    }
+
+    fun disableGenerateGetters(modelInfo: GeneratedModelInfo): Boolean {
+        return getModelViewConfig(modelInfo as? ModelViewInfo)?.disableGenerateGetters
+            ?: disableGenerateGetters
+    }
+
     private fun getConfigurationForElement(element: Element): PackageConfigSettings {
         return getConfigurationForPackage(elementUtils.getPackageOf(element))
     }
@@ -225,6 +266,10 @@ class ConfigManager internal constructor(
     }
 
     companion object {
+        const val PROCESSOR_OPTION_DISABLE_GENERATE_RESET = "epoxyDisableGenerateReset"
+        const val PROCESSOR_OPTION_DISABLE_GENERATE_GETTERS = "epoxyDisableGenerateGetters"
+        const val PROCESSOR_OPTION_DISABLE_GENERATE_BUILDER_OVERLOADS =
+            "epoxyDisableGenerateOverloads"
         const val PROCESSOR_OPTION_LOG_TIMINGS = "logEpoxyTimings"
         const val PROCESSOR_OPTION_ENABLE_PARALLEL = "enableParallelEpoxyProcessing"
         const val PROCESSOR_OPTION_VALIDATE_MODEL_USAGE = "validateEpoxyModelUsage"

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
@@ -216,6 +216,8 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
             ?: emptyList()
     }
 
+    fun isInGroup(attribute: AttributeInfo): Boolean = attributeToGroup.containsKey(attribute)
+
     fun isOverload(attribute: AttributeInfo): Boolean {
         return attributeToGroup[attribute]?.attributes?.let { it.size > 1 } == true
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
@@ -216,8 +216,6 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
             ?: emptyList()
     }
 
-    fun isInGroup(attribute: AttributeInfo): Boolean = attributeToGroup.containsKey(attribute)
-
     fun isOverload(attribute: AttributeInfo): Boolean {
         return attributeToGroup[attribute]?.attributes?.let { it.size > 1 } == true
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
@@ -220,6 +220,10 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
         return attributeToGroup[attribute]?.attributes?.let { it.size > 1 } == true
     }
 
+    fun attributeGroup(attribute: AttributeInfo): AttributeGroup? {
+        return attributeToGroup[attribute]
+    }
+
     class AttributeGroup internal constructor(
         groupName: String?,
         attributes: List<AttributeInfo>,

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/KotlinModelBuilderExtensionWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/KotlinModelBuilderExtensionWriter.kt
@@ -57,6 +57,10 @@ internal class KotlinModelBuilderExtensionWriter(
                 }
             }
             .flatten()
+            // Sort by function name to keep ordering consistent across builds. Otherwise if the
+            // processor processes models in differing orders we can have indeterminate source file
+            // generation which breaks cache keys.
+            .sortedBy { it.name }
             .forEach { fileBuilder.addFunction(it) }
 
         // We suppress Deprecation warnings for this class in case any of the models used are deprecated.

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewProcessor.kt
@@ -62,6 +62,8 @@ class ModelViewProcessor : BaseProcessorWithPackageConfigs() {
             // Up until here our code generation has assumed that that all attributes in a group are
             // view attributes (and not attributes inherited from a base model class), so this should be
             // done after grouping attributes, and these attributes should not be grouped.
+            // No code to bind these attributes is generated, as it is assumed that the original model
+            // handles its own bind (also we can't know how to bind these).
             updatesViewsForInheritedBaseModelAttributes()
             addStyleAttributes()
         }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewWriter.kt
@@ -46,7 +46,7 @@ internal class ModelViewWriter(
 
                     // If there are multiple attributes, or a default kotlin value, then we need to generate code to
                     // check which properties have been set.
-                    val noConditionals = attrCount == 1 && !attr(0).hasDefaultKotlinValue
+                    val noConditionals = !hasConditionals(attributeGroup)
 
                     for (i in 0 until attrCount) {
                         val viewAttribute = attr(i)
@@ -123,8 +123,7 @@ internal class ModelViewWriter(
 
                 for (attributeGroup in modelInfo.attributeGroups) {
                     val attributes = attributeGroup.attributes
-                    val noConditionals = attributes.size == 1 &&
-                        !(attributes.first() as ViewAttributeInfo).hasDefaultKotlinValue
+                    val noConditionals = !hasConditionals(attributeGroup)
 
                     methodBuilder.addCode("\n")
 
@@ -396,6 +395,14 @@ internal class ModelViewWriter(
     ) {
         for (methodName in modelInfo.afterPropsSetMethodNames) {
             methodBuilder.addStatement(boundObjectParam.name + "." + methodName + "()")
+        }
+    }
+
+    companion object {
+        fun hasConditionals(attributeGroup: GeneratedModelInfo.AttributeGroup?): Boolean {
+            if (attributeGroup == null) return false
+            
+            return attributeGroup.attributes.size > 1 || (attributeGroup.defaultAttribute as ViewAttributeInfo?)?.hasDefaultKotlinValue == true
         }
     }
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewWriter.kt
@@ -401,7 +401,7 @@ internal class ModelViewWriter(
     companion object {
         fun hasConditionals(attributeGroup: GeneratedModelInfo.AttributeGroup?): Boolean {
             if (attributeGroup == null) return false
-            
+
             return attributeGroup.attributes.size > 1 || (attributeGroup.defaultAttribute as ViewAttributeInfo?)?.hasDefaultKotlinValue == true
         }
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/PackageModelViewSettings.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/PackageModelViewSettings.kt
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy.processor
 
+import com.airbnb.epoxy.ModelView
 import com.airbnb.epoxy.PackageModelViewConfig
 import com.squareup.javapoet.ClassName
 import javax.lang.model.element.TypeElement
@@ -16,6 +17,10 @@ class PackageModelViewSettings(
     val layoutName: String = annotation.defaultLayoutPattern
     val includeAlternateLayouts: Boolean = annotation.useLayoutOverloads
     val generatedModelSuffix: String = annotation.generatedModelSuffix
+    val disableGenerateBuilderOverloads: Boolean? =
+        annotation.disableGenerateBuilderOverloads.toBoolean()
+    val disableGenerateGetters: Boolean? = annotation.disableGenerateGetters.toBoolean()
+    val disableGenerateReset: Boolean? = annotation.disableGenerateReset.toBoolean()
 
     val defaultBaseModel: TypeMirror? by lazy {
 
@@ -40,5 +45,13 @@ class PackageModelViewSettings(
         val viewName = Utils.toSnakeCase(viewElement.simpleName.toString())
         val resourceName = layoutName.replace("%s", viewName)
         return ResourceValue(rClass, resourceName, 0)
+    }
+
+    private fun PackageModelViewConfig.Option.toBoolean(): Boolean? {
+        return when (this) {
+            PackageModelViewConfig.Option.Default -> null
+            PackageModelViewConfig.Option.Enabled -> true
+            PackageModelViewConfig.Option.Disabled -> false
+        }
     }
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/PackageModelViewSettings.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/PackageModelViewSettings.kt
@@ -1,6 +1,5 @@
 package com.airbnb.epoxy.processor
 
-import com.airbnb.epoxy.ModelView
 import com.airbnb.epoxy.PackageModelViewConfig
 import com.squareup.javapoet.ClassName
 import javax.lang.model.element.TypeElement

--- a/epoxy-processortest/src/test/resources/AutoLayoutModelViewMatchParentModel_.java
+++ b/epoxy-processortest/src/test/resources/AutoLayoutModelViewMatchParentModel_.java
@@ -9,13 +9,10 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class AutoLayoutModelViewMatchParentModel_ extends EpoxyModel<AutoLayoutModelViewMatchParent> implements GeneratedModel<AutoLayoutModelViewMatchParent>, AutoLayoutModelViewMatchParentModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<AutoLayoutModelViewMatchParentModel_, AutoLayoutModelViewMatchParent> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<AutoLayoutModelViewMatchParentModel_, AutoLayoutModelViewMatchParent> onModelUnboundListener_epoxyGeneratedModel;
@@ -24,8 +21,6 @@ public class AutoLayoutModelViewMatchParentModel_ extends EpoxyModel<AutoLayoutM
 
   private OnModelVisibilityChangedListener<AutoLayoutModelViewMatchParentModel_, AutoLayoutModelViewMatchParent> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private int value_Int = 0;
 
   @Override
@@ -166,7 +161,6 @@ public class AutoLayoutModelViewMatchParentModel_ extends EpoxyModel<AutoLayoutM
    * @see AutoLayoutModelViewMatchParent#setValue(int)
    */
   public AutoLayoutModelViewMatchParentModel_ value(int value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.value_Int = value;
     return this;
@@ -255,7 +249,6 @@ public class AutoLayoutModelViewMatchParentModel_ extends EpoxyModel<AutoLayoutM
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.value_Int = 0;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/AutoLayoutModelViewModel_.java
+++ b/epoxy-processortest/src/test/resources/AutoLayoutModelViewModel_.java
@@ -9,13 +9,10 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class AutoLayoutModelViewModel_ extends EpoxyModel<AutoLayoutModelView> implements GeneratedModel<AutoLayoutModelView>, AutoLayoutModelViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<AutoLayoutModelViewModel_, AutoLayoutModelView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<AutoLayoutModelViewModel_, AutoLayoutModelView> onModelUnboundListener_epoxyGeneratedModel;
@@ -24,8 +21,6 @@ public class AutoLayoutModelViewModel_ extends EpoxyModel<AutoLayoutModelView> i
 
   private OnModelVisibilityChangedListener<AutoLayoutModelViewModel_, AutoLayoutModelView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private int value_Int = 0;
 
   @Override
@@ -165,7 +160,6 @@ public class AutoLayoutModelViewModel_ extends EpoxyModel<AutoLayoutModelView> i
    * @see AutoLayoutModelView#setValue(int)
    */
   public AutoLayoutModelViewModel_ value(int value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.value_Int = value;
     return this;
@@ -253,7 +247,6 @@ public class AutoLayoutModelViewModel_ extends EpoxyModel<AutoLayoutModelView> i
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.value_Int = 0;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/BaseModelWithAttributeViewModel_.java
+++ b/epoxy-processortest/src/test/resources/BaseModelWithAttributeViewModel_.java
@@ -177,7 +177,6 @@ public class BaseModelViewModel_ extends TestBaseModel<BaseModelView> implements
   }
 
   public BaseModelViewModel_ baseModelString(String baseModelString) {
-    assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
     super.baseModelString = baseModelString;
     return this;

--- a/epoxy-processortest/src/test/resources/CustomPackageLayoutPatternViewModel_.java
+++ b/epoxy-processortest/src/test/resources/CustomPackageLayoutPatternViewModel_.java
@@ -7,13 +7,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class CustomPackageLayoutPatternViewModel_ extends EpoxyModel<CustomPackageLayoutPatternView> implements GeneratedModel<CustomPackageLayoutPatternView>, CustomPackageLayoutPatternViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(0);
-
   private OnModelBoundListener<CustomPackageLayoutPatternViewModel_, CustomPackageLayoutPatternView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<CustomPackageLayoutPatternViewModel_, CustomPackageLayoutPatternView> onModelUnboundListener_epoxyGeneratedModel;
@@ -217,7 +214,6 @@ public class CustomPackageLayoutPatternViewModel_ extends EpoxyModel<CustomPacka
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/DefaultPackageLayoutPatternViewModel_.java
+++ b/epoxy-processortest/src/test/resources/DefaultPackageLayoutPatternViewModel_.java
@@ -7,13 +7,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class DefaultPackageLayoutPatternViewModel_ extends EpoxyModel<DefaultPackageLayoutPatternView> implements GeneratedModel<DefaultPackageLayoutPatternView>, DefaultPackageLayoutPatternViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(0);
-
   private OnModelBoundListener<DefaultPackageLayoutPatternViewModel_, DefaultPackageLayoutPatternView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<DefaultPackageLayoutPatternViewModel_, DefaultPackageLayoutPatternView> onModelUnboundListener_epoxyGeneratedModel;
@@ -217,7 +214,6 @@ public class DefaultPackageLayoutPatternViewModel_ extends EpoxyModel<DefaultPac
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/GeneratedModelSuffixViewSuffix_.java
+++ b/epoxy-processortest/src/test/resources/GeneratedModelSuffixViewSuffix_.java
@@ -7,13 +7,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class GeneratedModelSuffixViewSuffix_ extends EpoxyModel<GeneratedModelSuffixView> implements GeneratedModel<GeneratedModelSuffixView>, GeneratedModelSuffixViewSuffixBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(0);
-
   private OnModelBoundListener<GeneratedModelSuffixViewSuffix_, GeneratedModelSuffixView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<GeneratedModelSuffixViewSuffix_, GeneratedModelSuffixView> onModelUnboundListener_epoxyGeneratedModel;
@@ -216,7 +213,6 @@ public class GeneratedModelSuffixViewSuffix_ extends EpoxyModel<GeneratedModelSu
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/LayoutOverloadsViewModel_.java
+++ b/epoxy-processortest/src/test/resources/LayoutOverloadsViewModel_.java
@@ -7,13 +7,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class LayoutOverloadsViewModel_ extends EpoxyModel<LayoutOverloadsView> implements GeneratedModel<LayoutOverloadsView>, LayoutOverloadsViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(0);
-
   private OnModelBoundListener<LayoutOverloadsViewModel_, LayoutOverloadsView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<LayoutOverloadsViewModel_, LayoutOverloadsView> onModelUnboundListener_epoxyGeneratedModel;
@@ -225,7 +222,6 @@ public class LayoutOverloadsViewModel_ extends EpoxyModel<LayoutOverloadsView> i
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelViewExtendingSuperClassModel_.java
+++ b/epoxy-processortest/src/test/resources/ModelViewExtendingSuperClassModel_.java
@@ -9,13 +9,10 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class ModelViewExtendingSuperClassModel_ extends EpoxyModel<ModelViewExtendingSuperClass> implements GeneratedModel<ModelViewExtendingSuperClass>, ModelViewExtendingSuperClassModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(2);
-
   private OnModelBoundListener<ModelViewExtendingSuperClassModel_, ModelViewExtendingSuperClass> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<ModelViewExtendingSuperClassModel_, ModelViewExtendingSuperClass> onModelUnboundListener_epoxyGeneratedModel;
@@ -24,12 +21,8 @@ public class ModelViewExtendingSuperClassModel_ extends EpoxyModel<ModelViewExte
 
   private OnModelVisibilityChangedListener<ModelViewExtendingSuperClassModel_, ModelViewExtendingSuperClass> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private int subClassValue_Int = 0;
 
-  /**
-   * Bitset index: 1 */
   private int superClassValue_Int = 0;
 
   @Override
@@ -179,7 +172,6 @@ public class ModelViewExtendingSuperClassModel_ extends EpoxyModel<ModelViewExte
    * @see ModelViewExtendingSuperClass#subClassValue(int)
    */
   public ModelViewExtendingSuperClassModel_ subClassValue(int subClassValue) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.subClassValue_Int = subClassValue;
     return this;
@@ -195,7 +187,6 @@ public class ModelViewExtendingSuperClassModel_ extends EpoxyModel<ModelViewExte
    * @see ModelViewExtendingSuperClass#superClassValue(int)
    */
   public ModelViewExtendingSuperClassModel_ superClassValue(int superClassValue) {
-    assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
     this.superClassValue_Int = superClassValue;
     return this;
@@ -284,7 +275,6 @@ public class ModelViewExtendingSuperClassModel_ extends EpoxyModel<ModelViewExte
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.subClassValue_Int = 0;
     this.superClassValue_Int = 0;
     super.reset();

--- a/epoxy-processortest/src/test/resources/ModelViewSuperClassModel_.java
+++ b/epoxy-processortest/src/test/resources/ModelViewSuperClassModel_.java
@@ -9,13 +9,10 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class ModelViewSuperClassModel_ extends EpoxyModel<ModelViewSuperClass> implements GeneratedModel<ModelViewSuperClass>, ModelViewSuperClassModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<ModelViewSuperClassModel_, ModelViewSuperClass> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<ModelViewSuperClassModel_, ModelViewSuperClass> onModelUnboundListener_epoxyGeneratedModel;
@@ -24,8 +21,6 @@ public class ModelViewSuperClassModel_ extends EpoxyModel<ModelViewSuperClass> i
 
   private OnModelVisibilityChangedListener<ModelViewSuperClassModel_, ModelViewSuperClass> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private int superClassValue_Int = 0;
 
   @Override
@@ -167,7 +162,6 @@ public class ModelViewSuperClassModel_ extends EpoxyModel<ModelViewSuperClass> i
    * @see ModelViewSuperClass#superClassValue(int)
    */
   public ModelViewSuperClassModel_ superClassValue(int superClassValue) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.superClassValue_Int = superClassValue;
     return this;
@@ -255,7 +249,6 @@ public class ModelViewSuperClassModel_ extends EpoxyModel<ModelViewSuperClass> i
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.superClassValue_Int = 0;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/ModelViewWithParisModel_.java
+++ b/epoxy-processortest/src/test/resources/ModelViewWithParisModel_.java
@@ -17,7 +17,6 @@ import java.lang.Runnable;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
 import java.lang.ref.WeakReference;
-import java.util.BitSet;
 import java.util.Objects;
 
 /**
@@ -31,8 +30,6 @@ public class ModelViewWithParisModel_ extends EpoxyModel<ModelViewWithParis> imp
 
   private static WeakReference<Style> parisStyleReference_default;
 
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(2);
-
   private OnModelBoundListener<ModelViewWithParisModel_, ModelViewWithParis> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<ModelViewWithParisModel_, ModelViewWithParis> onModelUnboundListener_epoxyGeneratedModel;
@@ -41,12 +38,8 @@ public class ModelViewWithParisModel_ extends EpoxyModel<ModelViewWithParis> imp
 
   private OnModelVisibilityChangedListener<ModelViewWithParisModel_, ModelViewWithParis> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private int value_Int = 0;
 
-  /**
-   * Bitset index: 1 */
   private Style style = DEFAULT_PARIS_STYLE;
 
   @Override
@@ -205,7 +198,6 @@ public class ModelViewWithParisModel_ extends EpoxyModel<ModelViewWithParis> imp
   }
 
   public ModelViewWithParisModel_ style(Style style) {
-    assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
     this.style = style;
     return this;
@@ -260,7 +252,6 @@ public class ModelViewWithParisModel_ extends EpoxyModel<ModelViewWithParis> imp
    * @see ModelViewWithParis#value
    */
   public ModelViewWithParisModel_ value(int value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.value_Int = value;
     return this;
@@ -348,7 +339,6 @@ public class ModelViewWithParisModel_ extends EpoxyModel<ModelViewWithParis> imp
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.value_Int = 0;
     this.style = DEFAULT_PARIS_STYLE;
     super.reset();

--- a/epoxy-processortest/src/test/resources/NullOnRecycleViewModel_.java
+++ b/epoxy-processortest/src/test/resources/NullOnRecycleViewModel_.java
@@ -7,13 +7,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class NullOnRecycleViewModel_ extends EpoxyModel<NullOnRecycleView> implements GeneratedModel<NullOnRecycleView>, NullOnRecycleViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<NullOnRecycleViewModel_, NullOnRecycleView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<NullOnRecycleViewModel_, NullOnRecycleView> onModelUnboundListener_epoxyGeneratedModel;
@@ -22,8 +19,6 @@ public class NullOnRecycleViewModel_ extends EpoxyModel<NullOnRecycleView> imple
 
   private OnModelVisibilityChangedListener<NullOnRecycleViewModel_, NullOnRecycleView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   @Nullable
   private CharSequence title_CharSequence = (CharSequence) null;
 
@@ -153,7 +148,6 @@ public class NullOnRecycleViewModel_ extends EpoxyModel<NullOnRecycleView> imple
    * @see NullOnRecycleView#setTitle(CharSequence)
    */
   public NullOnRecycleViewModel_ title(@Nullable CharSequence title) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.title_CharSequence = title;
     return this;
@@ -243,7 +237,6 @@ public class NullOnRecycleViewModel_ extends EpoxyModel<NullOnRecycleView> imple
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.title_CharSequence = (CharSequence) null;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/PropDefaultsViewModel_.java
+++ b/epoxy-processortest/src/test/resources/PropDefaultsViewModel_.java
@@ -25,8 +25,6 @@ public class PropDefaultsViewModel_ extends EpoxyModel<PropDefaultsView> impleme
 
   private OnModelVisibilityChangedListener<PropDefaultsViewModel_, PropDefaultsView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   @Nullable
   private CharSequence defaultsToNull_CharSequence = (CharSequence) null;
 
@@ -35,21 +33,13 @@ public class PropDefaultsViewModel_ extends EpoxyModel<PropDefaultsView> impleme
   @NonNull
   private CharSequence noDefaultSoItIsRequired_CharSequence;
 
-  /**
-   * Bitset index: 2 */
   private int primitivesHaveImplicitDefaultsAndCannotBeRequired_Int = 0;
 
-  /**
-   * Bitset index: 3 */
   private int primitiveWithExplicitDefault_Int = PropDefaultsView.PRIMITIVE_DEFAULT;
 
-  /**
-   * Bitset index: 4 */
   @NonNull
   private String objectWithDefault_String = PropDefaultsView.STRING_DEFAULT;
 
-  /**
-   * Bitset index: 5 */
   @Nullable
   private String objectWithDefaultAndNullable_String = PropDefaultsView.STRING_DEFAULT;
 
@@ -206,7 +196,6 @@ public class PropDefaultsViewModel_ extends EpoxyModel<PropDefaultsView> impleme
    * @see PropDefaultsView#defaultsToNull(CharSequence)
    */
   public PropDefaultsViewModel_ defaultsToNull(@Nullable CharSequence defaultsToNull) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.defaultsToNull_CharSequence = defaultsToNull;
     return this;
@@ -245,7 +234,6 @@ public class PropDefaultsViewModel_ extends EpoxyModel<PropDefaultsView> impleme
    */
   public PropDefaultsViewModel_ primitivesHaveImplicitDefaultsAndCannotBeRequired(
       int primitivesHaveImplicitDefaultsAndCannotBeRequired) {
-    assignedAttributes_epoxyGeneratedModel.set(2);
     onMutation();
     this.primitivesHaveImplicitDefaultsAndCannotBeRequired_Int = primitivesHaveImplicitDefaultsAndCannotBeRequired;
     return this;
@@ -261,7 +249,6 @@ public class PropDefaultsViewModel_ extends EpoxyModel<PropDefaultsView> impleme
    * @see PropDefaultsView#primitiveWithExplicitDefault(int)
    */
   public PropDefaultsViewModel_ primitiveWithExplicitDefault(int primitiveWithExplicitDefault) {
-    assignedAttributes_epoxyGeneratedModel.set(3);
     onMutation();
     this.primitiveWithExplicitDefault_Int = primitiveWithExplicitDefault;
     return this;
@@ -280,7 +267,6 @@ public class PropDefaultsViewModel_ extends EpoxyModel<PropDefaultsView> impleme
     if (objectWithDefault == null) {
       throw new IllegalArgumentException("objectWithDefault cannot be null");
     }
-    assignedAttributes_epoxyGeneratedModel.set(4);
     onMutation();
     this.objectWithDefault_String = objectWithDefault;
     return this;
@@ -298,7 +284,6 @@ public class PropDefaultsViewModel_ extends EpoxyModel<PropDefaultsView> impleme
    */
   public PropDefaultsViewModel_ objectWithDefaultAndNullable(
       @Nullable String objectWithDefaultAndNullable) {
-    assignedAttributes_epoxyGeneratedModel.set(5);
     onMutation();
     this.objectWithDefaultAndNullable_String = objectWithDefaultAndNullable;
     return this;

--- a/epoxy-processortest/src/test/resources/RLayoutInViewModelAnnotationWorksViewModel_.java
+++ b/epoxy-processortest/src/test/resources/RLayoutInViewModelAnnotationWorksViewModel_.java
@@ -7,13 +7,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class RLayoutInViewModelAnnotationWorksViewModel_ extends EpoxyModel<RLayoutInViewModelAnnotationWorksView> implements GeneratedModel<RLayoutInViewModelAnnotationWorksView>, RLayoutInViewModelAnnotationWorksViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(0);
-
   private OnModelBoundListener<RLayoutInViewModelAnnotationWorksViewModel_, RLayoutInViewModelAnnotationWorksView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<RLayoutInViewModelAnnotationWorksViewModel_, RLayoutInViewModelAnnotationWorksView> onModelUnboundListener_epoxyGeneratedModel;
@@ -217,7 +214,6 @@ public class RLayoutInViewModelAnnotationWorksViewModel_ extends EpoxyModel<RLay
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     super.reset();
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestAfterBindPropsViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestAfterBindPropsViewModel_.java
@@ -7,13 +7,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class TestAfterBindPropsViewModel_ extends EpoxyModel<TestAfterBindPropsView> implements GeneratedModel<TestAfterBindPropsView>, TestAfterBindPropsViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(2);
-
   private OnModelBoundListener<TestAfterBindPropsViewModel_, TestAfterBindPropsView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<TestAfterBindPropsViewModel_, TestAfterBindPropsView> onModelUnboundListener_epoxyGeneratedModel;
@@ -22,12 +19,8 @@ public class TestAfterBindPropsViewModel_ extends EpoxyModel<TestAfterBindPropsV
 
   private OnModelVisibilityChangedListener<TestAfterBindPropsViewModel_, TestAfterBindPropsView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private boolean flag_Boolean = false;
 
-  /**
-   * Bitset index: 1 */
   private boolean flagSuper_Boolean = false;
 
   @Override
@@ -162,7 +155,6 @@ public class TestAfterBindPropsViewModel_ extends EpoxyModel<TestAfterBindPropsV
    * @see TestAfterBindPropsView#setFlag(boolean)
    */
   public TestAfterBindPropsViewModel_ flag(boolean flag) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.flag_Boolean = flag;
     return this;
@@ -178,7 +170,6 @@ public class TestAfterBindPropsViewModel_ extends EpoxyModel<TestAfterBindPropsV
    * @see TestAfterBindPropsSuperView#setFlagSuper(boolean)
    */
   public TestAfterBindPropsViewModel_ flagSuper(boolean flagSuper) {
-    assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
     this.flagSuper_Boolean = flagSuper;
     return this;
@@ -268,7 +259,6 @@ public class TestAfterBindPropsViewModel_ extends EpoxyModel<TestAfterBindPropsV
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.flag_Boolean = false;
     this.flagSuper_Boolean = false;
     super.reset();

--- a/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
@@ -8,13 +8,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView> implements GeneratedModel<TestCallbackPropView>, TestCallbackPropViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<TestCallbackPropViewModel_, TestCallbackPropView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<TestCallbackPropViewModel_, TestCallbackPropView> onModelUnboundListener_epoxyGeneratedModel;
@@ -23,8 +20,6 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
 
   private OnModelVisibilityChangedListener<TestCallbackPropViewModel_, TestCallbackPropView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   @Nullable
   private View.OnClickListener listener_OnClickListener = (View.OnClickListener) null;
 
@@ -152,7 +147,6 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public TestCallbackPropViewModel_ listener(
       @Nullable final OnModelClickListener<TestCallbackPropViewModel_, TestCallbackPropView> listener) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     if (listener == null) {
       this.listener_OnClickListener = null;
@@ -169,7 +163,6 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
    * @see TestCallbackPropView#setListener(View.OnClickListener)
    */
   public TestCallbackPropViewModel_ listener(@Nullable View.OnClickListener listener) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.listener_OnClickListener = listener;
     return this;
@@ -260,7 +253,6 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.listener_OnClickListener = (View.OnClickListener) null;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/TestFieldPropCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropCallbackPropViewModel_.java
@@ -10,13 +10,10 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPropCallbackPropView> implements GeneratedModel<TestFieldPropCallbackPropView>, TestFieldPropCallbackPropViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<TestFieldPropCallbackPropViewModel_, TestFieldPropCallbackPropView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<TestFieldPropCallbackPropViewModel_, TestFieldPropCallbackPropView> onModelUnboundListener_epoxyGeneratedModel;
@@ -25,8 +22,6 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
 
   private OnModelVisibilityChangedListener<TestFieldPropCallbackPropViewModel_, TestFieldPropCallbackPropView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   @Nullable
   private View.OnClickListener value_OnClickListener = (View.OnClickListener) null;
 
@@ -168,7 +163,6 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public TestFieldPropCallbackPropViewModel_ value(
       @Nullable final OnModelClickListener<TestFieldPropCallbackPropViewModel_, TestFieldPropCallbackPropView> value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     if (value == null) {
       this.value_OnClickListener = null;
@@ -185,7 +179,6 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
    * @see TestFieldPropCallbackPropView#value
    */
   public TestFieldPropCallbackPropViewModel_ value(@Nullable View.OnClickListener value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.value_OnClickListener = value;
     return this;
@@ -275,7 +268,6 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.value_OnClickListener = (View.OnClickListener) null;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/TestFieldPropChildViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropChildViewModel_.java
@@ -35,8 +35,6 @@ public class TestFieldPropChildViewModel_ extends EpoxyModel<TestFieldPropChildV
    * Bitset index: 0 */
   private StringAttributeData textValue_StringAttributeData =  new StringAttributeData();
 
-  /**
-   * Bitset index: 1 */
   @Nullable
   private View.OnClickListener value_OnClickListener = (View.OnClickListener) null;
 
@@ -247,7 +245,6 @@ public class TestFieldPropChildViewModel_ extends EpoxyModel<TestFieldPropChildV
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public TestFieldPropChildViewModel_ value(
       @Nullable final OnModelClickListener<TestFieldPropChildViewModel_, TestFieldPropChildView> value) {
-    assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
     if (value == null) {
       this.value_OnClickListener = null;
@@ -261,10 +258,9 @@ public class TestFieldPropChildViewModel_ extends EpoxyModel<TestFieldPropChildV
   /**
    * <i>Optional</i>: Default value is (View.OnClickListener) null
    *
-   * @see TestFieldPropChildView#value
+   * @see TestFieldPropParentView#value
    */
   public TestFieldPropChildViewModel_ value(@Nullable View.OnClickListener value) {
-    assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
     this.value_OnClickListener = value;
     return this;

--- a/epoxy-processortest/src/test/resources/TestFieldPropModelPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropModelPropViewModel_.java
@@ -9,13 +9,10 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class TestFieldPropModelPropViewModel_ extends EpoxyModel<TestFieldPropModelPropView> implements GeneratedModel<TestFieldPropModelPropView>, TestFieldPropModelPropViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<TestFieldPropModelPropViewModel_, TestFieldPropModelPropView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<TestFieldPropModelPropViewModel_, TestFieldPropModelPropView> onModelUnboundListener_epoxyGeneratedModel;
@@ -24,8 +21,6 @@ public class TestFieldPropModelPropViewModel_ extends EpoxyModel<TestFieldPropMo
 
   private OnModelVisibilityChangedListener<TestFieldPropModelPropViewModel_, TestFieldPropModelPropView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private int value_Int = 0;
 
   @Override
@@ -167,7 +162,6 @@ public class TestFieldPropModelPropViewModel_ extends EpoxyModel<TestFieldPropMo
    * @see TestFieldPropModelPropView#value
    */
   public TestFieldPropModelPropViewModel_ value(int value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.value_Int = value;
     return this;
@@ -256,7 +250,6 @@ public class TestFieldPropModelPropViewModel_ extends EpoxyModel<TestFieldPropMo
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.value_Int = 0;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/TestFieldPropNullOnRecycleOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropNullOnRecycleOptionViewModel_.java
@@ -9,14 +9,11 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.UnsupportedOperationException;
-import java.util.BitSet;
 import javax.annotation.Nullable;
 
 /**
  * Generated file. Do not modify! */
 public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestFieldPropNullOnRecycleOptionView> implements GeneratedModel<TestFieldPropNullOnRecycleOptionView>, TestFieldPropNullOnRecycleOptionViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<TestFieldPropNullOnRecycleOptionViewModel_, TestFieldPropNullOnRecycleOptionView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<TestFieldPropNullOnRecycleOptionViewModel_, TestFieldPropNullOnRecycleOptionView> onModelUnboundListener_epoxyGeneratedModel;
@@ -25,8 +22,6 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
 
   private OnModelVisibilityChangedListener<TestFieldPropNullOnRecycleOptionViewModel_, TestFieldPropNullOnRecycleOptionView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   @Nullable
   private View.OnClickListener value_OnClickListener = (View.OnClickListener) null;
 
@@ -168,7 +163,6 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
    * Set a click listener that will provide the parent view, model, and adapter position of the clicked view. This will clear the normal View.OnClickListener if one has been set */
   public TestFieldPropNullOnRecycleOptionViewModel_ value(
       @Nullable final OnModelClickListener<TestFieldPropNullOnRecycleOptionViewModel_, TestFieldPropNullOnRecycleOptionView> value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     if (value == null) {
       this.value_OnClickListener = null;
@@ -185,7 +179,6 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
    * @see TestFieldPropNullOnRecycleOptionView#value
    */
   public TestFieldPropNullOnRecycleOptionViewModel_ value(@Nullable View.OnClickListener value) {
-    assignedAttributes_epoxyGeneratedModel.set(0);
     onMutation();
     this.value_OnClickListener = value;
     return this;
@@ -279,7 +272,6 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.value_OnClickListener = (View.OnClickListener) null;
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
@@ -40,37 +40,25 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
   @NonNull
   private String stringValue_String;
 
-  /**
-   * Bitset index: 1 */
   @Nullable
   private String nullableStringValue_String = (String) null;
 
-  /**
-   * Bitset index: 2 */
   private int intValue_Int = 0;
 
-  /**
-   * Bitset index: 3 */
   @StringRes
   private int intValueWithAnnotation_Int = 0;
 
-  /**
-   * Bitset index: 4 */
   @IntRange(
       from = 0,
       to = 200
   )
   private int intValueWithRangeAnnotation_Int = 0;
 
-  /**
-   * Bitset index: 5 */
   @Dimension(
       unit = 0
   )
   private int intValueWithDimenTypeAnnotation_Int = 0;
 
-  /**
-   * Bitset index: 6 */
   @IntRange(
       from = 0,
       to = 200
@@ -85,8 +73,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
   @NonNull
   private Integer integerValue_Integer;
 
-  /**
-   * Bitset index: 8 */
   private boolean boolValue_Boolean = false;
 
   /**
@@ -109,8 +95,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
   @NonNull
   private View.OnClickListener clickListener_OnClickListener;
 
-  /**
-   * Bitset index: 13 */
   private StringAttributeData title_StringAttributeData =  new StringAttributeData((CharSequence) null);
 
   @Override
@@ -341,7 +325,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    * @see TestManyTypesView#setNullableStringValue(String)
    */
   public TestManyTypesViewModel_ nullableStringValue(@Nullable String nullableStringValue) {
-    assignedAttributes_epoxyGeneratedModel.set(1);
     onMutation();
     this.nullableStringValue_String = nullableStringValue;
     return this;
@@ -358,7 +341,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    * @see TestManyTypesView#setIntValue(int)
    */
   public TestManyTypesViewModel_ intValue(int intValue) {
-    assignedAttributes_epoxyGeneratedModel.set(2);
     onMutation();
     this.intValue_Int = intValue;
     return this;
@@ -374,7 +356,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    * @see TestManyTypesView#setIntValueWithAnnotation(int)
    */
   public TestManyTypesViewModel_ intValueWithAnnotation(@StringRes int intValueWithAnnotation) {
-    assignedAttributes_epoxyGeneratedModel.set(3);
     onMutation();
     this.intValueWithAnnotation_Int = intValueWithAnnotation;
     return this;
@@ -392,7 +373,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    */
   public TestManyTypesViewModel_ intValueWithRangeAnnotation(
       @IntRange(from = 0, to = 200) int intValueWithRangeAnnotation) {
-    assignedAttributes_epoxyGeneratedModel.set(4);
     onMutation();
     this.intValueWithRangeAnnotation_Int = intValueWithRangeAnnotation;
     return this;
@@ -413,7 +393,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    */
   public TestManyTypesViewModel_ intValueWithDimenTypeAnnotation(
       @Dimension(unit = 0) int intValueWithDimenTypeAnnotation) {
-    assignedAttributes_epoxyGeneratedModel.set(5);
     onMutation();
     this.intValueWithDimenTypeAnnotation_Int = intValueWithDimenTypeAnnotation;
     return this;
@@ -433,7 +412,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    */
   public TestManyTypesViewModel_ intWithMultipleAnnotations(
       @IntRange(from = 0, to = 200) @Dimension(unit = 0) int intWithMultipleAnnotations) {
-    assignedAttributes_epoxyGeneratedModel.set(6);
     onMutation();
     this.intWithMultipleAnnotations_Int = intWithMultipleAnnotations;
     return this;
@@ -476,7 +454,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    * @see TestManyTypesView#setBoolValue(boolean)
    */
   public TestManyTypesViewModel_ boolValue(boolean boolValue) {
-    assignedAttributes_epoxyGeneratedModel.set(8);
     onMutation();
     this.boolValue_Boolean = boolValue;
     return this;
@@ -593,7 +570,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    */
   public TestManyTypesViewModel_ title(@Nullable CharSequence title) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(13);
     title_StringAttributeData.setValue(title);
     return this;
   }
@@ -607,7 +583,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    */
   public TestManyTypesViewModel_ title(@StringRes int stringRes) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(13);
     title_StringAttributeData.setValue(stringRes);
     return this;
   }
@@ -621,7 +596,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
    */
   public TestManyTypesViewModel_ title(@StringRes int stringRes, Object... formatArgs) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(13);
     title_StringAttributeData.setValue(stringRes, formatArgs);
     return this;
   }
@@ -636,7 +610,6 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
   public TestManyTypesViewModel_ titleQuantityRes(@PluralsRes int pluralRes, int quantity,
       Object... formatArgs) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(13);
     title_StringAttributeData.setValue(pluralRes, quantity, formatArgs);
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestNullStringOverloadsViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestNullStringOverloadsViewModel_.java
@@ -10,13 +10,10 @@ import java.lang.Number;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.BitSet;
 
 /**
  * Generated file. Do not modify! */
 public class TestNullStringOverloadsViewModel_ extends EpoxyModel<TestNullStringOverloadsView> implements GeneratedModel<TestNullStringOverloadsView>, TestNullStringOverloadsViewModelBuilder {
-  private final BitSet assignedAttributes_epoxyGeneratedModel = new BitSet(1);
-
   private OnModelBoundListener<TestNullStringOverloadsViewModel_, TestNullStringOverloadsView> onModelBoundListener_epoxyGeneratedModel;
 
   private OnModelUnboundListener<TestNullStringOverloadsViewModel_, TestNullStringOverloadsView> onModelUnboundListener_epoxyGeneratedModel;
@@ -25,8 +22,6 @@ public class TestNullStringOverloadsViewModel_ extends EpoxyModel<TestNullString
 
   private OnModelVisibilityChangedListener<TestNullStringOverloadsViewModel_, TestNullStringOverloadsView> onModelVisibilityChangedListener_epoxyGeneratedModel;
 
-  /**
-   * Bitset index: 0 */
   private StringAttributeData title_StringAttributeData =  new StringAttributeData((CharSequence) null);
 
   @Override
@@ -161,7 +156,6 @@ public class TestNullStringOverloadsViewModel_ extends EpoxyModel<TestNullString
    */
   public TestNullStringOverloadsViewModel_ title(@Nullable CharSequence title) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(0);
     title_StringAttributeData.setValue(title);
     return this;
   }
@@ -175,7 +169,6 @@ public class TestNullStringOverloadsViewModel_ extends EpoxyModel<TestNullString
    */
   public TestNullStringOverloadsViewModel_ title(@StringRes int stringRes) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(0);
     title_StringAttributeData.setValue(stringRes);
     return this;
   }
@@ -189,7 +182,6 @@ public class TestNullStringOverloadsViewModel_ extends EpoxyModel<TestNullString
    */
   public TestNullStringOverloadsViewModel_ title(@StringRes int stringRes, Object... formatArgs) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(0);
     title_StringAttributeData.setValue(stringRes, formatArgs);
     return this;
   }
@@ -204,7 +196,6 @@ public class TestNullStringOverloadsViewModel_ extends EpoxyModel<TestNullString
   public TestNullStringOverloadsViewModel_ titleQuantityRes(@PluralsRes int pluralRes, int quantity,
       Object... formatArgs) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(0);
     title_StringAttributeData.setValue(pluralRes, quantity, formatArgs);
     return this;
   }
@@ -289,7 +280,6 @@ public class TestNullStringOverloadsViewModel_ extends EpoxyModel<TestNullString
     onModelUnboundListener_epoxyGeneratedModel = null;
     onModelVisibilityStateChangedListener_epoxyGeneratedModel = null;
     onModelVisibilityChangedListener_epoxyGeneratedModel = null;
-    assignedAttributes_epoxyGeneratedModel.clear();
     this.title_StringAttributeData =  new StringAttributeData((CharSequence) null);
     super.reset();
     return this;

--- a/epoxy-processortest/src/test/resources/TextPropDefaultViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TextPropDefaultViewModel_.java
@@ -32,8 +32,6 @@ public class TextPropDefaultViewModel_ extends EpoxyModel<TextPropDefaultView> i
    * Bitset index: 0 */
   private StringAttributeData textWithDefault_StringAttributeData =  new StringAttributeData(R.string.string_resource_value);
 
-  /**
-   * Bitset index: 1 */
   private StringAttributeData nullableTextWithDefault_StringAttributeData =  new StringAttributeData(R.string.string_resource_value);
 
   @Override
@@ -238,7 +236,6 @@ public class TextPropDefaultViewModel_ extends EpoxyModel<TextPropDefaultView> i
   public TextPropDefaultViewModel_ nullableTextWithDefault(
       @Nullable CharSequence nullableTextWithDefault) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(1);
     nullableTextWithDefault_StringAttributeData.setValue(nullableTextWithDefault);
     return this;
   }
@@ -252,7 +249,6 @@ public class TextPropDefaultViewModel_ extends EpoxyModel<TextPropDefaultView> i
    */
   public TextPropDefaultViewModel_ nullableTextWithDefault(@StringRes int stringRes) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(1);
     nullableTextWithDefault_StringAttributeData.setValue(stringRes);
     return this;
   }
@@ -267,7 +263,6 @@ public class TextPropDefaultViewModel_ extends EpoxyModel<TextPropDefaultView> i
   public TextPropDefaultViewModel_ nullableTextWithDefault(@StringRes int stringRes,
       Object... formatArgs) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(1);
     nullableTextWithDefault_StringAttributeData.setValue(stringRes, formatArgs);
     return this;
   }
@@ -282,7 +277,6 @@ public class TextPropDefaultViewModel_ extends EpoxyModel<TextPropDefaultView> i
   public TextPropDefaultViewModel_ nullableTextWithDefaultQuantityRes(@PluralsRes int pluralRes,
       int quantity, Object... formatArgs) {
     onMutation();
-    assignedAttributes_epoxyGeneratedModel.set(1);
     nullableTextWithDefault_StringAttributeData.setValue(pluralRes, quantity, formatArgs);
     return this;
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.0.0eli1-SNAPSHOT
+VERSION_NAME=4.0.0-beta3
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.0.0-beta2
+VERSION_NAME=4.0.0eli1-SNAPSHOT
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.0.0-beta1
+VERSION_NAME=4.0.0-beta2
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
- Sort functions in generated kotlin extension function files deterministically to prevent generated sources from changing and potentially breaking cache keys
- Avoid generating bitset checks in models when not needed
- Add options to skip generation of functions for getters, reset, and method overloads to reduce generated code

New annotation processor options are:
- epoxyDisableGenerateOverloads
- epoxyDisableGenerateGetters
- epoxyDisableGenerateReset

These can also be controlled (and overridden) on a per package level with the `PackageModelViewConfig` package annotation.