### PR TITLE
Remove ui-tooling dependency from epoxy-compose

### DIFF
--- a/epoxy-compose/build.gradle
+++ b/epoxy-compose/build.gradle
@@ -40,7 +40,6 @@ dependencies {
 
   implementation rootProject.deps.composeUi
   implementation rootProject.deps.activityCompose
-  implementation rootProject.deps.composeUiTooling
   implementation rootProject.deps.androidCoreKtx
   implementation rootProject.deps.androidAppcompat
   implementation rootProject.deps.androidDesignLibrary


### PR DESCRIPTION
This isn't necessary for epoxy-compose so removing it from the library

@elihart @meggamind 