### PR TITLE
ModelGroupHolder to get the pool from parent RecyclerView

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.LayoutRes;
@@ -71,10 +70,11 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   private Boolean shouldSaveViewState = null;
 
   /**
-   * The pool to be used to recycle view in the group, it usually correspond to the recycler view.
+   * The pool for recycling within the group. Looked up in the parent view hierarchy if a RecyclerView
+   * is found. Else, if not found, it remains null.
    */
-  @NonNull
-  private RecycledViewPool viewPool = new LocalGroupRecycledViewPool();
+  @Nullable
+  private RecycledViewPool parentViewPool = null;
 
   /**
    * @param layoutRes The layout to use with these models.
@@ -134,11 +134,10 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 
   @Override
   protected View buildView(@NonNull ViewGroup parent) {
-    if (viewPool == null) {
-      viewPool = ModelGroupHolder.findViewPool(parent, viewPool);
+    if (parentViewPool == null) {
+      parentViewPool = ModelGroupHolder.findViewPool(parent);
     }
-    View group = super.buildView(parent);
-    return group;
+    return super.buildView(parent);
   }
 
   protected void addModel(@NonNull EpoxyModel<?> model) {
@@ -294,7 +293,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 
   @Override
   protected final ModelGroupHolder createNewHolder() {
-    return new ModelGroupHolder(viewPool);
+    return new ModelGroupHolder(parentViewPool);
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewStub;
 
 import java.util.ArrayList;
@@ -8,11 +9,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView.RecycledViewPool;
 
 /**
  * An {@link EpoxyModel} that contains other models, and allows you to combine those models in
@@ -68,6 +71,12 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   private Boolean shouldSaveViewState = null;
 
   /**
+   * The pool to be used to recycle view in the group, it usually correspond to the recycler view.
+   */
+  @NonNull
+  private RecycledViewPool viewPool = new LocalGroupRecycledViewPool();
+
+  /**
    * @param layoutRes The layout to use with these models.
    * @param models    The models that will be used to bind the views in the given layout.
    */
