### PR TITLE
ModelGroupHolder to get the pool from parent - another solution

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -98,7 +98,7 @@ public abstract class BaseEpoxyAdapter
   public EpoxyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
     EpoxyModel<?> model = viewTypeManager.getModelForViewType(this, viewType);
     View view = model.buildView(parent);
-    return new EpoxyViewHolder(view, model.shouldSaveViewState());
+    return new EpoxyViewHolder(parent, view, model.shouldSaveViewState());
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyHolder.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.view.View;
+import android.view.ViewParent;
 
 import androidx.annotation.NonNull;
 
@@ -9,6 +10,14 @@ import androidx.annotation.NonNull;
  * pattern when binding to a model.
  */
 public abstract class EpoxyHolder {
+
+  public EpoxyHolder(@NonNull ViewParent parent) {
+    this();
+  }
+
+  public EpoxyHolder() {
+  }
+
   /**
    * Called when this holder is created, with the view that it should hold. You can use this
    * opportunity to find views by id, and do any other initialization you need. This is called only

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelGroup.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.view.View;
+import android.view.ViewParent;
 import android.view.ViewStub;
 
 import java.util.ArrayList;
@@ -275,8 +276,8 @@ public class EpoxyModelGroup extends EpoxyModelWithHolder<ModelGroupHolder> {
   }
 
   @Override
-  protected final ModelGroupHolder createNewHolder() {
-    return new ModelGroupHolder();
+  protected final ModelGroupHolder createNewHolder(@NonNull ViewParent parent) {
+    return new ModelGroupHolder(parent);
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModelWithHolder.java
@@ -1,5 +1,7 @@
 package com.airbnb.epoxy;
 
+import android.view.ViewParent;
+
 import com.airbnb.epoxy.VisibilityState.Visibility;
 
 import java.util.List;
@@ -22,7 +24,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   }
 
   /** This should return a new instance of your {@link com.airbnb.epoxy.EpoxyHolder} class. */
-  protected abstract T createNewHolder();
+  protected abstract T createNewHolder(@NonNull ViewParent parent);
 
   @Override
   public void bind(@NonNull T holder) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -20,6 +20,8 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
   private List<Object> payloads;
   private EpoxyHolder epoxyHolder;
   @Nullable ViewHolderState.ViewState initialViewState;
+
+  // Once the EpoxyHolder is created parent will be set to null.
   private ViewParent parent;
 
   public EpoxyViewHolder(ViewParent parent, View view, boolean saveInitialState) {
@@ -48,6 +50,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     if (epoxyHolder == null && model instanceof EpoxyModelWithHolder) {
       epoxyHolder = ((EpoxyModelWithHolder) model).createNewHolder(parent);
       epoxyHolder.bindView(itemView);
+      parent = null;
     }
 
     if (model instanceof GeneratedModel) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy;
 
 import android.view.View;
+import android.view.ViewParent;
 
 import com.airbnb.epoxy.ViewHolderState.ViewState;
 import com.airbnb.epoxy.VisibilityState.Visibility;
@@ -19,10 +20,12 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
   private List<Object> payloads;
   private EpoxyHolder epoxyHolder;
   @Nullable ViewHolderState.ViewState initialViewState;
+  private ViewParent parent;
 
-  public EpoxyViewHolder(View view, boolean saveInitialState) {
+  public EpoxyViewHolder(ViewParent parent, View view, boolean saveInitialState) {
     super(view);
 
+    this.parent = parent;
     if (saveInitialState) {
       // We save the initial state of the view when it is created so that we can reset this initial
       // state before a model is bound for the first time. Otherwise the view may carry over
@@ -43,7 +46,7 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     this.payloads = payloads;
 
     if (epoxyHolder == null && model instanceof EpoxyModelWithHolder) {
-      epoxyHolder = ((EpoxyModelWithHolder) model).createNewHolder();
+      epoxyHolder = ((EpoxyModelWithHolder) model).createNewHolder(parent);
       epoxyHolder.bindView(itemView);
     }
 

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -50,8 +50,9 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     if (epoxyHolder == null && model instanceof EpoxyModelWithHolder) {
       epoxyHolder = ((EpoxyModelWithHolder) model).createNewHolder(parent);
       epoxyHolder.bindView(itemView);
-      parent = null;
     }
+    // Safe to set to null as it is only used for createNewHolder method
+    parent = null;
 
     if (model instanceof GeneratedModel) {
       // The generated method will enforce that only a properly typed listener can be set

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
@@ -235,7 +235,7 @@ private class HelperAdapter : RecyclerView.Adapter<EpoxyViewHolder>() {
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EpoxyViewHolder {
-        return EpoxyViewHolder(model!!.buildView(parent), model!!.shouldSaveViewState())
+        return EpoxyViewHolder(parent, model!!.buildView(parent), model!!.shouldSaveViewState())
     }
 
     override fun onBindViewHolder(holder: EpoxyViewHolder, position: Int) {

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyModelGroupTest.kt
@@ -42,7 +42,8 @@ class EpoxyModelGroupTest(val useViewStubs: Boolean) {
 
     private fun bind(modelGroup: EpoxyModelGroup, previousGroup: EpoxyModelGroup? = null) {
         if (topLevelHolder == null) {
-            topLevelHolder = EpoxyViewHolder(modelGroup.buildView(recyclerView), false)
+            topLevelHolder =
+                EpoxyViewHolder(recyclerView, modelGroup.buildView(recyclerView), false)
         }
         topLevelHolder!!.bind(modelGroup, previousGroup, emptyList(), 0)
     }

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/UnboundedViewPoolTests.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/UnboundedViewPoolTests.kt
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy
 
+import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.recyclerview.widget.RecyclerView
@@ -61,7 +62,7 @@ class UnboundedViewPoolTests {
      */
     private class RvAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
-            EpoxyViewHolder(parent, false)
+            EpoxyViewHolder(parent, View(parent.context), false)
 
         override fun getItemCount() = 0
 

--- a/epoxy-databinding/src/main/java/com/airbnb/epoxy/DataBindingEpoxyModel.java
+++ b/epoxy-databinding/src/main/java/com/airbnb/epoxy/DataBindingEpoxyModel.java
@@ -3,6 +3,7 @@ package com.airbnb.epoxy;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 
 import com.airbnb.epoxy.DataBindingEpoxyModel.DataBindingHolder;
 
@@ -95,7 +96,7 @@ public abstract class DataBindingEpoxyModel extends EpoxyModelWithHolder<DataBin
   }
 
   @Override
-  protected final DataBindingHolder createNewHolder() {
+  protected final DataBindingHolder createNewHolder(@NonNull ViewParent parent) {
     return new DataBindingHolder();
   }
 

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelGroupRecyclingTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelGroupRecyclingTest.kt
@@ -1,0 +1,154 @@
+package com.airbnb.epoxy
+
+import android.content.Context
+import android.os.Looper
+import android.widget.FrameLayout
+import android.widget.FrameLayout.LayoutParams
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.runner.AndroidJUnit4
+import com.airbnb.epoxy.integrationtest.R
+import com.airbnb.epoxy.integrationtest.TestActivity
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+/**
+ * Tests view pool of [EpoxyModelGroup] within [EpoxyRecyclerView].
+ */
+@Config(sdk = [21], qualifiers = "h831dp-mdpi")
+@RunWith(AndroidJUnit4::class)
+class EpoxyModelGroupRecyclingTest {
+
+    @get:Rule
+    var activityRule = activityScenarioRule<TestActivity>()
+
+    private lateinit var recyclerView1: EpoxyRecyclerView
+
+    private lateinit var recyclerView2: EpoxyRecyclerView
+
+    /**
+     * Verify that the groups inherit of the view pool configuration from the parent recycler view.
+     * Pool is shared within the context.
+     */
+    @Test
+    fun testModelGroupPool_shared() {
+
+        setupRecyclerView(shareViewPoolAcrossContext = true)
+        Assert.assertSame(recyclerView1.recycledViewPool, recyclerView2.recycledViewPool)
+
+        var modelsBound = 0
+        val assertOnModelBound: (EpoxyModelGroup, ModelGroupHolder, Int) -> Unit = { _, view, _ ->
+            modelsBound++
+            Assert.assertSame(recyclerView1.recycledViewPool, view.viewPool)
+        }
+        withModels(
+            buildModels1 = {
+                group {
+                    id("1")
+                    layout(R.layout.vertical_linear_group)
+                    onBind(assertOnModelBound)
+                }
+            },
+            buildModels2 = {
+                group {
+                    layout(R.layout.vertical_linear_group)
+                    id("2")
+                    onBind(assertOnModelBound)
+                }
+            }
+        )
+        Assert.assertEquals(2, modelsBound)
+    }
+
+    /**
+     * Verify that the groups inherit of the view pool configuration from the parent recycler view.
+     * Pool is not shared within the context.
+     */
+    @Test
+    fun testModelGroupPool_notShared() {
+
+        setupRecyclerView(shareViewPoolAcrossContext = false)
+        Assert.assertNotEquals(recyclerView1.recycledViewPool, recyclerView2.recycledViewPool)
+
+        var modelsBound = 0
+        val assertOnModelBound1: (EpoxyModelGroup, ModelGroupHolder, Int) -> Unit = { _, view, _ ->
+            modelsBound++
+            Assert.assertSame(recyclerView1.recycledViewPool, view.viewPool)
+        }
+        val assertOnModelBound2: (EpoxyModelGroup, ModelGroupHolder, Int) -> Unit = { _, view, _ ->
+            modelsBound++
+            Assert.assertSame(recyclerView2.recycledViewPool, view.viewPool)
+        }
+        withModels(
+            buildModels1 = {
+                group {
+                    id("1")
+                    layout(R.layout.vertical_linear_group)
+                    onBind(assertOnModelBound1)
+                }
+            },
+            buildModels2 = {
+                group {
+                    layout(R.layout.vertical_linear_group)
+                    id("2")
+                    onBind(assertOnModelBound2)
+                }
+            }
+        )
+        Assert.assertEquals("2 models should have been bound", 2, modelsBound)
+    }
+
+    /** Sets the models in the [recyclerView1] and [recyclerView2]. */
+    private fun setupRecyclerView(
+        shareViewPoolAcrossContext: Boolean
+    ) {
+        activityRule.scenario.onActivity {
+            if (shareViewPoolAcrossContext) {
+                recyclerView1 = EpoxyRecyclerView(it)
+                recyclerView2 = EpoxyRecyclerView(it)
+            } else {
+                recyclerView1 = NonSharedEpoxyRecyclerView(it)
+                recyclerView2 = NonSharedEpoxyRecyclerView(it)
+            }
+            it.setContentView(
+                FrameLayout(it).apply {
+                    addView(
+                        recyclerView1,
+                        LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+                    )
+                    addView(
+                        recyclerView2,
+                        LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+                    )
+                }
+            )
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
+    }
+
+    /** Sets the models in the [recyclerView1] and [recyclerView2]. */
+    private fun withModels(
+        buildModels1: EpoxyController.() -> Unit,
+        buildModels2: EpoxyController.() -> Unit
+    ) {
+        activityRule.scenario.onActivity {
+            recyclerView1.withModels {
+                buildModels1.invoke(this)
+            }
+            recyclerView2.withModels {
+                buildModels2.invoke(this)
+            }
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
+    }
+
+    private class NonSharedEpoxyRecyclerView(
+        context: Context
+    ) : EpoxyRecyclerView(context) {
+
+        override fun shouldShareViewPoolAcrossContext() = false
+    }
+}

--- a/epoxy-preloadersample/src/main/java/com/airbnb/epoxy/preloadersample/ImageModel.kt
+++ b/epoxy-preloadersample/src/main/java/com/airbnb/epoxy/preloadersample/ImageModel.kt
@@ -1,5 +1,7 @@
 package com.airbnb.epoxy.preloadersample
 
+import android.view.View
+import android.view.ViewParent
 import android.widget.ImageView
 import android.widget.TextView
 import com.airbnb.epoxy.EpoxyAttribute
@@ -30,9 +32,9 @@ abstract class ImageModel : EpoxyModelWithHolder<ImageHolder>() {
     }
 }
 
-class ImageHolder : KotlinHolder(), Preloadable {
+class ImageHolder(parent: ViewParent) : KotlinHolder(), Preloadable {
     val image by bind<ImageView>(R.id.image_view)
     val text by bind<TextView>(R.id.text_view)
-    val glide by lazy { Glide.with(image.context) }
+    val glide = Glide.with((parent as View).context)
     override val viewsToPreload by lazy { listOf(image) }
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -1102,10 +1102,15 @@ class GeneratedModelWriter(
             return
         }
 
-        createHolderMethod = createHolderMethod.toBuilder()
-            .returns(modelClassInfo.modelType)
-            .addStatement("return new \$T()", modelClassInfo.modelType)
-            .build()
+        createHolderMethod = with(createHolderMethod.toBuilder()) {
+            returns(modelClassInfo.modelType)
+//            if (modelClassInfo.modelType.hasViewParentConstructor()) { TODO implements
+//                addStatement("return new \$T(parent)", modelClassInfo.modelType)
+//            } else {
+                addStatement("return new \$T()", modelClassInfo.modelType)
+//            }
+            build()
+        }
 
         methods.add(createHolderMethod)
     }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -1092,6 +1092,10 @@ class GeneratedModelWriter(
         )
             .addAnnotation(Override::class.java)
             .addModifiers(Modifier.PROTECTED)
+            .addParameter(
+                ClassName.get("android.view", "ViewParent"),
+                "parent"
+            )
             .build()
 
         if (implementsMethod(originalClassElement, createHolderMethod, types, elements)) {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -1076,6 +1076,8 @@ class GeneratedModelWriter(
     /**
      * If the model is a holder and doesn't implement the "createNewHolder" method we can generate a
      * default implementation by getting the class type and creating a new instance of it.
+     *
+     * If the holder class have a constructor that accept the parent it will invoke it.
      */
     private fun addCreateHolderMethodIfNeeded(
         modelClassInfo: GeneratedModelInfo,
@@ -1104,11 +1106,14 @@ class GeneratedModelWriter(
 
         createHolderMethod = with(createHolderMethod.toBuilder()) {
             returns(modelClassInfo.modelType)
-//            if (modelClassInfo.modelType.hasViewParentConstructor()) { TODO implements
-//                addStatement("return new \$T(parent)", modelClassInfo.modelType)
-//            } else {
+            val modelTypeElement = (modelClassInfo.modelType as? ClassName)?.asTypeElement(elements)
+            if (modelTypeElement != null &&
+                modelClassInfo.memoizer.hasViewParentConstructor(modelTypeElement)
+            ) {
+                addStatement("return new \$T(parent)", modelClassInfo.modelType)
+            } else {
                 addStatement("return new \$T()", modelClassInfo.modelType)
-//            }
+            }
             build()
         }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/Memoizer.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/Memoizer.kt
@@ -13,6 +13,7 @@ import com.airbnb.epoxy.TextProp
 import com.airbnb.epoxy.processor.GeneratedModelInfo.Companion.RESET_METHOD
 import com.airbnb.epoxy.processor.GeneratedModelInfo.Companion.buildParamSpecs
 import com.airbnb.epoxy.processor.Utils.isSubtype
+import com.squareup.javapoet.ClassName
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
@@ -369,6 +370,17 @@ class Memoizer(
                     // Also check the class hierarchy
                     implementsModelCollector(superClassElement)
                 } ?: false
+            }
+        }
+    }
+
+    private val hasViewParentConstructorMap = mutableMapOf<Name, Boolean>()
+    fun hasViewParentConstructor(classElement: TypeElement): Boolean {
+        return synchronized(typeMap) {
+            hasViewParentConstructorMap.getOrPut(classElement.qualifiedName) {
+                getClassConstructors(classElement).filter {
+                    it.params.size == 1 && it.params[0].type == ClassName.get("android.view", "ViewParent")
+                }.isNotEmpty()
             }
         }
     }

--- a/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
+++ b/epoxy-processortest/src/test/resources/AbstractModelWithHolder_.java
@@ -1,5 +1,6 @@
 package com.airbnb.epoxy;
 
+import android.view.ViewParent;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.Nullable;
 import java.lang.CharSequence;
@@ -201,7 +202,7 @@ public class AbstractModelWithHolder_ extends AbstractModelWithHolder implements
   }
 
   @Override
-  protected AbstractModelWithHolder.Holder createNewHolder() {
+  protected AbstractModelWithHolder.Holder createNewHolder(ViewParent parent) {
     return new AbstractModelWithHolder.Holder();
   }
 

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/helpers/ViewBindingEpoxyModelWithHolder.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/helpers/ViewBindingEpoxyModelWithHolder.kt
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy.kotlinsample.helpers
 
 import android.view.View
+import android.view.ViewParent
 import androidx.viewbinding.ViewBinding
 import com.airbnb.epoxy.EpoxyHolder
 import com.airbnb.epoxy.EpoxyModelWithHolder
@@ -18,7 +19,7 @@ abstract class ViewBindingEpoxyModelWithHolder<in T : ViewBinding> :
 
     abstract fun T.bind()
 
-    override fun createNewHolder(): ViewBindingHolder {
+    override fun createNewHolder(parent: ViewParent): ViewBindingHolder {
         return ViewBindingHolder(this::class.java)
     }
 }


### PR DESCRIPTION
Fix for #1094

This change remove PoolReference from ModelGroupHolder. Instead it just need a RecyclerView.RecycledViewPool.
`ModelGroupHolder` will find the pool from the `ViewParent` passed in constructor. 

- `EpoxyModelWithHolder` updated to add the `parent` in `createNewHolder`.
- `ModelGroupHolder` will use the `parent` to retrieve a view pool.
- `EpoxyHolder` have 2 constructors, one empty, one with the parent (to prevent painful breaking change). The code generation will invoke the constructor with parent if it exists.
- As an example, I updated the `ImageModel.ImageHolder` in sample app. If we have the parent we don't need `by lazy` to initialize glide (03e0e4a).
- With unit test

The change have changed in generated code. I plan to update the processor unit tests after the code review to prevent noise in diff.

There is one more change I want to address but it can go in a separate pull request which is related to `Carousel`. I think a carousel should always get the view pool from parent. Currently it get it from the logic we have in `EpoxyRecyclerView`. If the share pool across context is false we would have really inefficient pooling on nested lists (unfortunately Hilt force us to set it to false).

@elihart this is the solution you proposed #1095 which I think it cleaner too.