### PR TITLE
[proposal] linking the view pool to activities to lifecycle owner

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyRecyclerView.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyRecyclerView.kt
@@ -248,7 +248,7 @@ open class EpoxyRecyclerView @JvmOverloads constructor(
         }
 
         setRecycledViewPool(
-            ACTIVITY_RECYCLER_POOL.getPool(
+            LIFECYCLE_OWNER_RECYCLER_POOL.getPool(
                 context
             ) { createViewPool() }.viewPool
         )
@@ -627,7 +627,7 @@ open class EpoxyRecyclerView @JvmOverloads constructor(
         // Views in the pool hold context references which can keep the activity from being GC'd,
         // plus they can hold significant memory resources. We should clear it asap after the pool
         // is no longer needed - the main signal we use for this is that the activity is destroyed.
-        if (context.isActivityDestroyed()) {
+        if (context.isLifecycleDestroyed()) {
             recycledViewPool.clear()
         }
     }
@@ -636,9 +636,9 @@ open class EpoxyRecyclerView @JvmOverloads constructor(
         private const val DEFAULT_ADAPTER_REMOVAL_DELAY_MS = 2000
 
         /**
-         * Store one unique pool per activity. They are cleared out when activities are destroyed, so this
-         * only needs to hold pools for active activities.
+         * Store one unique pool per [androidx.lifecycle.LifecycleOwner]. They are cleared out when
+         * lifecycles is destroyed, so this only needs to hold pools for active lifecycles.
          */
-        private val ACTIVITY_RECYCLER_POOL = ActivityRecyclerPool()
+        private val LIFECYCLE_OWNER_RECYCLER_POOL = LifecycleOwnerRecyclerPool()
     }
 }


### PR DESCRIPTION
This is a proposal and will require an update to Hilt, see https://github.com/google/dagger/issues/2202#issuecomment-735984477.

The idea of theses changes in to Epoxy and Hilt are to fix a memory leak. It happen because Epoxy link the view pool to the activity. However, when a view get inflated in a Hilt fragment, the view's context is a wrapper and hold a reference on the fragment. The fragment leak for the whole activity lifecycle.

So why Epoxy link the view pool arbitrary to the `Activity`? Instead, could we use the view's context and find the closest `LifecycleOwner`. When this lifecycle get destroyed we can clear the pool.

It is a proposal, happy to discuss here. Using the `LifecycleOwner` instead of `Activity` looks natural. Is it possible to use Epoxy outside of an `Activity` that is not a `LifecycleOwner`?