### PR TITLE
Allow specifying layout in GroupModel constructor

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -110,9 +110,10 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   /**
    * Constructor use for DSL
    */
-  protected EpoxyModelGroup() {
+  protected EpoxyModelGroup(@LayoutRes int layoutRes) {
     models = new ArrayList<>();
     shouldSaveViewStateDefault = false;
+    layout(layoutRes);
   }
 
   protected void addModel(@NonNull EpoxyModel<?> model) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -110,9 +110,16 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   /**
    * Constructor use for DSL
    */
-  protected EpoxyModelGroup(@LayoutRes int layoutRes) {
+  protected EpoxyModelGroup() {
     models = new ArrayList<>();
     shouldSaveViewStateDefault = false;
+  }
+
+  /**
+   * Constructor use for DSL
+   */
+  protected EpoxyModelGroup(@LayoutRes int layoutRes) {
+    this();
     layout(layoutRes);
   }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/GroupModel.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/GroupModel.kt
@@ -22,8 +22,9 @@ import androidx.annotation.LayoutRes
  * ```
  */
 @EpoxyModelClass
-abstract class GroupModel(@LayoutRes layoutRes: Int = 0) :
-    EpoxyModelGroup(layoutRes), ModelCollector {
+abstract class GroupModel : EpoxyModelGroup, ModelCollector {
+    constructor() : super()
+    constructor(@LayoutRes layoutRes: Int) : super(layoutRes)
 
     override fun add(model: EpoxyModel<*>) {
         super.addModel(model)

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/GroupModel.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/GroupModel.kt
@@ -22,8 +22,8 @@ import androidx.annotation.LayoutRes
  * ```
  */
 @EpoxyModelClass
-abstract class GroupModel(@LayoutRes layoutRes: Int = 0) : EpoxyModelGroup(layoutRes),
-    ModelCollector {
+abstract class GroupModel(@LayoutRes layoutRes: Int = 0) :
+    EpoxyModelGroup(layoutRes), ModelCollector {
 
     override fun add(model: EpoxyModel<*>) {
         super.addModel(model)

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/GroupModel.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/GroupModel.kt
@@ -1,5 +1,7 @@
 package com.airbnb.epoxy
 
+import androidx.annotation.LayoutRes
+
 /**
  * An [EpoxyModelGroup] usable in a DSL manner via the [group] extension.
  * <p>
@@ -20,7 +22,8 @@ package com.airbnb.epoxy
  * ```
  */
 @EpoxyModelClass
-abstract class GroupModel : EpoxyModelGroup(), ModelCollector {
+abstract class GroupModel(@LayoutRes layoutRes: Int = 0) : EpoxyModelGroup(layoutRes),
+    ModelCollector {
 
     override fun add(model: EpoxyModel<*>) {
         super.addModel(model)

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
@@ -14,6 +14,7 @@ import com.airbnb.epoxy.kotlinsample.models.ItemDataClass
 import com.airbnb.epoxy.kotlinsample.models.ItemViewBindingDataClass
 import com.airbnb.epoxy.kotlinsample.models.carouselItemCustomView
 import com.airbnb.epoxy.kotlinsample.models.coloredSquareView
+import com.airbnb.epoxy.kotlinsample.models.decoratedLinearGroup
 import com.airbnb.epoxy.kotlinsample.models.itemCustomView
 import com.airbnb.epoxy.kotlinsample.models.itemEpoxyHolder
 import com.airbnb.epoxy.kotlinsample.models.itemViewBindingEpoxyHolder
@@ -37,6 +38,25 @@ class MainActivity : AppCompatActivity() {
             group {
                 id("epoxyModelGroupDsl")
                 layout(R.layout.vertical_linear_group)
+
+                coloredSquareView {
+                    id("coloredSquareView 1")
+                    color(Color.DKGRAY)
+                }
+
+                coloredSquareView {
+                    id("coloredSquareView 2")
+                    color(Color.GRAY)
+                }
+
+                coloredSquareView {
+                    id("coloredSquareView 3")
+                    color(Color.LTGRAY)
+                }
+            }
+
+            decoratedLinearGroup {
+                id("epoxyModelGroupWithLayoutDsl")
 
                 coloredSquareView {
                     id("coloredSquareView 1")

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/DecoratedLinearGroupModel.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/DecoratedLinearGroupModel.kt
@@ -1,0 +1,8 @@
+package com.airbnb.epoxy.kotlinsample.models
+
+import com.airbnb.epoxy.EpoxyModelClass
+import com.airbnb.epoxy.GroupModel
+import com.airbnb.epoxy.kotlinsample.R
+
+@EpoxyModelClass
+abstract class DecoratedLinearGroupModel : GroupModel(R.layout.decorated_linear_group)

--- a/kotlinsample/src/main/res/layout/decorated_linear_group.xml
+++ b/kotlinsample/src/main/res/layout/decorated_linear_group.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp"
+    android:background="#80000000"/>

--- a/kotlinsample/src/main/res/layout/decorated_linear_group.xml
+++ b/kotlinsample/src/main/res/layout/decorated_linear_group.xml
@@ -2,6 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="#80000000"
     android:orientation="horizontal"
-    android:padding="8dp"
-    android:background="#80000000"/>
+    android:padding="8dp" />


### PR DESCRIPTION
This is a small, but useful improvement to #1012. It allows us to generate and use predefined DSLs which do not require referencing layout each time the group DSL is used. This is especially useful when we don't want to access another module's R class.

As in example, by introducing abstract class that extends `GroupModel` and annotating it with `@EpoxyModelClass`:
```kotlin
@EpoxyModelClass
abstract class DecoratedLinearGroupModel : GroupModel(R.layout.decorated_linear_group)
```
we can use following DSL:
```kotlin
decoratedLinearGroup {
    id("epoxyModelGroupWithLayoutDsl")
    ...
}
```
instead of:
```kotlin
group {
    id("epoxyModelGroupWithLayoutDsl")
    layout(R.layout.decorated_linear_group)
    ...
}
```