### PR TITLE
Updated the package name of generated model files for interface class

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -58,7 +58,8 @@ class GeneratedModelWriter(
     asyncable: Asyncable
 ) {
 
-    val modelInterfaceWriter = ModelBuilderInterfaceWriter(filer, types, asyncable)
+    val modelInterfaceWriter = ModelBuilderInterfaceWriter(filer, types, asyncable, configManager,
+        elements)
 
     open class BuilderHooks {
         open fun beforeFinalBuild(builder: TypeSpec.Builder) {}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -58,8 +58,8 @@ class GeneratedModelWriter(
     asyncable: Asyncable
 ) {
 
-    val modelInterfaceWriter = ModelBuilderInterfaceWriter(filer, types, asyncable, configManager,
-        elements)
+    val modelInterfaceWriter =
+        ModelBuilderInterfaceWriter(filer, types, asyncable, configManager, elements)
 
     open class BuilderHooks {
         open fun beforeFinalBuild(builder: TypeSpec.Builder) {}

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
@@ -159,7 +159,7 @@ class ModelBuilderInterfaceWriter(
                 }
             }
 
-            val implementingViewTpeElement = details.implementingViews.firstOrNull()
+            val implementingViewTypeElement = details.implementingViews.firstOrNull()
             val packageName = implementingViewTpeElement?.let {
                 configManager.getModelViewConfig(it)?.rClass?.packageName()
             } ?: interfaceName.packageName()

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
@@ -160,7 +160,7 @@ class ModelBuilderInterfaceWriter(
             }
 
             val implementingViewTypeElement = details.implementingViews.firstOrNull()
-            val packageName = implementingViewTpeElement?.let {
+            val packageName = implementingViewTypeElement?.let {
                 configManager.getModelViewConfig(it)?.rClass?.packageName()
             } ?: interfaceName.packageName()
             JavaFile.builder(packageName, interfaceSpec)


### PR DESCRIPTION
This change was needed because of an issue I started noticing when I wanted to modularize our repo. Let's look at an example to understand the problem a bit more. Consider the following example - 

```kotlin

// Module A

@ModelView
class A: C {
    @Override
    @TextProp
    fun setSomething(str: String){}
}

// Module B

@ModelView
class B: C {
    @Override
    @TextProp
    fun setSomething(str: String){}
}

// Module C

interface C {
    fun setSomething(str: String)
}

```

With a setup like this, Epoxy generates model classes for `C` interface in both `Module A` and `Module B`. In addition, the package used for the generated class is the original package of the interface. As a result CI fails due to an error of the following nature - 

```
Type CModel_ is defined multiple times: module_A_Path/.transforms/454c4635b2207bebc964d1c1d9732022/transformed/classes/classes.dex, module_B_Path/.transforms/fe9e902fb5a130a5f8099b602342c7ea/transformed/classes/classes.dex
```

In order to fix this, I update the package name that's used for the generated interface model classes to be the package of the module its being generated in. This helps in avoiding the duplication issue as the package names help in differentiating the two classes. 
