### PR TITLE
[View Binder] Add visibility tracker tests and API tweaks

### DIFF
--- a/epoxy-integrationtest/build.gradle
+++ b/epoxy-integrationtest/build.gradle
@@ -42,6 +42,7 @@ android {
 
 dependencies {
   implementation rootProject.deps.kotlin
+  implementation rootProject.deps.androidAppcompat
   implementation rootProject.deps.androidRecyclerView
   implementation rootProject.deps.androidPagingComponent
   implementation project(':epoxy-adapter')
@@ -52,7 +53,6 @@ dependencies {
 
   kapt project(':epoxy-processor')
 
-  testImplementation rootProject.deps.androidAppcompat
   testImplementation rootProject.deps.robolectric
   testImplementation rootProject.deps.junit
   testImplementation rootProject.deps.mockito

--- a/epoxy-integrationtest/build.gradle
+++ b/epoxy-integrationtest/build.gradle
@@ -48,9 +48,11 @@ dependencies {
   implementation project(':epoxy-annotations')
   implementation project(':epoxy-databinding')
   implementation project(':epoxy-paging')
+  implementation project(':epoxy-viewbinder')
 
   kapt project(':epoxy-processor')
 
+  testImplementation rootProject.deps.androidAppcompat
   testImplementation rootProject.deps.robolectric
   testImplementation rootProject.deps.junit
   testImplementation rootProject.deps.mockito

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/TestActivity.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/TestActivity.kt
@@ -1,8 +1,8 @@
 package com.airbnb.epoxy.integrationtest
 
-import android.app.Activity
+import androidx.core.app.ComponentActivity
 
 /**
  * Empty activity used for view testing.
  */
-class TestActivity : Activity()
+class TestActivity : ComponentActivity()

--- a/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/TestActivity.kt
+++ b/epoxy-integrationtest/src/main/java/com/airbnb/epoxy/integrationtest/TestActivity.kt
@@ -1,8 +1,8 @@
 package com.airbnb.epoxy.integrationtest
 
-import androidx.core.app.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 
 /**
  * Empty activity used for view testing.
  */
-class TestActivity : ComponentActivity()
+class TestActivity : AppCompatActivity()

--- a/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyViewBinderVisibilityTrackerTest.kt
+++ b/epoxy-integrationtest/src/test/java/com/airbnb/epoxy/EpoxyViewBinderVisibilityTrackerTest.kt
@@ -1,0 +1,742 @@
+package com.airbnb.epoxy
+
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.Space
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.runner.AndroidJUnit4
+import com.airbnb.epoxy.integrationtest.R
+import com.airbnb.epoxy.integrationtest.TestActivity
+import com.airbnb.epoxy.models.TrackerTestModel
+import com.airbnb.epoxy.models.trackerTestModel
+import com.airbnb.epoxy.models.trackerTestModelGroup
+import com.airbnb.epoxy.utils.VisibilityAssertHelper
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.math.roundToInt
+
+@Config(qualifiers = "h831dp-mdpi")
+@RunWith(AndroidJUnit4::class)
+class EpoxyViewBinderVisibilityTrackerTest {
+
+    @get:Rule
+    var activityRule = activityScenarioRule<TestActivity>()
+
+    private lateinit var linearLayout: LinearLayout
+    private lateinit var scrollView: ScrollView
+    private val scrollViewId = View.generateViewId()
+    private var ids = 0
+
+    @Before
+    fun setUp() {
+        activityRule.scenario.onActivity {
+            linearLayout = LinearLayout(it)
+            linearLayout.orientation = LinearLayout.VERTICAL
+            scrollView = ScrollView(it)
+            scrollView.addView(linearLayout)
+            scrollView.id = scrollViewId
+            it.setContentView(scrollView)
+            shadowOf(Looper.getMainLooper()).idle()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        ids = 0
+    }
+
+    @Test
+    fun testModelInitiallyVisible_full() {
+        activityRule.scenario.onActivity {
+            val helper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            it.withModel(itemHeight) {
+                trackerTestModel("model", itemHeight, helper = helper)
+            }
+
+            helper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testModelInitiallyVisible_partial() {
+        activityRule.scenario.onActivity {
+            val helper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            val spaceHeight = (itemHeight * 1.5).toInt()
+            it.addSpace(spaceHeight)
+            it.withModel(itemHeight) {
+                trackerTestModel("model", itemHeight, helper = helper)
+            }
+
+            helper.assert(
+                visibleHeight = scrollView.measuredHeight - spaceHeight,
+                percentVisibleHeight = (scrollView.measuredHeight - spaceHeight).toFloat() / itemHeight * 100,
+                visible = true,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testModelInitiallyVisible_partial_scrolledToBottom() {
+        activityRule.scenario.onActivity {
+            val helper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            val spaceHeight = (itemHeight * 1.5).toInt()
+            it.addSpace(spaceHeight)
+            it.withModel(itemHeight) {
+                trackerTestModel("model", itemHeight, helper = helper)
+            }
+
+            scrollView.scrollTo(0, spaceHeight - itemHeight)
+            shadowOf(Looper.getMainLooper()).idle()
+
+            // The binder currently doesn't get updates when scrolled so visibility remains the same prior to scrolling
+            helper.assert(
+                visibleHeight = scrollView.measuredHeight - spaceHeight,
+                percentVisibleHeight = (scrollView.measuredHeight - spaceHeight).toFloat() / itemHeight * 100,
+                visible = true,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testModelRemoved() {
+        activityRule.scenario.onActivity {
+            val helper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            var addModel = true
+            val binder = it.withModel(itemHeight) {
+                if (addModel) {
+                    trackerTestModel("model", itemHeight, helper = helper)
+                }
+            }
+
+            addModel = false
+            helper.reset()
+            binder.invalidate()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            helper.assert(
+                visibleHeight = 0,
+                percentVisibleHeight = 0f,
+                visible = false,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.INVISIBLE,
+                    VisibilityState.UNFOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_INVISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testModelAdded() {
+        activityRule.scenario.onActivity {
+            val helper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 3
+            var addModel = false
+            val binder = it.withModel(itemHeight) {
+                if (addModel) {
+                    trackerTestModel("model", itemHeight, helper = helper)
+                }
+            }
+
+            addModel = true
+            binder.invalidate()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            helper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testModelReplaced_notSupported() {
+        activityRule.scenario.onActivity {
+            val helper = nextAssertHelper()
+            val replacementHelper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 3
+            var useReplacement = false
+            val binder = it.withModel(itemHeight) {
+                if (useReplacement) {
+                    trackerTestModel("replacementModel", itemHeight, helper = replacementHelper)
+                } else {
+                    trackerTestModel("model", itemHeight, helper = helper)
+                }
+            }
+
+            useReplacement = true
+            helper.reset()
+            binder.invalidate()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            // Replacement of models that use the same view are not currently supported so there should be no changes
+            helper.assertDefault()
+            replacementHelper.assertDefault()
+        }
+    }
+
+    @Test
+    fun testModelReplaced_differentModel() {
+        activityRule.scenario.onActivity {
+            val helper = nextAssertHelper()
+            val replacementGroupHelper = nextAssertHelper()
+            val replacementNestedHelper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 3
+            var useReplacement = false
+            val binder = it.withModel(itemHeight) {
+                if (useReplacement) {
+                    trackerTestModelGroup("group", replacementGroupHelper) {
+                        layout(R.layout.view_holder_no_databinding)
+                        setModels(
+                            TrackerTestModel(
+                                "innerModel",
+                                itemHeight,
+                                helper = replacementNestedHelper
+                            )
+                        )
+                    }
+                } else {
+                    trackerTestModel("model", itemHeight, helper = helper)
+                }
+            }
+
+            useReplacement = true
+            helper.reset()
+            binder.invalidate()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            // Replacement of new models is only partially supported. The old model will not receive events but the new
+            // one will.
+            helper.assertDefault()
+
+            replacementGroupHelper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+            replacementNestedHelper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testModelGroup() {
+        activityRule.scenario.onActivity {
+            val groupHelper = nextAssertHelper()
+            val nestedHelper = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            it.withModel(itemHeight) {
+                trackerTestModelGroup("group", groupHelper) {
+                    layout(R.layout.view_holder_no_databinding)
+                    setModels(
+                        TrackerTestModel("innerModel", itemHeight, helper = nestedHelper)
+                    )
+                }
+            }
+
+            groupHelper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+            nestedHelper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testModelGroup_withCarousel() {
+        activityRule.scenario.onActivity {
+            val groupHelper = nextAssertHelper()
+            val helper1 = nextAssertHelper()
+            val helper2 = nextAssertHelper()
+            val helper3 = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            val itemWidth = (scrollView.measuredWidth / 1.5).roundToInt()
+            it.withModel(itemHeight) {
+                trackerTestModelGroup("group", groupHelper) {
+                    layout(R.layout.view_holder_no_databinding)
+                    setModels(
+                        CarouselModel_().apply {
+                            id("carousel")
+                            paddingDp(0)
+                            models(
+                                listOf(
+                                    TrackerTestModel(
+                                        "carouselItem1",
+                                        itemHeight = itemHeight,
+                                        itemWidth = itemWidth,
+                                        helper = helper1
+                                    ),
+                                    TrackerTestModel(
+                                        "carouselItem1",
+                                        itemHeight = itemHeight,
+                                        itemWidth = itemWidth,
+                                        helper = helper2
+                                    ),
+                                    TrackerTestModel(
+                                        "carouselItem1",
+                                        itemHeight = itemHeight,
+                                        itemWidth = itemWidth,
+                                        helper = helper3
+                                    )
+                                )
+                            )
+                        }
+                    )
+                }
+            }
+
+            groupHelper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+
+            helper1.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+
+            helper2.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth / 2,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = (scrollView.measuredWidth - itemWidth).toFloat() / itemWidth * 100,
+                visible = true,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE
+                )
+            )
+
+            helper3.assertDefault()
+        }
+    }
+
+    @Test
+    fun testModelGroup_withCarousel_scrolledToEnd() {
+        activityRule.scenario.onActivity {
+            val groupHelper = nextAssertHelper()
+            val helper1 = nextAssertHelper()
+            val helper2 = nextAssertHelper()
+            val helper3 = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            val itemWidth = (scrollView.measuredWidth / 1.5).roundToInt()
+            val binder = it.withModel(itemHeight) {
+                trackerTestModelGroup("group", groupHelper) {
+                    layout(R.layout.view_holder_no_databinding)
+                    setModels(
+                        CarouselModel_().apply {
+                            id("carousel")
+                            paddingDp(0)
+                            models(
+                                listOf(
+                                    TrackerTestModel(
+                                        "carouselItem1",
+                                        itemHeight = itemHeight,
+                                        itemWidth = itemWidth,
+                                        helper = helper1
+                                    ),
+                                    TrackerTestModel(
+                                        "carouselItem1",
+                                        itemHeight = itemHeight,
+                                        itemWidth = itemWidth,
+                                        helper = helper2
+                                    ),
+                                    TrackerTestModel(
+                                        "carouselItem1",
+                                        itemHeight = itemHeight,
+                                        itemWidth = itemWidth,
+                                        helper = helper3
+                                    )
+                                )
+                            )
+                        }
+                    )
+                }
+            }
+
+            // Scroll so last carousel model is fully visible
+            ((binder.view as ViewGroup).getChildAt(0) as RecyclerView)
+                .layoutManager!!
+                .scrollToPosition(2)
+            shadowOf(Looper.getMainLooper()).idle()
+
+            groupHelper.assert(
+                visibleHeight = itemHeight,
+                percentVisibleHeight = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+
+            helper1.assert(
+                visibleHeight = 0,
+                visibleWidth = 0,
+                percentVisibleHeight = 0f,
+                percentVisibleWidth = 0f,
+                visible = false,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE,
+                    VisibilityState.INVISIBLE,
+                    VisibilityState.UNFOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_INVISIBLE
+                )
+            )
+
+            helper2.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth / 2,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = (scrollView.measuredWidth - itemWidth).toFloat() / itemWidth * 100,
+                visible = true,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE
+                )
+            )
+
+            helper3.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testCarousel() {
+        activityRule.scenario.onActivity {
+            val helper1 = nextAssertHelper()
+            val helper2 = nextAssertHelper()
+            val helper3 = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            val itemWidth = (scrollView.measuredWidth / 1.5).roundToInt()
+            it.withModel(itemHeight) {
+                CarouselModel_().apply {
+                    id("carousel")
+                    paddingDp(0)
+                    models(
+                        listOf(
+                            TrackerTestModel(
+                                "carouselItem1",
+                                itemHeight = itemHeight,
+                                itemWidth = itemWidth,
+                                helper = helper1
+                            ),
+                            TrackerTestModel(
+                                "carouselItem1",
+                                itemHeight = itemHeight,
+                                itemWidth = itemWidth,
+                                helper = helper2
+                            ),
+                            TrackerTestModel(
+                                "carouselItem1",
+                                itemHeight = itemHeight,
+                                itemWidth = itemWidth,
+                                helper = helper3
+                            )
+                        )
+                    )
+                }.addTo(this)
+            }
+
+            helper1.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+
+            helper2.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth / 2,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = (scrollView.measuredWidth - itemWidth).toFloat() / itemWidth * 100,
+                visible = true,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE
+                )
+            )
+
+            helper3.assertDefault()
+        }
+    }
+
+    @Test
+    fun testCarousel_scrolledToEnd() {
+        activityRule.scenario.onActivity {
+            val helper1 = nextAssertHelper()
+            val helper2 = nextAssertHelper()
+            val helper3 = nextAssertHelper()
+            val itemHeight = scrollView.measuredHeight / 2
+            val itemWidth = (scrollView.measuredWidth / 1.5).roundToInt()
+            val binder = it.withModel(itemHeight) {
+                CarouselModel_().apply {
+                    id("carousel")
+                    paddingDp(0)
+                    models(
+                        listOf(
+                            TrackerTestModel(
+                                "carouselItem1",
+                                itemHeight = itemHeight,
+                                itemWidth = itemWidth,
+                                helper = helper1
+                            ),
+                            TrackerTestModel(
+                                "carouselItem1",
+                                itemHeight = itemHeight,
+                                itemWidth = itemWidth,
+                                helper = helper2
+                            ),
+                            TrackerTestModel(
+                                "carouselItem1",
+                                itemHeight = itemHeight,
+                                itemWidth = itemWidth,
+                                helper = helper3
+                            )
+                        )
+                    )
+                }.addTo(this)
+            }
+
+            // Scroll so last carousel model is fully visible
+            (binder.view as RecyclerView).layoutManager!!.scrollToPosition(2)
+            shadowOf(Looper.getMainLooper()).idle()
+
+            helper1.assert(
+                visibleHeight = 0,
+                visibleWidth = 0,
+                percentVisibleHeight = 0f,
+                percentVisibleWidth = 0f,
+                visible = false,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE,
+                    VisibilityState.INVISIBLE,
+                    VisibilityState.UNFOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_INVISIBLE
+                )
+            )
+
+            helper2.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth / 2,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = (scrollView.measuredWidth - itemWidth).toFloat() / itemWidth * 100,
+                visible = true,
+                partialImpression = false,
+                fullImpression = false,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE
+                )
+            )
+
+            helper3.assert(
+                visibleHeight = itemHeight,
+                visibleWidth = itemWidth,
+                percentVisibleHeight = 100f,
+                percentVisibleWidth = 100f,
+                visible = true,
+                partialImpression = true,
+                fullImpression = true,
+                visitedStates = intArrayOf(
+                    VisibilityState.VISIBLE,
+                    VisibilityState.FOCUSED_VISIBLE,
+                    VisibilityState.PARTIAL_IMPRESSION_VISIBLE,
+                    VisibilityState.FULL_IMPRESSION_VISIBLE
+                )
+            )
+        }
+    }
+
+    /**
+     * Set up an [EpoxyViewBinder] and add models to it. Do not call this multiple times in a test as it will re-set up
+     * the view binder, not make incremental changes. If incremental changes are needed, add logic to the
+     * [modelProvider].
+     *
+     * @see [LifecycleAwareEpoxyViewBinder]
+     *
+     * @param stubHeight the height to use for the view binder's stub. This will inherently be used for the populated
+     * model's height per [EpoxyViewBinder] logic.
+     * @param modelProvider the provider block used for the [EpoxyViewBinder]
+     */
+    private fun TestActivity.withModel(
+        stubHeight: Int,
+        modelProvider: EpoxyController.() -> Unit
+    ): LifecycleAwareEpoxyViewBinder {
+        val viewBinderContainer = EpoxyViewStub(this)
+        viewBinderContainer.layoutParams =
+            ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, stubHeight)
+        viewBinderContainer.id = View.generateViewId()
+        linearLayout.addView(viewBinderContainer)
+
+        val binder by epoxyView(
+            viewBinderContainer.id,
+            useVisibilityTracking = true,
+            initializer = { },
+            {
+                modelProvider(this)
+            }
+        )
+
+        binder.invalidate()
+        shadowOf(Looper.getMainLooper()).idle()
+        return binder
+    }
+
+    /**
+     * Adds an empty view of the desired height to the linear layout in the fragment. Useful for testing partial
+     * visibility.
+     */
+    private fun TestActivity.addSpace(height: Int) {
+        val spaceView = Space(this)
+        spaceView.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height)
+        linearLayout.addView(spaceView)
+    }
+
+    /** Get a [VisibilityAssertHelper] using an auto-incrementing ID. */
+    private fun nextAssertHelper() = VisibilityAssertHelper(ids++)
+}

--- a/epoxy-viewbinder/build.gradle
+++ b/epoxy-viewbinder/build.gradle
@@ -18,9 +18,10 @@ dependencies {
   implementation rootProject.deps.androidAppcompat
   implementation rootProject.deps.androidCoreKtx
   implementation rootProject.deps.androidRecyclerView
-  api project(':epoxy-annotations')
   api project(':epoxy-adapter')
+  api project(':epoxy-annotations')
 
+  testImplementation rootProject.deps.androidTestCore
   testImplementation rootProject.deps.junit
   testImplementation rootProject.deps.robolectric
   testImplementation rootProject.deps.mockito

--- a/epoxy-viewbinder/src/main/java/com/airbnb/epoxy/EpoxyViewBinder.kt
+++ b/epoxy-viewbinder/src/main/java/com/airbnb/epoxy/EpoxyViewBinder.kt
@@ -27,7 +27,7 @@ class EpoxyViewBinder : EpoxyController() {
 
     private var tempModel: EpoxyModel<*>? = null
 
-    private var interceptor: EpoxyController.Interceptor? = null
+    private var interceptor: Interceptor? = null
 
     override fun addInterceptor(interceptor: Interceptor) {
         this.interceptor = interceptor
@@ -222,11 +222,11 @@ internal var View.viewHolder: EpoxyViewHolder?
  */
 fun ComponentActivity.epoxyView(
     @IdRes viewId: Int,
+    useVisibilityTracking: Boolean = false,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
-    modelProvider: EpoxyController.() -> Unit,
-    useVisibilityTracking: Boolean = false
+    modelProvider: EpoxyController.() -> Unit
 ) = lazy {
-    return@lazy epoxyViewInternal(viewId, initializer, modelProvider, useVisibilityTracking)
+    return@lazy epoxyViewInternal(viewId, useVisibilityTracking, initializer, modelProvider)
 }
 
 /**
@@ -236,11 +236,11 @@ fun ComponentActivity.epoxyView(
  */
 fun Fragment.epoxyView(
     @IdRes viewId: Int,
+    useVisibilityTracking: Boolean = false,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
-    modelProvider: EpoxyController.() -> Unit,
-    useVisibilityTracking: Boolean = false
+    modelProvider: EpoxyController.() -> Unit
 ) = lazy {
-    return@lazy epoxyViewInternal(viewId, initializer, modelProvider, useVisibilityTracking)
+    return@lazy epoxyViewInternal(viewId, useVisibilityTracking, initializer, modelProvider)
 }
 
 /**
@@ -250,11 +250,11 @@ fun Fragment.epoxyView(
  */
 fun ViewGroup.epoxyView(
     @IdRes viewId: Int,
+    useVisibilityTracking: Boolean = false,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
-    modelProvider: EpoxyController.() -> Unit,
-    useVisibilityTracking: Boolean = false
+    modelProvider: EpoxyController.() -> Unit
 ) = lazy {
-    return@lazy epoxyViewInternal(viewId, initializer, modelProvider, useVisibilityTracking)
+    return@lazy epoxyViewInternal(viewId, useVisibilityTracking, initializer, modelProvider)
 }
 
 /**
@@ -266,16 +266,16 @@ fun ViewGroup.epoxyView(
  */
 fun ComponentActivity.optionalEpoxyView(
     @IdRes viewId: Int,
-    initializer: LifecycleAwareEpoxyViewBinder.() -> Unit = { },
-    modelProvider: EpoxyController.() -> Unit,
+    useVisibilityTracking: Boolean = false,
     fallbackToNameLookup: Boolean = false,
-    useVisibilityTracking: Boolean = false
+    initializer: LifecycleAwareEpoxyViewBinder.() -> Unit = { },
+    modelProvider: EpoxyController.() -> Unit
 ) = lazy {
     val view = findViewById<View>(android.R.id.content)
     // View id is not present, we just return null in that case.
     if (view.maybeFindViewByIdName<View>(viewId, fallbackToNameLookup) == null) return@lazy null
 
-    return@lazy epoxyViewInternal(viewId, initializer, modelProvider, useVisibilityTracking)
+    return@lazy epoxyViewInternal(viewId, useVisibilityTracking, initializer, modelProvider)
 }
 
 /**
@@ -287,16 +287,16 @@ fun ComponentActivity.optionalEpoxyView(
  */
 fun Fragment.optionalEpoxyView(
     @IdRes viewId: Int,
-    modelProvider: EpoxyController.() -> Unit,
-    initializer: (LifecycleAwareEpoxyViewBinder.() -> Unit) = { },
+    useVisibilityTracking: Boolean = false,
     fallbackToNameLookup: Boolean = false,
-    useVisibilityTracking: Boolean = false
+    modelProvider: EpoxyController.() -> Unit,
+    initializer: (LifecycleAwareEpoxyViewBinder.() -> Unit) = { }
 ) = lazy {
     val view = view ?: error("Fragment view has not been created")
     // View id is not present, we just return null in that case.
     if (view.maybeFindViewByIdName<View>(viewId, fallbackToNameLookup) == null) return@lazy null
 
-    return@lazy epoxyViewInternal(viewId, initializer, modelProvider, useVisibilityTracking)
+    return@lazy epoxyViewInternal(viewId, useVisibilityTracking, initializer, modelProvider)
 }
 
 /**
@@ -308,55 +308,55 @@ fun Fragment.optionalEpoxyView(
  */
 fun ViewGroup.optionalEpoxyView(
     @IdRes viewId: Int,
-    initializer: LifecycleAwareEpoxyViewBinder.() -> Unit = { },
-    modelProvider: EpoxyController.() -> Unit,
+    useVisibilityTracking: Boolean = false,
     fallbackToNameLookup: Boolean = false,
-    useVisibilityTracking: Boolean = false
+    initializer: LifecycleAwareEpoxyViewBinder.() -> Unit = { },
+    modelProvider: EpoxyController.() -> Unit
 ) = lazy {
     val view = this
     // View id is not present, we just return null in that case.
     if (view.maybeFindViewByIdName<View>(viewId, fallbackToNameLookup) == null) return@lazy null
 
-    return@lazy epoxyViewInternal(viewId, initializer, modelProvider, useVisibilityTracking)
+    return@lazy epoxyViewInternal(viewId, useVisibilityTracking, initializer, modelProvider)
 }
 
 private fun ComponentActivity.epoxyViewInternal(
     @IdRes viewId: Int,
+    useVisibilityTracking: Boolean = false,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
-    modelProvider: EpoxyController.() -> Unit,
-    useVisibilityTracking: Boolean = false
+    modelProvider: EpoxyController.() -> Unit
 ) = LifecycleAwareEpoxyViewBinder(
     this,
     { findViewById(android.R.id.content) },
     viewId,
-    modelProvider,
-    useVisibilityTracking = useVisibilityTracking
+    useVisibilityTracking = useVisibilityTracking,
+    modelProvider = modelProvider
 ).apply(initializer)
 
 private fun Fragment.epoxyViewInternal(
     @IdRes viewId: Int,
+    useVisibilityTracking: Boolean = false,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
-    modelProvider: EpoxyController.() -> Unit,
-    useVisibilityTracking: Boolean = false
+    modelProvider: EpoxyController.() -> Unit
 ) = LifecycleAwareEpoxyViewBinder(
     viewLifecycleOwner,
     { view },
     viewId,
-    modelProvider,
-    useVisibilityTracking = useVisibilityTracking
+    useVisibilityTracking = useVisibilityTracking,
+    modelProvider = modelProvider
 ).apply(initializer)
 
 private fun ViewGroup.epoxyViewInternal(
     @IdRes viewId: Int,
+    useVisibilityTracking: Boolean = false,
     initializer: LifecycleAwareEpoxyViewBinder.() -> Unit,
-    modelProvider: EpoxyController.() -> Unit,
-    useVisibilityTracking: Boolean = false
+    modelProvider: EpoxyController.() -> Unit
 ) = LifecycleAwareEpoxyViewBinder(
     (this.context as? LifecycleOwner) ?: error("LifecycleOwner required as view's context "),
     { this },
     viewId,
-    modelProvider,
-    useVisibilityTracking = useVisibilityTracking
+    useVisibilityTracking = useVisibilityTracking,
+    modelProvider = modelProvider
 ).apply(initializer)
 
 /**
@@ -372,9 +372,9 @@ class LifecycleAwareEpoxyViewBinder(
     private val lifecycleOwner: LifecycleOwner,
     private val rootView: (() -> View?),
     @IdRes private val viewId: Int,
-    private val modelProvider: EpoxyController.() -> Unit,
+    private val useVisibilityTracking: Boolean = false,
     private val fallbackToNameLookup: Boolean = false,
-    private val useVisibilityTracking: Boolean = false
+    private val modelProvider: EpoxyController.() -> Unit,
 ) : LifecycleObserver {
     private val viewBinder = EpoxyViewBinder()
     private var lazyView: View? = null

--- a/epoxy-viewbinder/src/test/java/com/example/epoxy_viewbinder/EpoxyViewBinderTest.kt
+++ b/epoxy-viewbinder/src/test/java/com/example/epoxy_viewbinder/EpoxyViewBinderTest.kt
@@ -1,0 +1,138 @@
+package com.example.epoxy_viewbinder
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewParent
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import com.airbnb.epoxy.EpoxyHolder
+import com.airbnb.epoxy.EpoxyModel
+import com.airbnb.epoxy.EpoxyModelWithHolder
+import com.airbnb.epoxy.EpoxyViewBinder
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class EpoxyViewBinderTest {
+
+    private val epoxyViewBinder = EpoxyViewBinder()
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+    private val view = View(context)
+    private val viewGroup = FrameLayout(context)
+    private val currentView: View
+        get() = viewGroup.getChildAt(0) // We always have children in viewGroup
+
+    private val viewModel = EpoxyModelMock()
+    private val viewHolderModel = EpoxyModelWithHolderMock()
+
+    @Before
+    fun setUp() {
+        viewGroup.addView(view)
+    }
+
+    @After
+    fun tearDown() {
+        viewGroup.removeAllViews()
+    }
+
+    @Test
+    fun unbindWithoutBindWillNoOp() {
+        epoxyViewBinder.unbind(view)
+
+        // Won't crash because we are no-op if no model is bound
+    }
+
+    @Test
+    fun bindWithView() {
+        epoxyViewBinder.replaceView(view, viewModel)
+
+        // Old view is removed from parent
+        assertNull(view.parent)
+        // A new view is added
+        assertEquals(viewGroup, currentView.parent)
+        // New view is bound to EpoxyModel
+        assertEquals(currentView, viewModel.boundView)
+    }
+
+    @Test
+    fun unbindWithViewBound() {
+        epoxyViewBinder.replaceView(view, viewModel)
+        epoxyViewBinder.unbind(currentView)
+
+        // View is unbound from EpoxyModel
+        assertNull(viewModel.boundView)
+    }
+
+    @Test
+    fun bindWithViewHolder() {
+        epoxyViewBinder.replaceView(view, viewHolderModel)
+
+        // Old view is removed from parent
+        assertNull(view.parent)
+        // A new view is added
+        assertEquals(viewGroup, currentView.parent)
+        // New view is bound to ViewHolder
+        assertEquals(currentView, viewHolderModel.boundHolder?.boundView)
+    }
+
+    @Test
+    fun unbindWithViewHolderBound() {
+        epoxyViewBinder.replaceView(view, viewHolderModel)
+        epoxyViewBinder.unbind(currentView)
+
+        // Holder is unbound from Model
+        assertNull(viewHolderModel.boundHolder)
+    }
+}
+
+private class EpoxyHolderMock : EpoxyHolder() {
+    var boundView: View? = null
+    override fun bindView(itemView: View) {
+        boundView = itemView
+    }
+}
+
+private class EpoxyModelMock : EpoxyModel<View>() {
+    var boundView: View? = null
+
+    override fun getDefaultLayout() = throw UnsupportedOperationException("No default layout")
+
+    override fun buildView(parent: ViewGroup) = createView()
+
+    override fun bind(view: View) { boundView = view }
+    override fun unbind(view: View) {
+        if (boundView == view) {
+            boundView = null
+        }
+    }
+}
+
+private class EpoxyModelWithHolderMock : EpoxyModelWithHolder<EpoxyHolderMock>() {
+    var boundHolder: EpoxyHolderMock? = null
+
+    override fun getDefaultLayout() = throw UnsupportedOperationException("No default layout")
+
+    override fun buildView(parent: ViewGroup) = createView()
+
+    override fun createNewHolder(parent: ViewParent) = EpoxyHolderMock()
+
+    override fun bind(holder: EpoxyHolderMock) {
+        boundHolder = holder
+    }
+
+    override fun unbind(holder: EpoxyHolderMock) {
+        if (boundHolder == holder) {
+            boundHolder = null
+        }
+    }
+}
+
+private fun createView() = View(ApplicationProvider.getApplicationContext())


### PR DESCRIPTION
Adding unit tests for the visibility tracker along with some API tweaks that will allow for the model provider to still be a trailing lambda (if desired) or an unnamed parameter.
