### PR TITLE
[paging3] Expose modelCache

### DIFF
--- a/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedDataModelCache.kt
+++ b/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedDataModelCache.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.Flow
  * that thread we allow a special case of cache modification when a new list is being submitted,
  * and all cache access is marked with @Synchronize to ensure safety when this happens.
  */
-internal class PagedDataModelCache<T : Any>(
+class PagedDataModelCache<T : Any>(
     private val modelBuilder: (itemIndex: Int, item: T?) -> EpoxyModel<*>,
     private val rebuildCallback: () -> Unit,
     itemDiffCallback: DiffUtil.ItemCallback<T>,

--- a/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedListEpoxyController.kt
+++ b/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedListEpoxyController.kt
@@ -59,7 +59,7 @@ abstract class PagedListEpoxyController<T : Any>(
     itemDiffCallback: DiffUtil.ItemCallback<T> = DEFAULT_ITEM_DIFF_CALLBACK as DiffUtil.ItemCallback<T>
 ) : EpoxyController(modelBuildingHandler, diffingHandler) {
     // this is where we keep the already built models
-    private val modelCache = PagedListModelCache(
+    val modelCache = PagedListModelCache(
         modelBuilder = { pos, item ->
             buildItemModel(pos, item)
         },

--- a/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedListModelCache.kt
+++ b/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagedListModelCache.kt
@@ -48,7 +48,7 @@ import java.util.concurrent.Executor
  * that thread we allow a special case of cache modification when a new list is being submitted,
  * and all cache access is marked with @Synchronize to ensure safety when this happens.
  */
-internal class PagedListModelCache<T : Any>(
+class PagedListModelCache<T : Any>(
     private val modelBuilder: (itemIndex: Int, item: T?) -> EpoxyModel<*>,
     private val rebuildCallback: () -> Unit,
     private val itemDiffCallback: DiffUtil.ItemCallback<T>,

--- a/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagingDataEpoxyController.kt
+++ b/epoxy-paging3/src/main/java/com/airbnb/epoxy/paging3/PagingDataEpoxyController.kt
@@ -53,7 +53,7 @@ abstract class PagingDataEpoxyController<T : Any>(
     itemDiffCallback: DiffUtil.ItemCallback<T> = DEFAULT_ITEM_DIFF_CALLBACK as DiffUtil.ItemCallback<T>
 ) : EpoxyController(modelBuildingHandler, diffingHandler) {
     // this is where we keep the already built models
-    private val modelCache = PagedDataModelCache(
+    val modelCache = PagedDataModelCache(
         modelBuilder = { pos, item ->
             buildItemModel(pos, item)
         },


### PR DESCRIPTION
Intended to support two use cases without resorting to reflection:


### "Load more" button

This was requested by our designers to leave room for footer content rather than infinite scrolling. Disabling automatic loading can be done just by removing call to super. And to load the next page, we just use `modelCache.loadAround()`:
```
override fun onModelBound(holder: EpoxyViewHolder, boundModel: EpoxyModel<*>, position: Int, previouslyBoundModel: EpoxyModel<*>?) {
    // Disable automatically loading pages by removing call to super
    // super.onModelBound(holder, boundModel, position, previouslyBoundModel)
}

override fun buildItemModel(currentPosition: Int, item: I?): EpoxyModel<*> {
    if (item == null) {
        return LoadMoreBindingModel_().apply {
            id("load more")
            onClick { _ -> modelCache.loadAround(currentPosition) }
        }
    }
    ...
}
```

### Invalidate item models

An item model may depends on both paging data from remote and some view state. We're able to manually rebuild EpoxyModels for individual items using the `modelCache.updateCallback.onChanged()`. 
```
var seletedItemIds = emptySet()

override fun buildItemModel(currentPosition: Int, item: ItemType?): EpoxyModel<*> {
    return ItemBindingModel_().apply {
        id(item.id)
        selected(seletedItemIds.contains(item.id))
        onClick { _ -> 
            selectedItemIds += item.id
            modelCache.updateCallback.onChanged(currentPosition, 1, null) 
        }
    }
}
```