### PR TITLE
Add support for Async Layout inflation with EPoxy

### DIFF
--- a/blessedDeps.gradle
+++ b/blessedDeps.gradle
@@ -37,6 +37,7 @@ rootProject.ext.ANDROID_DATA_BINDING = "1.3.1"
 rootProject.ext.ANDROID_RUNTIME_VERSION = "4.1.1.4"
 rootProject.ext.ANDROID_TEST_RUNNER = "1.4.0"
 rootProject.ext.ASSERTJ_VERSION = "1.7.1"
+rootProject.ext.ASYNCLAYOUTINFLATOR_VERSION = "1.0.0"
 rootProject.ext.AUTO_VALUE_VERSION = "1.7.4"
 rootProject.ext.GLIDE_VERSION = "4.12.0"
 rootProject.ext.GOOGLE_TESTING_COMPILE_VERSION = "0.19"
@@ -78,6 +79,7 @@ rootProject.ext.deps = [
     androidTestRules          : "androidx.test:rules:$ANDROID_TEST_RUNNER",
     androidTestRunner         : "androidx.test:runner:$ANDROID_TEST_RUNNER",
     assertj                   : "org.assertj:assertj-core:$ASSERTJ_VERSION",
+    asyncLayoutInflater       : "androidx.asynclayoutinflater:asynclayoutinflater:$ASYNCLAYOUTINFLATOR_VERSION",
     autoValue                 : "com.google.auto.value:auto-value:$AUTO_VALUE_VERSION",
     composeMaterial           : "androidx.compose.material:material:$COMPOSE_VERSION",
     composeUi                 : "androidx.compose.ui:ui:$COMPOSE_VERSION",

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/AsyncFrameLayout.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/AsyncFrameLayout.java
@@ -1,0 +1,49 @@
+package com.airbnb.epoxy;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Base class to support Async layout inflation with EPoxy
+ */
+public abstract class AsyncFrameLayout extends FrameLayout {
+  protected boolean isInflated = false;
+  protected List<Runnable> pendingFunctions = new ArrayList<>();
+
+  public AsyncFrameLayout(Context context) {
+    super(context);
+  }
+
+  public AsyncFrameLayout(Context context, @Nullable AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public AsyncFrameLayout(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+  }
+
+  /**
+   * Call this method once the inflation is completed
+   */
+  protected void onInflationComplete() {
+    isInflated = true;
+    for (Runnable runnable: pendingFunctions) {
+      runnable.run();
+    }
+    pendingFunctions.clear();
+  }
+
+  public void executeWhenInflated(Runnable runnable) {
+    if (isInflated) {
+      runnable.run();
+    } else {
+      pendingFunctions.add(runnable);
+    }
+  }
+}

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -108,6 +108,11 @@ public abstract class BaseEpoxyAdapter
 
   @Override
   public void onBindViewHolder(EpoxyViewHolder holder, int position, List<Object> payloads) {
+    executeWhenInflated(holder,
+        () -> onBindViewHolderInternal(holder, holder.getBindingAdapterPosition(), payloads));
+  }
+
+  private void onBindViewHolderInternal(EpoxyViewHolder holder, int position, List<Object> payloads) {
     EpoxyModel<?> modelToShow = getModelForPosition(position);
 
     EpoxyModel<?> previouslyBoundModel = null;
@@ -209,15 +214,19 @@ public abstract class BaseEpoxyAdapter
   @CallSuper
   @Override
   public void onViewAttachedToWindow(EpoxyViewHolder holder) {
-    //noinspection unchecked,rawtypes
-    ((EpoxyModel) holder.getModel()).onViewAttachedToWindow(holder.objectToBind());
+    executeWhenInflated(holder,
+        () ->
+            //noinspection unchecked,rawtypes
+            ((EpoxyModel) holder.getModel()).onViewAttachedToWindow(holder.objectToBind()));
   }
 
   @CallSuper
   @Override
   public void onViewDetachedFromWindow(EpoxyViewHolder holder) {
-    //noinspection unchecked,rawtypes
-    ((EpoxyModel) holder.getModel()).onViewDetachedFromWindow(holder.objectToBind());
+    executeWhenInflated(holder,
+        () ->
+            //noinspection unchecked,rawtypes
+            ((EpoxyModel) holder.getModel()).onViewDetachedFromWindow(holder.objectToBind()));
   }
 
   public void onSaveInstanceState(Bundle outState) {
@@ -339,4 +348,12 @@ public abstract class BaseEpoxyAdapter
   }
 
   //endregion
+
+  protected void executeWhenInflated(EpoxyViewHolder holder, Runnable runnable) {
+    if (holder.itemView instanceof AsyncFrameLayout) {
+      ((AsyncFrameLayout)holder.itemView).executeWhenInflated(runnable);
+    } else {
+      runnable.run();
+    }
+  }
 }

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyControllerAdapter.java
@@ -125,13 +125,15 @@ public final class EpoxyControllerAdapter extends BaseEpoxyAdapter implements Re
   @Override
   public void onViewAttachedToWindow(@NonNull EpoxyViewHolder holder) {
     super.onViewAttachedToWindow(holder);
-    epoxyController.onViewAttachedToWindow(holder, holder.getModel());
+    executeWhenInflated(holder,
+        () -> epoxyController.onViewAttachedToWindow(holder, holder.getModel()));
   }
 
   @Override
   public void onViewDetachedFromWindow(@NonNull EpoxyViewHolder holder) {
     super.onViewDetachedFromWindow(holder);
-    epoxyController.onViewDetachedFromWindow(holder, holder.getModel());
+    executeWhenInflated(holder,
+        () -> epoxyController.onViewDetachedFromWindow(holder, holder.getModel()));
   }
 
   @Override

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.kt
@@ -7,8 +7,6 @@ import androidx.annotation.IdRes
 import androidx.annotation.IntRange
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.viewmodeladapter.R
-import java.util.ArrayList
-import java.util.HashMap
 
 /**
  * A simple way to track visibility events on [com.airbnb.epoxy.EpoxyModel].
@@ -206,6 +204,16 @@ class EpoxyVisibilityTracker {
      * @param eventOriginForDebug a debug strings used for logs
      */
     private fun processChild(child: View, detachEvent: Boolean, eventOriginForDebug: String) {
+        if (child is AsyncFrameLayout) {
+            child.executeWhenInflated {
+                processChildInternal(child, detachEvent, eventOriginForDebug)
+            }
+        } else {
+            processChildInternal(child, detachEvent, eventOriginForDebug)
+        }
+    }
+
+    private fun processChildInternal(child: View, detachEvent: Boolean, eventOriginForDebug: String) {
 
         // Only if attached
         val recyclerView = attachedRecyclerView ?: return

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=5.0.0-beta05
+VERSION_NAME=5.0.0-beta06
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/kotlinsample/build.gradle
+++ b/kotlinsample/build.gradle
@@ -30,6 +30,7 @@ android {
 dependencies {
   implementation rootProject.deps.androidRecyclerView
   implementation rootProject.deps.androidAppcompat
+  implementation rootProject.deps.asyncLayoutInflater
   implementation project(':epoxy-databinding')
   implementation project(':epoxy-adapter')
   implementation project(':epoxy-annotations')

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/MainActivity.kt
@@ -13,6 +13,7 @@ import com.airbnb.epoxy.group
 import com.airbnb.epoxy.kotlinsample.helpers.carouselNoSnapBuilder
 import com.airbnb.epoxy.kotlinsample.models.ItemDataClass
 import com.airbnb.epoxy.kotlinsample.models.ItemViewBindingDataClass
+import com.airbnb.epoxy.kotlinsample.models.asyncItemCustomView
 import com.airbnb.epoxy.kotlinsample.models.carouselItemCustomView
 import com.airbnb.epoxy.kotlinsample.models.coloredSquareView
 import com.airbnb.epoxy.kotlinsample.models.decoratedLinearGroup
@@ -141,10 +142,30 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
 
+                asyncItemCustomView {
+                    id("custom view $i")
+                    color(Color.GREEN)
+                    title("Async Row - Open sticky header activity")
+                    listener { _ ->
+                        Toast.makeText(this@MainActivity, "clicked", Toast.LENGTH_LONG).show()
+                        startActivity(Intent(this@MainActivity, StickyHeaderActivity::class.java))
+                    }
+                }
+
                 itemCustomView {
                     id("custom view $i")
                     color(Color.MAGENTA)
                     title("Open Drag and Dropt activity")
+                    listener { _ ->
+                        Toast.makeText(this@MainActivity, "clicked", Toast.LENGTH_LONG).show()
+                        startActivity(Intent(this@MainActivity, DragAndDropActivity::class.java))
+                    }
+                }
+
+                asyncItemCustomView {
+                    id("custom view $i")
+                    color(Color.MAGENTA)
+                    title("Async Row - Open Drag and Dropt activity")
                     listener { _ ->
                         Toast.makeText(this@MainActivity, "clicked", Toast.LENGTH_LONG).show()
                         startActivity(Intent(this@MainActivity, DragAndDropActivity::class.java))

--- a/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/AsyncItemCustomView.kt
+++ b/kotlinsample/src/main/java/com/airbnb/epoxy/kotlinsample/models/AsyncItemCustomView.kt
@@ -1,0 +1,142 @@
+package com.airbnb.epoxy.kotlinsample.models
+
+import android.content.Context
+import android.graphics.Color
+import android.util.AttributeSet
+import android.util.Log
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.annotation.ColorInt
+import com.airbnb.epoxy.AfterPropsSet
+import com.airbnb.epoxy.AsyncFrameLayout
+import com.airbnb.epoxy.CallbackProp
+import com.airbnb.epoxy.ModelProp
+import com.airbnb.epoxy.ModelView
+import com.airbnb.epoxy.OnViewRecycled
+import com.airbnb.epoxy.OnVisibilityChanged
+import com.airbnb.epoxy.OnVisibilityStateChanged
+import com.airbnb.epoxy.TextProp
+import com.airbnb.epoxy.VisibilityState
+import com.airbnb.epoxy.kotlinsample.R
+import androidx.asynclayoutinflater.view.AsyncLayoutInflater
+
+// The ModelView annotation is used on Views to have models generated from those views.
+// This is pretty straightforward with Kotlin, but properties need some special handling.
+@ModelView(autoLayout = ModelView.Size.MATCH_WIDTH_WRAP_HEIGHT)
+class AsyncItemCustomView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : AsyncFrameLayout(context, attrs, defStyleAttr) {
+
+    private val onVisibilityEventDrawable = OnVisibilityEventDrawable(context)
+
+    private lateinit var textView: TextView
+
+    init {
+        AsyncLayoutInflater(context).inflate(R.layout.async_custom_view_item, this) {
+            view, _, _ ->
+            addView(view)
+            textView = (findViewById(R.id.title))
+            textView.setCompoundDrawables(null, null, onVisibilityEventDrawable, null)
+            textView.compoundDrawablePadding = (4 * resources.displayMetrics.density).toInt()
+            onInflationComplete()
+        }
+    }
+
+    // You can annotate your methods with @ModelProp
+    // A default model property value can be set by using Kotlin default arguments, but you
+    // must use JvmOverloads for Epoxy to handle it correctly.
+    @JvmOverloads
+    @ModelProp
+    fun color(@ColorInt color: Int = Color.RED) {
+        textView.setTextColor(color)
+    }
+
+    // Or if you need to store data in properties there are two options
+
+    // 1.You can make it nullable like this and annotate the setter
+    var listener: View.OnClickListener? = null
+        @CallbackProp set
+
+    // 2. Or you can use lateinit
+    @TextProp
+    lateinit var title: CharSequence
+
+    @AfterPropsSet
+    fun useProps() {
+        // This is optional, and is called after the annotated properties above are set.
+        // This is useful for using several properties in one method to guarantee they are all set first.
+        textView.text = title
+        textView.setOnClickListener(listener)
+    }
+
+    @OnVisibilityStateChanged
+    fun onVisibilityStateChanged(
+        @VisibilityState.Visibility visibilityState: Int
+    ) {
+        when (visibilityState) {
+            VisibilityState.VISIBLE -> {
+                Log.d(TAG, "$title Visible")
+                onVisibilityEventDrawable.visible = true
+            }
+            VisibilityState.INVISIBLE -> {
+                Log.d(TAG, "$title Invisible")
+                onVisibilityEventDrawable.visible = false
+            }
+            VisibilityState.FOCUSED_VISIBLE -> {
+                Log.d(TAG, "$title FocusedVisible")
+                onVisibilityEventDrawable.focusedVisible = true
+            }
+            VisibilityState.UNFOCUSED_VISIBLE -> {
+                Log.d(TAG, "$title UnfocusedVisible")
+                onVisibilityEventDrawable.focusedVisible = false
+            }
+            VisibilityState.PARTIAL_IMPRESSION_VISIBLE -> {
+                Log.d(TAG, "$title PartialImpressionVisible")
+                onVisibilityEventDrawable.partialImpression = true
+            }
+            VisibilityState.PARTIAL_IMPRESSION_INVISIBLE -> {
+                Log.d(TAG, "$title PartialImpressionInVisible")
+                onVisibilityEventDrawable.partialImpression = false
+            }
+            VisibilityState.FULL_IMPRESSION_VISIBLE -> {
+                Log.d(TAG, "$title FullImpressionVisible")
+                onVisibilityEventDrawable.fullImpression = true
+            }
+        }
+    }
+
+    @OnVisibilityChanged
+    fun onVisibilityChanged(
+        percentVisibleHeight: Float,
+        percentVisibleWidth: Float,
+        visibleHeight: Int,
+        visibleWidth: Int
+    ) {
+        Log.d(
+            TAG,
+            "$title onChanged ${percentVisibleHeight.toInt()} ${percentVisibleWidth.toInt()} " +
+                "$visibleHeight $visibleWidth ${System.identityHashCode(
+                    this
+                )}"
+        )
+        with(onVisibilityEventDrawable) {
+            if ((percentVisibleHeight < 100 || percentVisibleWidth < 100) && fullImpression) {
+                fullImpression = false
+            }
+            percentHeight = percentVisibleHeight
+            percentWidth = percentVisibleWidth
+        }
+    }
+
+    @OnViewRecycled
+    fun clear() {
+        onVisibilityEventDrawable.reset()
+    }
+
+    companion object {
+        private const val TAG = "ItemCustomView"
+    }
+}

--- a/kotlinsample/src/main/res/layout/async_custom_view_item.xml
+++ b/kotlinsample/src/main/res/layout/async_custom_view_item.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:padding="20dp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#80000000" />
+</LinearLayout>


### PR DESCRIPTION
EPoxy currently supports only synchronous layout inflation with most of the time during first layout is spent on the inflation of the views.

To make the first layout faster, we should support asynchronous layout inflation. With this approach, the application developer can make heavy views (like video player) asynchronous and improve the page load time

https://user-images.githubusercontent.com/2263278/165597664-3e3355bf-9296-4f78-9ab5-ef4f832099c7.mov