@@ -121,6 +130,15 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   protected EpoxyModelGroup(@LayoutRes int layoutRes) {
     this();
     layout(layoutRes);
+  }
+
+  @Override
+  protected View buildView(@NonNull ViewGroup parent) {
+    if (viewPool == null) {
+      viewPool = ModelGroupHolder.findViewPool(parent, viewPool);
+    }
+    View group = super.buildView(parent);
+    return group;
   }
 
   protected void addModel(@NonNull EpoxyModel<?> model) {
@@ -276,7 +294,7 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
 
   @Override
   protected final ModelGroupHolder createNewHolder() {
-    return new ModelGroupHolder();
+    return new ModelGroupHolder(viewPool);
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
@@ -8,11 +8,12 @@ import com.airbnb.viewmodeladapter.R
 import java.util.ArrayList
 
 class ModelGroupHolder(
-    val viewPool: RecyclerView.RecycledViewPool
+    parentViewPool: RecyclerView.RecycledViewPool?
 ) : EpoxyHolder() {
     val viewHolders = ArrayList<EpoxyViewHolder>(4)
 
-    private var viewPoolInitialized = false
+    /** Use parent pool or create a local pool */
+    private val viewPool = parentViewPool ?: LocalGroupRecycledViewPool()
 
     /**
      * Get the root view group (aka
@@ -187,10 +188,7 @@ class ModelGroupHolder(
          * new [LocalGroupRecycledViewPool].
          */
         @JvmStatic
-        fun findViewPool(
-            view: ViewGroup,
-            defaultValue: RecyclerView.RecycledViewPool
-        ): RecyclerView.RecycledViewPool {
+        fun findViewPool(view: ViewGroup): RecyclerView.RecycledViewPool? {
             var viewPool: RecyclerView.RecycledViewPool? = null
             while (viewPool == null) {
                 viewPool = if (view is RecyclerView) {
@@ -198,10 +196,10 @@ class ModelGroupHolder(
                 } else {
                     val parent = view.parent
                     if (parent is ViewGroup) {
-                        findViewPool(parent, defaultValue)
+                        findViewPool(parent)
                     } else {
-                        // This model group is is not in a RecyclerView, use default value.
-                        defaultValue
+                        // This model group is is not in a RecyclerView
+                        null
                     }
                 }
             }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
@@ -13,7 +13,7 @@ class ModelGroupHolder(
     val viewHolders = ArrayList<EpoxyViewHolder>(4)
 
     /** Use parent pool or create a local pool */
-    private val viewPool = parentViewPool ?: LocalGroupRecycledViewPool()
+    val viewPool = parentViewPool ?: LocalGroupRecycledViewPool()
 
     /**
      * Get the root view group (aka

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
@@ -186,6 +186,16 @@ class EpoxyModelGroupTest(val useViewStubs: Boolean) {
         }
     }
 
+    @Test
+    fun modelGroupHolderUseSameViewPoolThanRecyclerView() {
+        TODO("implements")
+    }
+
+    @Test
+    fun modelGroupHolderUseLocalRecyclerViewPool() {
+        TODO("implements")
+    }
+
     private fun createFrameLayoutGroup(modelCount: Int): EpoxyModelGroup {
         val models = (0 until modelCount).map { NestedModelFrameLayout().id(it) }
         return if (useViewStubs) ViewStubsGroupModel(models) else LinerLayoutGroupModel(models)

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
@@ -186,16 +186,6 @@ class EpoxyModelGroupTest(val useViewStubs: Boolean) {
         }
     }
 
-    @Test
-    fun modelGroupHolderUseSameViewPoolThanRecyclerView() {
-        TODO("implements")
-    }
-
-    @Test
-    fun modelGroupHolderUseLocalRecyclerViewPool() {
-        TODO("implements")
-    }
-
     private fun createFrameLayoutGroup(modelCount: Int): EpoxyModelGroup {
         val models = (0 until modelCount).map { NestedModelFrameLayout().id(it) }
         return if (useViewStubs) ViewStubsGroupModel(models) else LinerLayoutGroupModel(models)

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelGroupRecyclingTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelGroupRecyclingTest.kt
@@ -1,0 +1,154 @@
+package com.airbnb.epoxy
+
+import android.content.Context
+import android.os.Looper
+import android.widget.FrameLayout
+import android.widget.FrameLayout.LayoutParams
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.runner.AndroidJUnit4
+import com.airbnb.epoxy.integrationtest.R
+import com.airbnb.epoxy.integrationtest.TestActivity
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+/**
+ * Tests view pool of [EpoxyModelGroup] within [EpoxyRecyclerView].
+ */
+@Config(sdk = [21], qualifiers = "h831dp-mdpi")
+@RunWith(AndroidJUnit4::class)
+class EpoxyModelGroupRecyclingTest {
+
+    @get:Rule
+    var activityRule = activityScenarioRule<TestActivity>()
+
+    private lateinit var recyclerView1: EpoxyRecyclerView
+
+    private lateinit var recyclerView2: EpoxyRecyclerView
+
+    /**
+     * Verify that the groups inherit of the view pool configuration from the parent recycler view.
+     * Pool is shared within the context.
+     */
+    @Test
+    fun testModelGroupPool_shared() {
+
+        setupRecyclerView(shareViewPoolAcrossContext = true)
+        Assert.assertSame(recyclerView1.recycledViewPool, recyclerView2.recycledViewPool)
+
+        var modelsBound = 0
+        val assertOnModelBound: (EpoxyModelGroup, ModelGroupHolder, Int) -> Unit = { _, view, _ ->
+            modelsBound++
+            Assert.assertSame(recyclerView1.recycledViewPool, view.viewPool)
+        }
+        withModels(
+            buildModels1 = {
+                group {
+                    id("1")
+                    layout(R.layout.vertical_linear_group)
+                    onBind(assertOnModelBound)
+                }
+            },
+            buildModels2 = {
+                group {
+                    layout(R.layout.vertical_linear_group)
+                    id("2")
+                    onBind(assertOnModelBound)
+                }
+            }
+        )
+        Assert.assertEquals(2, modelsBound)
+    }
+
+    /**
+     * Verify that the groups inherit of the view pool configuration from the parent recycler view.
+     * Pool is not shared within the context.
+     */
+    @Test
+    fun testModelGroupPool_notShared() {
+
+        setupRecyclerView(shareViewPoolAcrossContext = false)
+        Assert.assertNotEquals(recyclerView1.recycledViewPool, recyclerView2.recycledViewPool)
+
+        var modelsBound = 0
+        val assertOnModelBound1: (EpoxyModelGroup, ModelGroupHolder, Int) -> Unit = { _, view, _ ->
+            modelsBound++
+            Assert.assertSame(recyclerView1.recycledViewPool, view.viewPool)
+        }
+        val assertOnModelBound2: (EpoxyModelGroup, ModelGroupHolder, Int) -> Unit = { _, view, _ ->
+            modelsBound++
+            Assert.assertSame(recyclerView2.recycledViewPool, view.viewPool)
+        }
+        withModels(
+            buildModels1 = {
+                group {
+                    id("1")
+                    layout(R.layout.vertical_linear_group)
+                    onBind(assertOnModelBound1)
+                }
+            },
+            buildModels2 = {
+                group {
+                    layout(R.layout.vertical_linear_group)
+                    id("2")
+                    onBind(assertOnModelBound2)
+                }
+            }
+        )
+        Assert.assertEquals("2 models should have been bound", 2, modelsBound)
+    }
+
+    /** Sets the models in the [recyclerView1] and [recyclerView2]. */
+    private fun setupRecyclerView(
+        shareViewPoolAcrossContext: Boolean
+    ) {
+        activityRule.scenario.onActivity {
+            if (shareViewPoolAcrossContext) {
+                recyclerView1 = EpoxyRecyclerView(it)
+                recyclerView2 = EpoxyRecyclerView(it)
+            } else {
+                recyclerView1 = NonSharedEpoxyRecyclerView(it)
+                recyclerView2 = NonSharedEpoxyRecyclerView(it)
+            }
+            it.setContentView(
+                FrameLayout(it).apply {
+                    addView(
+                        recyclerView1,
+                        LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+                    )
+                    addView(
+                        recyclerView2,
+                        LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+                    )
+                }
+            )
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
+    }
+
+    /** Sets the models in the [recyclerView1] and [recyclerView2]. */
+    private fun withModels(
+        buildModels1: EpoxyController.() -> Unit,
+        buildModels2: EpoxyController.() -> Unit
+    ) {
+        activityRule.scenario.onActivity {
+            recyclerView1.withModels {
+                buildModels1.invoke(this)
+            }
+            recyclerView2.withModels {
+                buildModels2.invoke(this)
+            }
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
+    }
+
+    private class NonSharedEpoxyRecyclerView(
+        context: Context
+    ) : EpoxyRecyclerView(context) {
+
+        override fun shouldShareViewPoolAcrossContext() = false
+    }
+}


### PR DESCRIPTION
Fix for #1094

This change remove `PoolReference` from `ModelGroupHolder`. Instead it just need a `RecyclerView.RecycledViewPool`. 

This new pool is passed in the constructor by the `EpoxyModelGroup` as it is the only place we have access to the parent `RecyclerView`.

`EpoxyModelGroup` will try to find a pool from the closest `RecyclerView` parent. If the group is not in a `RecyclerView` then it will use a local pool.