### PR TITLE
Release 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 4.6.0 (May 12, 2021)
+- View Binder Support (#1175) Bind epoxy models to views outside of a RecyclerView.
+
+### Potentially Breaking
+- Use kotlin dsl marker for model building receivers (#1180)
+
+This change uses Kotlin's DSL marker annotation to enforce proper usage of model building extension
+functions. You may now need to change some references in your model building code to explicitly reference properties with `this`.
+
 # 4.5.0 (April 13, 2021)
 - Fix generated code consistency in builder interfaces (#1166)
 - Provided support to invalidate `modelCache` in `PagingDataEpoxyController` (#1161)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.5.0
+VERSION_NAME=4.6.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
# 4.6.0 (May 12, 2021)

### New Feature!
Epoxy View Binder (#1175) Bind epoxy models to views outside of a RecyclerView.

### Potentially Breaking
- Use kotlin dsl marker for model building receivers (#1180)

This change uses Kotlin's DSL marker annotation to enforce proper usage of model building extension
functions. You may now need to change some references in your model building code to explicitly reference properties with `this`.