### PR TITLE
Update KotlinPoet to 1.7.2

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -33,7 +33,7 @@ rootProject.ext.ANDROID_DATA_BINDING = "1.3.1"
 rootProject.ext.ANDROID_ARCH_TESTING = "1.1.1"
 rootProject.ext.ANDROID_TEST_RUNNER = "1.0.2"
 rootProject.ext.SQUARE_JAVAPOET_VERSION = "1.11.1"
-rootProject.ext.SQUARE_KOTLINPOET_VERSION = "1.5.0"
+rootProject.ext.SQUARE_KOTLINPOET_VERSION = "1.7.2"
 rootProject.ext.KOTLIN_COROUTINES_VERSION = "1.3.9"
 rootProject.ext.GLIDE_VERSION = "4.9.0"
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/KotlinModelBuilderExtensionWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/KotlinModelBuilderExtensionWriter.kt
@@ -78,10 +78,6 @@ internal class KotlinModelBuilderExtensionWriter(
         val constructorIsNotPublic =
             constructor != null && Modifier.PUBLIC !in constructor.modifiers
 
-        // Kotlin cannot directly reference a class with a $ in the name. It must be wrapped in ticks (``)
-        val useTicksAroundModelName = model.generatedName.simpleName().contains("$")
-        val tick = if (useTicksAroundModelName) "`" else ""
-
         val initializerLambda = LambdaTypeName.get(
             receiver = getBuilderInterfaceTypeName(model).toKPoet(),
             returnType = KClassNames.KOTLIN_UNIT
@@ -112,7 +108,7 @@ internal class KotlinModelBuilderExtensionWriter(
 
             addStatement("add(")
             beginControlFlow(
-                "$tick%T$tick(${params.joinToString(", ") { it.name }}).apply",
+                "%T(${params.joinToString(", ") { it.name }}).apply",
                 modelClass
             )
             addStatement("modelInitializer()")


### PR DESCRIPTION
I recently ran into some strange issues with conflicting KotlinPoet versions between Epoxy and Moshi; updating KotlinPoet version in Epoxy fixes the problem. Additionally, in KotlinPoet 1.6.0, the issue with not escaping class name that contains `$` has been fixed.