### PR TITLE
Fix generated code consistency in builder interfaces

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
@@ -150,6 +150,10 @@ class ModelBuilderInterfaceWriter(
                             returns(interfaceName)
                         }
                     }
+                        // For cache consistency of generated files make sure these are sorted.
+                        // Methods may have the same name due to overloads, so also sorting by
+                        // hashcode.
+                        .sortedWith(compareBy({ it.name }, { it.hashCode() }))
                 )
 
                 details.implementingViews.forEach {


### PR DESCRIPTION
The generated files of the builder interfaces could be different across builds because of methods being generated in different orders. This can lead to different cache keys and cache misses.