### PR TITLE
Option to disable dsl marker generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 4.6.1 (May 13, 2021)
+Adds "epoxyDisableDslMarker" annotation processor flag which you can use to delay migration to the model building scope DLSMarker introduced in 4.6.0 if it is a large breaking change for your project.
+
+Note that this only applies to your project modules that you apply it to, and does not apply to the handful of models that ship with the Epoxy library (like the Carousel or `group` builder).
+
+For example:
+```groovy
+project.android.buildTypes.all { buildType ->
+    buildType.javaCompileOptions.annotationProcessorOptions.arguments =
+            [
+                    epoxyDisableDslMarker     : "true",
+            ]
+}
+```
+
 # 4.6.0 (May 12, 2021)
 - View Binder Support (#1175) Bind epoxy models to views outside of a RecyclerView.
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ConfigManager.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ConfigManager.kt
@@ -30,6 +30,7 @@ class ConfigManager internal constructor(
     private val disableGenerateReset: Boolean
     private val disableGenerateGetters: Boolean
     private val disableGenerateBuilderOverloads: Boolean
+    val disableDslMarker: Boolean
     val logTimings: Boolean
     val enableCoroutines: Boolean
 
@@ -90,6 +91,12 @@ class ConfigManager internal constructor(
         disableGenerateBuilderOverloads = getBooleanOption(
             options,
             PROCESSOR_OPTION_DISABLE_GENERATE_BUILDER_OVERLOADS,
+            defaultValue = false
+        )
+
+        disableDslMarker = getBooleanOption(
+            options,
+            PROCESSOR_OPTION_DISABLE_DLS_MARKER,
             defaultValue = false
         )
     }
@@ -270,6 +277,7 @@ class ConfigManager internal constructor(
     }
 
     companion object {
+        const val PROCESSOR_OPTION_DISABLE_DLS_MARKER = "epoxyDisableDslMarker"
         const val PROCESSOR_OPTION_DISABLE_GENERATE_RESET = "epoxyDisableGenerateReset"
         const val PROCESSOR_OPTION_DISABLE_GENERATE_GETTERS = "epoxyDisableGenerateGetters"
         const val PROCESSOR_OPTION_DISABLE_GENERATE_BUILDER_OVERLOADS =

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
@@ -82,7 +82,9 @@ class ModelBuilderInterfaceWriter(
             addModifiers(Modifier.PUBLIC)
             addTypeVariables(modelInfo.typeVariables)
             addMethods(interfaceMethods)
-            addAnnotation(EpoxyBuildScope::class.java)
+            if (!configManager.disableDslMarker) {
+                addAnnotation(EpoxyBuildScope::class.java)
+            }
 
             if (modelInfo.memoizer.implementsModelCollector(modelInfo.superClassElement)) {
                 // If the model implements "ModelCollector" we want the builder too

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=4.6.0
+VERSION_NAME=4.6.1
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
# 4.6.1 (May 13, 2021)
Adds "epoxyDisableDslMarker" annotation processor flag which you can use to delay migration to the model building scope DLSMarker introduced in 4.6.0 if it is a large breaking change for your project.

Note that this only applies to your project modules that you apply it to, and does not apply to the handful of models that ship with the Epoxy library (like the Carousel or `group` builder).

For example:
```groovy
project.android.buildTypes.all { buildType ->
    buildType.javaCompileOptions.annotationProcessorOptions.arguments =
            [
                    epoxyDisableDslMarker     : "true",
            ]
}
```
