### PR TITLE
Release 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# 4.4.0 (Feb 18, 2021)
+# 4.4.1 (Feb 22, 2021)
 - Support for Paging3 (#1126) (Thanks to @osipxd and @anhanh11001!)
 - Update KotlinPoet to 1.7.2 (#1117)
+
+# 4.4.0 (Feb 18, 2021)
+Bad release, don't use
 
 # 4.3.1 (Dec 2, 2020)
 - Fix ANR and view pool resolution in nested group (#1101)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.4.0 (Feb 18, 2021)
 - Support for Paging3 (#1126) (Thanks to @osipxd and @anhanh11001!)
--Update KotlinPoet to 1.7.2 (#1117)
+- Update KotlinPoet to 1.7.2 (#1117)
 
 # 4.3.1 (Dec 2, 2020)
 - Fix ANR and view pool resolution in nested group (#1101)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.4.0
+VERSION_NAME=4.4.1
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
4.4.0 (https://github.com/airbnb/epoxy/pull/1136) didn't actually include the paging update due to a mistake. This is the proper release.