### PR TITLE
Add unbind extension to ItemViewBindingEpoxyHolder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
 
   ext.KOTLIN_VERSION = "1.4.32"
-  ext.ANDROID_PLUGIN_VERSION = '7.0.0-beta03'
+  ext.ANDROID_PLUGIN_VERSION = '7.0.0'
 
   repositories {
     google()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/helpers/ViewBindingEpoxyModelWithHolder.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/helpers/ViewBindingEpoxyModelWithHolder.kt
@@ -19,6 +19,13 @@ abstract class ViewBindingEpoxyModelWithHolder<in T : ViewBinding> :
 
     abstract fun T.bind()
 
+    @Suppress("UNCHECKED_CAST")
+    override fun unbind(holder: ViewBindingHolder) {
+        (holder.viewBinding as T).unbind()
+    }
+
+    open fun T.unbind() {}
+
     override fun createNewHolder(parent: ViewParent): ViewBindingHolder {
         return ViewBindingHolder(this::class.java)
     }

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/ItemViewBindingEpoxyHolder.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/ItemViewBindingEpoxyHolder.kt
@@ -16,4 +16,9 @@ abstract class ItemViewBindingEpoxyHolder : ViewBindingEpoxyModelWithHolder<View
         title.text = this@ItemViewBindingEpoxyHolder.title
         title.setOnClickListener { listener() }
     }
+
+    override fun ViewBindingHolderItemBinding.unbind() {
+        // Don't leak listeners as this view goes back to the view pool
+        title.setOnClickListener(null)
+    }
 }


### PR DESCRIPTION
In epoxy-sample, we show an example of using `unbind` to avoid memory leaks. Add an extension function for unbind to ItemViewBindingEpoxyHolder so that view binding can be used to clear listeners too.
The `unbind` extension function can be an optional override since not all ViewHolders will have listeners/resource allocation.

Also add example usage to kotlin-sample.