### PR TITLE
Fix ANR and view pool resolution in nested group

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.viewmodeladapter.R
 import java.util.ArrayList
 
-class ModelGroupHolder(parent: ViewParent) : EpoxyHolder() {
+class ModelGroupHolder(private val modelGroupParent: ViewParent) : EpoxyHolder() {
     val viewHolders = ArrayList<EpoxyViewHolder>(4)
 
     /** Use parent pool or create a local pool */
@@ -150,6 +150,7 @@ class ModelGroupHolder(parent: ViewParent) : EpoxyHolder() {
 
         return recycledView as? EpoxyViewHolder
             ?: HELPER_ADAPTER.createViewHolder(
+                modelGroupParent,
                 model,
                 parent,
                 viewType
@@ -251,16 +252,24 @@ private class LocalGroupRecycledViewPool : RecyclerView.RecycledViewPool()
 private class HelperAdapter : RecyclerView.Adapter<EpoxyViewHolder>() {
 
     private var model: EpoxyModel<*>? = null
+    private var modelGroupParent: ViewParent? = null
 
-    fun createViewHolder(model: EpoxyModel<*>, parent: ViewGroup, viewType: Int): EpoxyViewHolder {
+    fun createViewHolder(
+        modelGroupParent: ViewParent,
+        model: EpoxyModel<*>,
+        parent: ViewGroup,
+        viewType: Int
+    ): EpoxyViewHolder {
         this.model = model
+        this.modelGroupParent = modelGroupParent
         val viewHolder = createViewHolder(parent, viewType)
         this.model = null
+        this.modelGroupParent = null
         return viewHolder
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EpoxyViewHolder {
-        return EpoxyViewHolder(parent, model!!.buildView(parent), model!!.shouldSaveViewState())
+        return EpoxyViewHolder(modelGroupParent, model!!.buildView(parent), model!!.shouldSaveViewState())
     }
 
     override fun onBindViewHolder(holder: EpoxyViewHolder, position: Int) {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/ModelGroupHolder.kt
@@ -14,7 +14,7 @@ class ModelGroupHolder(parent: ViewParent) : EpoxyHolder() {
 
     /** Use parent pool or create a local pool */
     @VisibleForTesting
-    val viewPool = findViewPool(parent) ?: LocalGroupRecycledViewPool()
+    val viewPool = findViewPool(modelGroupParent)
 
     /**
      * Get the root view group (aka
@@ -185,7 +185,7 @@ class ModelGroupHolder(parent: ViewParent) : EpoxyHolder() {
 
         private val HELPER_ADAPTER = HelperAdapter()
 
-        private fun findViewPool(view: ViewParent): RecyclerView.RecycledViewPool? {
+        private fun findViewPool(view: ViewParent): RecyclerView.RecycledViewPool {
             var viewPool: RecyclerView.RecycledViewPool? = null
             while (viewPool == null) {
                 viewPool = if (view is RecyclerView) {
@@ -196,7 +196,7 @@ class ModelGroupHolder(parent: ViewParent) : EpoxyHolder() {
                         findViewPool(parent)
                     } else {
                         // This model group is is not in a RecyclerView
-                        null
+                        LocalGroupRecycledViewPool()
                     }
                 }
             }

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelGroupRecyclingTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyModelGroupRecyclingTest.kt
@@ -50,6 +50,18 @@ class EpoxyModelGroupRecyclingTest {
                     id("1")
                     layout(R.layout.vertical_linear_group)
                     onBind(assertOnModelBound)
+
+                    group {
+                        id("1.1")
+                        layout(R.layout.vertical_linear_group)
+                        onBind(assertOnModelBound)
+                    }
+
+                    group {
+                        id("1.1.1")
+                        layout(R.layout.vertical_linear_group)
+                        onBind(assertOnModelBound)
+                    }
                 }
             },
             buildModels2 = {
@@ -60,7 +72,7 @@ class EpoxyModelGroupRecyclingTest {
                 }
             }
         )
-        Assert.assertEquals(2, modelsBound)
+        Assert.assertEquals(4, modelsBound)
     }
 
     /**
@@ -88,6 +100,18 @@ class EpoxyModelGroupRecyclingTest {
                     id("1")
                     layout(R.layout.vertical_linear_group)
                     onBind(assertOnModelBound1)
+
+                    group {
+                        id("1.1")
+                        layout(R.layout.vertical_linear_group)
+                        onBind(assertOnModelBound1)
+
+                        group {
+                            id("1.1.1")
+                            layout(R.layout.vertical_linear_group)
+                            onBind(assertOnModelBound1)
+                        }
+                    }
                 }
             },
             buildModels2 = {
@@ -98,7 +122,7 @@ class EpoxyModelGroupRecyclingTest {
                 }
             }
         )
-        Assert.assertEquals("2 models should have been bound", 2, modelsBound)
+        Assert.assertEquals(4, modelsBound)
     }
 
     /** Sets the models in the [recyclerView1] and [recyclerView2]. */


### PR DESCRIPTION
Well, I completely forgot there was an infinite loop with a nested group with Epoxy 4.3.0. First, there is a bug in the `findViewPool` on the exit condition. If no parent found it would run on an infinite loop. Happen consistently with a nested group.

So the second fix is to make sure the nested group finds the right pool. I updated the `HelperAdapter` so it knows about the `ModelGroupHolder`'s parent. (the `parent` passed in the `HelperAdapter.createViewHolder` is not yet attached so `findViewPool` would not work as intended).

I added a nested group in the unit test coverage.