### PR TITLE
EpoxyViewBinder update - add epoxyView / optionalEpoxyView to ViewGroup

### DIFF
--- a/epoxy-viewbinder/src/main/java/com/airbnb/epoxy/EpoxyViewBinder.kt
+++ b/epoxy-viewbinder/src/main/java/com/airbnb/epoxy/EpoxyViewBinder.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.IdRes
-import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ComponentActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.children
 import androidx.core.view.isVisible
@@ -220,7 +220,7 @@ internal var View.viewHolder: EpoxyViewHolder?
  *
  * @param viewId resource ID for the view to replace. This should be an [EpoxyViewStub].
  */
-fun AppCompatActivity.epoxyView(
+fun ComponentActivity.epoxyView(
     @IdRes viewId: Int,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
     modelProvider: EpoxyController.() -> Unit,
@@ -264,7 +264,7 @@ fun ViewGroup.epoxyView(
  *
  * @param viewId resource ID for the view to replace. This should be an [EpoxyViewStub].
  */
-fun AppCompatActivity.optionalEpoxyView(
+fun ComponentActivity.optionalEpoxyView(
     @IdRes viewId: Int,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit = { },
     modelProvider: EpoxyController.() -> Unit,
@@ -320,7 +320,7 @@ fun ViewGroup.optionalEpoxyView(
     return@lazy epoxyViewInternal(viewId, initializer, modelProvider, useVisibilityTracking)
 }
 
-private fun AppCompatActivity.epoxyViewInternal(
+private fun ComponentActivity.epoxyViewInternal(
     @IdRes viewId: Int,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
     modelProvider: EpoxyController.() -> Unit,

--- a/epoxy-viewbinder/src/main/java/com/airbnb/epoxy/EpoxyViewBinder.kt
+++ b/epoxy-viewbinder/src/main/java/com/airbnb/epoxy/EpoxyViewBinder.kt
@@ -258,6 +258,26 @@ fun AppCompatActivity.epoxyView(
 /**
  * Shortcut for creating a [LifecycleAwareEpoxyViewBinder] in a lazy way.
  *
+ * @param viewId resource ID for the view to replace. This should be an [EpoxyViewStub].
+ */
+fun ViewGroup.epoxyView(
+    @IdRes viewId: Int,
+    initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
+    modelProvider: EpoxyController.() -> Unit,
+    useVisibilityTracking: Boolean = false
+) = lazy {
+    return@lazy LifecycleAwareEpoxyViewBinder(
+        (this.context as? LifecycleOwner) ?: error("LifecycleOwner required as view's context "),
+        { this },
+        viewId,
+        modelProvider,
+        useVisibilityTracking = useVisibilityTracking
+    ).apply(initializer)
+}
+
+/**
+ * Shortcut for creating a [LifecycleAwareEpoxyViewBinder] in a lazy way.
+ *
  * If the returned view binder is null it means that the view could not be found.
  *
  * @param viewId resource ID for the view to replace. This should be an [EpoxyViewStub].


### PR DESCRIPTION
We have use case where the activity or the fragment is unaware of what model we want to bind, in this case we want to bind the model from any view (`ViewGroup` actually).

This PR also add `optionalEpoxyView` to activity.