### PR TITLE
StickyHeaderLinearLayoutManager scroll issue

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/stickyheader/StickyHeaderLinearLayoutManager.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/stickyheader/StickyHeaderLinearLayoutManager.kt
@@ -141,7 +141,8 @@ class StickyHeaderLinearLayoutManager @JvmOverloads constructor(
 
         // Current sticky header is the same as at the position. Adjust the scroll offset and reset pending scroll.
         if (stickyHeader != null && headerIndex == findHeaderIndex(stickyHeaderPosition)) {
-            val adjustedOffset = (if (offset != INVALID_OFFSET) offset else 0) + stickyHeader!!.height
+            val adjustedOffset =
+                (if (offset != INVALID_OFFSET) offset else 0) + if (orientation == RecyclerView.VERTICAL) stickyHeader!!.height else stickyHeader!!.width
             super.scrollToPositionWithOffset(position, adjustedOffset)
             return
         }


### PR DESCRIPTION
Details on the problem can be found in this issue: https://github.com/airbnb/epoxy/issues/1305
Currently StickyHeaderLinearLayoutManager.kt doesn't take into account recycler orientation when computing offset for scrollToPosition method. This commit fixes the issue.