### PR TITLE
https://github.com/airbnb/epoxy/issues/1199

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/KotlinModelBuilderExtensionWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/KotlinModelBuilderExtensionWriter.kt
@@ -106,14 +106,15 @@ internal class KotlinModelBuilderExtensionWriter(
             addModifiers(KModifier.INLINE)
             addModifiers(if (constructorIsNotPublic) KModifier.INTERNAL else KModifier.PUBLIC)
 
-            addStatement("add(")
+            addStatement("val model = ")
             beginControlFlow(
                 "%T(${params.joinToString(", ") { it.name }}).apply",
                 modelClass
             )
             addStatement("modelInitializer()")
             endControlFlow()
-            addStatement(")")
+
+            addStatement("add(model)")
 
             model.originatingElements().forEach {
                 addOriginatingElement(it)


### PR DESCRIPTION
This is for the crash on Android 12 reported in https://github.com/airbnb/epoxy/issues/1199 and also here: https://issuetracker.google.com/issues/197818595

- temporary workaround (https://issuetracker.google.com/issues/197818595#comment20) suggested by google engineer:
- In generated kotlin extension functions, store the created epoxy model in a local field before passing the object to ModelCollector.add()