### PR TITLE
[ComposeInterop] EpoxyInterop now handles @AfterPropSet ModelView methods

### DIFF
--- a/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
+++ b/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
@@ -91,6 +91,8 @@ inline fun <reified T : EpoxyModel<*>> EpoxyInterop(
         },
         modifier = modifier,
     ) { view ->
-        (model as EpoxyModel<View>).bind(view.getChildAt(0))
+        val modelView = view.getChildAt(0)
+        (model as EpoxyModel<View>).bind(modelView)
+        (model as GeneratedModel<View>)?.handlePostBind(modelView, 0)
     }
 }

--- a/epoxy-composesample/src/main/java/com/airbnb/epoxy/compose/sample/epoxyviews/HeaderView.kt
+++ b/epoxy-composesample/src/main/java/com/airbnb/epoxy/compose/sample/epoxyviews/HeaderView.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.airbnb.epoxy.AfterPropsSet
 import com.airbnb.epoxy.ModelProp
 import com.airbnb.epoxy.ModelView
 import com.airbnb.epoxy.TextProp
@@ -45,6 +46,20 @@ class HeaderView(context: Context?) : LinearLayout(context) {
     @ModelProp
     fun setShowImage(isVisible: Boolean) {
         image?.visibility = if (isVisible) View.VISIBLE else View.GONE
+    }
+
+    @AfterPropsSet
+    fun changeTitleColor() {
+        title?.text?.last()?.let {
+            if (it.isDigit()) {
+                val isEven = it.digitToInt() % 2 == 0
+                if (isEven) {
+                    title?.setTextColor(resources.getColor(R.color.design_default_color_primary))
+                } else {
+                    title?.setTextColor(resources.getColor(R.color.design_default_color_secondary))
+                }
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
Currently `EpoxyInterop` won't call any `@AfterPropSet` method in the view. This fixes that by calling `handlePostBind` after the view has been bound.

Modified example to show alternating title colors with `@AfterPropSet fun changeTitleColor()`

Alternating title color.

| Before | After |
|---|---|
| <img width="250" alt="image" src="https://user-images.githubusercontent.com/110935264/184022567-bf3bd566-ccae-4698-8e89-e5234e50e749.png"> | <img width="250" alt="image" src="https://user-images.githubusercontent.com/110935264/184021883-bf157098-fb34-44b3-8347-77e80fcf0b7a.png"> |
