### PR TITLE
Release 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.5.0 (April 13, 2021)
+- Fix generated code consistency in builder interfaces (#1166)
+- Provided support to invalidate `modelCache` in `PagingDataEpoxyController` (#1161)
+- Explicitly add public modifier (#1162)
+- Unwrap context to find parent activity in order to share viewpool when using Hilt (#1157)
+
 # 4.4.4 (Mar 24, 2021)
 - Provide support for snapshot() function in PagingDataEpoxyController (#1144)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,31 +1,33 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-  ext.KOTLIN_VERSION = "1.4.30"
-  ext.ANDROID_PLUGIN_VERSION = '4.1.2'
+  ext.KOTLIN_VERSION = "1.4.32"
+  ext.ANDROID_PLUGIN_VERSION = '4.1.3'
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "com.android.tools.build:gradle:$ANDROID_PLUGIN_VERSION"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     // Upload with:
     // ./gradlew clean uploadArchives --no-daemon --no-parallel
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.12.0'
+    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
+    // Dokka is needed on classpath for vanniktech publish plugin
+    classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
   }
 }
 
 plugins {
-  id 'com.github.ben-manes.versions' version '0.28.0'
+  id 'com.github.ben-manes.versions' version '0.38.0'
 }
 
 allprojects {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   // Prevent javadoc task complaining about errors with kotlin files

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
   repositories {
     google()
     mavenCentral()
+    jcenter()
   }
   dependencies {
     classpath "com.android.tools.build:gradle:$ANDROID_PLUGIN_VERSION"
@@ -28,6 +29,7 @@ allprojects {
   repositories {
     google()
     mavenCentral()
+    jcenter()
   }
 
   // Prevent javadoc task complaining about errors with kotlin files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.4.4
+VERSION_NAME=4.5.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy
@@ -18,5 +18,6 @@ android.enableJetifier=false
 
 android.databinding.incremental=true
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# Dokka fails without a larger metaspace https://github.com/Kotlin/dokka/issues/1405
+org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1g
 kapt.includeCompileClasspath=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -1,5 +1,5 @@
 repositories {
-  jcenter()
+  mavenCentral()
 }
 
 configurations {
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-  ktlint "com.pinterest:ktlint:0.40.0"
+  ktlint "com.pinterest:ktlint:0.41.0"
   // additional 3rd party ruleset(s) can be specified here
   // just add them to the classpath (e.g. ktlint 'groupId:artifactId:version') and
   // ktlint will pick them up


### PR DESCRIPTION
# 4.5.0 (April 13, 2021)
- Fix generated code consistency in builder interfaces (#1166)
- Provided support to invalidate `modelCache` in `PagingDataEpoxyController` (#1161)
- Explicitly add public modifier (#1162)
- Unwrap context to find parent activity in order to share viewpool when using Hilt (#1157)