### PR TITLE
[COMPOSE] Added proper dispose support to Compose interop

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -51,7 +51,7 @@ rootProject.ext.PARIS_VERSION = "1.7.3"
 rootProject.ext.ROBOLECTRIC_VERSION = "4.5.1"
 rootProject.ext.SQUARE_JAVAPOET_VERSION = "1.13.0"
 rootProject.ext.SQUARE_KOTLINPOET_VERSION = "1.8.0"
-rootProject.ext.COMPOSE_VERSION = "1.0.0-beta06"
+rootProject.ext.COMPOSE_VERSION = "1.0.0-beta07"
 rootProject.ext.COMPOSE_ACTIVITY_VERSION = "1.3.0-alpha07"
 rootProject.ext.KOTLINX_LIFECYCLE_RUNTIME_VERSION = "2.3.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
 
   ext.KOTLIN_VERSION = "1.4.32"
-  ext.ANDROID_PLUGIN_VERSION = '7.0.0-alpha14'
+  ext.ANDROID_PLUGIN_VERSION = '7.0.0-beta03'
 
   repositories {
     google()

--- a/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
+++ b/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
@@ -28,6 +28,11 @@ class ComposeEpoxyModel(
         super.unbind(view)
         view.disposeComposition()
     }
+
+    override fun onViewDetachedFromWindow(view: ComposeView) {
+        super.onViewDetachedFromWindow(view)
+        view.disposeComposition()
+    }
 }
 
 fun ModelCollector.composableInterop(

--- a/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
+++ b/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
@@ -6,16 +6,27 @@ import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.viewinterop.AndroidView
 
 class ComposeEpoxyModel(
     private val composeFunction: @Composable () -> Unit
 ) : EpoxyModelWithView<ComposeView>() {
-    override fun buildView(parent: ViewGroup): ComposeView = ComposeView(parent.context)
+
+    override fun buildView(parent: ViewGroup): ComposeView = ComposeView(parent.context).apply {
+        setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+        )
+    }
 
     override fun bind(view: ComposeView) {
         super.bind(view)
         view.setContent(composeFunction)
+    }
+
+    override fun unbind(view: ComposeView) {
+        super.unbind(view)
+        view.disposeComposition()
     }
 }
 


### PR DESCRIPTION
In this PR, I updated `ComposeEpoxyModel` to properly dispose the composition by explicitly disposing on `unBind` and setting the appropriate view composition strategy on `ComposeView`. The default view composition strategy is `DisposeOnDetachedFromWindow ` and that keeps Composition instances in memory until the RecyclerView is detached from the window.  To make the Compose support work in all scenarios related to recyclerview's, it's necessary to use the DisposeOnViewTreeLifecycleDestroyed strategy.


@elihart @meggamind 