### PR TITLE
Drag n Drop not working in 4.6.1

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyTouchHelperCallback.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyTouchHelperCallback.kt
@@ -85,7 +85,7 @@ abstract class EpoxyTouchHelperCallback : ItemTouchHelper.Callback() {
         dropTargets: List<RecyclerView.ViewHolder>,
         curX: Int,
         curY: Int
-    ): EpoxyViewHolder = chooseDropTarget(
+    ): EpoxyViewHolder? = chooseDropTarget(
         selected as EpoxyViewHolder,
         dropTargets as List<EpoxyViewHolder>,
         curX,
@@ -100,8 +100,8 @@ abstract class EpoxyTouchHelperCallback : ItemTouchHelper.Callback() {
         dropTargets: List<EpoxyViewHolder>,
         curX: Int,
         curY: Int
-    ): EpoxyViewHolder =
-        super.chooseDropTarget(selected, dropTargets, curX, curY) as EpoxyViewHolder
+    ): EpoxyViewHolder? =
+        super.chooseDropTarget(selected, dropTargets, curX, curY) as? EpoxyViewHolder
 
     override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int): Unit =
         onSelectedChanged(viewHolder as EpoxyViewHolder?, actionState)

--- a/kotlinsample/src/main/AndroidManifest.xml
+++ b/kotlinsample/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         </activity>
 
         <activity android:name=".StickyHeaderActivity"/>
+        <activity android:name=".DragAndDropActivity"/>
     </application>
 
 </manifest>

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/DragAndDropActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/DragAndDropActivity.kt
@@ -1,0 +1,83 @@
+package com.airbnb.epoxy.kotlinsample
+
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.airbnb.epoxy.EpoxyModel
+import com.airbnb.epoxy.EpoxyRecyclerView
+import com.airbnb.epoxy.EpoxyTouchHelper
+import com.airbnb.epoxy.TypedEpoxyController
+import com.airbnb.epoxy.stickyheader.StickyHeaderLinearLayoutManager
+
+class DragAndDropActivity : AppCompatActivity() {
+    private lateinit var recyclerView: EpoxyRecyclerView
+    private var fruits = mutableListOf(
+        "Apples",
+        "Blueberries",
+        "Bananas",
+        "Oranges",
+        "Dragon fruit",
+        "Mango",
+        "Avocado",
+        "Lychee"
+    )
+
+    private var epoxyController = object : TypedEpoxyController<List<String>>() {
+
+        override fun buildModels(data: List<String>?) {
+            data?.forEach { fruit ->
+                dataBindingItem {
+                    id("data binding $fruit")
+                    text(fruit)
+                    onClick { _ ->
+                        Toast.makeText(
+                            this@DragAndDropActivity,
+                            "clicked $fruit",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                    onVisibilityStateChanged { model, view, visibilityState ->
+                        Log.d(TAG, "$model -> $visibilityState")
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity)
+        findViewById<View>(R.id.epoxy_view_stub)?.visibility = View.GONE
+
+        recyclerView = findViewById(R.id.recycler_view)
+
+        EpoxyTouchHelper.initDragging(epoxyController)
+            .withRecyclerView(recyclerView)
+            .forVerticalList()
+            .forAllModels()
+            .andCallbacks(object : EpoxyTouchHelper.DragCallbacks<EpoxyModel<*>>() {
+                override fun onModelMoved(
+                    fromPosition: Int,
+                    toPosition: Int,
+                    modelBeingMoved: EpoxyModel<*>?,
+                    itemView: View?
+                ) {
+                    Log.d(TAG, "onModelMoved from:$fromPosition -> to:$toPosition")
+                    val removed = fruits.removeAt(fromPosition)
+                    fruits.add(toPosition, removed)
+                    epoxyController.setData(fruits)
+                }
+            })
+
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.setController(epoxyController)
+        epoxyController.setData(fruits)
+    }
+
+    companion object {
+        private const val TAG = "DragAndDropActivity"
+    }
+}

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/DragAndDropActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/DragAndDropActivity.kt
@@ -10,7 +10,6 @@ import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.EpoxyRecyclerView
 import com.airbnb.epoxy.EpoxyTouchHelper
 import com.airbnb.epoxy.TypedEpoxyController
-import com.airbnb.epoxy.stickyheader.StickyHeaderLinearLayoutManager
 
 class DragAndDropActivity : AppCompatActivity() {
     private lateinit var recyclerView: EpoxyRecyclerView

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
@@ -135,6 +135,16 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
 
+                itemCustomView {
+                    id("custom view $i")
+                    color(Color.MAGENTA)
+                    title("Open Drag and Dropt activity")
+                    listener { _ ->
+                        Toast.makeText(this@MainActivity, "clicked", Toast.LENGTH_LONG).show()
+                        startActivity(Intent(this@MainActivity, DragAndDropActivity::class.java))
+                    }
+                }
+
                 itemEpoxyHolder {
                     id("view holder $i")
                     title("this is a View Holder item")

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/StickyHeaderActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/StickyHeaderActivity.kt
@@ -1,6 +1,7 @@
 package com.airbnb.epoxy.kotlinsample
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.airbnb.epoxy.EpoxyRecyclerView
 import com.airbnb.epoxy.stickyheader.StickyHeaderLinearLayoutManager
@@ -15,6 +16,8 @@ class StickyHeaderActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity)
+
+        findViewById<View>(R.id.epoxy_view_stub)?.visibility = View.GONE
 
         recyclerView = findViewById(R.id.recycler_view)
 


### PR DESCRIPTION
 Fixes #1187

Drag N Drop support is broken in 4.6.1 (working in 4.5). Due to migration of EpoxyTouchHelperCallback from java to kotlin and missing @Nullable annotation in ItemTouchHelper

The following can return null (checked in source code)
````
public ViewHolder chooseDropTarget(@NonNull ViewHolder selected,
                @NonNull List<ViewHolder> dropTargets, int curX, int curY) 
````

And code calling this is checking for null

````
 ViewHolder target = mCallback.chooseDropTarget(viewHolder, swapTargets, x, y);
        if (target == null) {
            mSwapTargets.clear();
            mDistances.clear();
            return;
        }
````

So i simply made the kotlin code using optionals.

I also added a drag n drop activity in sample app to test it.
I notice also that StickyHeaderActivity was not working due to epoxy_view_stub taking all vertical space