### PR TITLE
Allow PackageModelViewConfig to be set on Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.0-beta6 (July 15, 2020)
+- PackageModelViewConfig can now be applied to classes and interfaces in addition to package-info.java
+
 # 4.0.0-beta5 (July 9, 2020)
 Fixes:
 - An occasional processor crash when the option to log timings is enabled

--- a/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageModelViewConfig.java
+++ b/epoxy-annotations/src/main/java/com/airbnb/epoxy/PackageModelViewConfig.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
  * package. Also applies to subpackages, unless other package config values are set in those sub
  * packages.
  */
-@Target(ElementType.PACKAGE)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
 @Retention(RetentionPolicy.CLASS)
 public @interface PackageModelViewConfig {
   /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.0.0-beta5
+VERSION_NAME=4.0.0-beta6
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
There seems to be a KAPT issue where `package-info.java` files are not always included in incremental annotation processing. This is a problem for us as we use annotations like `PackageModelViewConfig` as a package annotation in these files to specify configurations for the processor.

A workaround is to put the annotation on a class or interface instead.