### PR TITLE
Provide support for snapshot() function in PagingDataEpoxyController

### DIFF
--- a/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedDataModelCache.kt
+++ b/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedDataModelCache.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.paging.AsyncPagingDataDiffer
 import androidx.paging.CombinedLoadStates
+import androidx.paging.ItemSnapshotList
 import androidx.paging.PagingData
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListUpdateCallback
@@ -178,6 +179,10 @@ internal class PagedDataModelCache<T : Any>(
 
     fun removeLoadStateListener(listener: (CombinedLoadStates) -> Unit) {
         asyncDiffer.removeLoadStateListener(listener)
+    }
+
+    fun snapshot(): ItemSnapshotList<T> {
+        return asyncDiffer.snapshot()
     }
 
     @Synchronized

--- a/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagingDataEpoxyController.kt
+++ b/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagingDataEpoxyController.kt
@@ -3,6 +3,7 @@ package com.airbnb.epoxy.paging3
 import android.annotation.SuppressLint
 import android.os.Handler
 import androidx.paging.CombinedLoadStates
+import androidx.paging.ItemSnapshotList
 import androidx.paging.LoadState
 import androidx.paging.LoadType
 import androidx.paging.LoadType.REFRESH
@@ -144,6 +145,14 @@ abstract class PagingDataEpoxyController<T : Any>(
      */
     fun removeLoadStateListener(listener: (CombinedLoadStates) -> Unit) {
         modelCache.removeLoadStateListener(listener)
+    }
+
+    /**
+     * Returns a new [ItemSnapshotList] representing the currently presented items, including any
+     * placeholders if they are enabled.
+     */
+    fun snapshot(): ItemSnapshotList<T> {
+        return modelCache.snapshot()
     }
 
     companion object {


### PR DESCRIPTION
The seems to be the only function in `paging3` lib I can find to provide access to all loaded data. I think it's useful.

A use case can be that as a developer, I want to track all of the IDs of the loaded posts in a screen, then this one can be used.