### PR TITLE
[ComposeInterop] Exposes Compose Epoxy Model generation

### DIFF
--- a/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
+++ b/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
@@ -69,14 +69,14 @@ fun ModelCollector.composableInterop(
     vararg keys: Any,
     composeFunction: @Composable () -> Unit
 ) {
-    add(generateComposeEpoxyModel(id, *keys, composeFunction = composeFunction))
+    add(composeEpoxyModel(id, *keys, composeFunction = composeFunction))
 }
 
 /**
- * [generateComposeEpoxyModel] can be used directly in cases where more control over the epoxy model
+ * [composeEpoxyModel] can be used directly in cases where more control over the epoxy model
  * is needed. Eg. When the epoxy model needs to be modified before it's added.
  */
-fun generateComposeEpoxyModel(
+fun composeEpoxyModel(
     id: String,
     vararg keys: Any,
     composeFunction: @Composable () -> Unit

--- a/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
+++ b/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
@@ -69,11 +69,21 @@ fun ModelCollector.composableInterop(
     vararg keys: Any,
     composeFunction: @Composable () -> Unit
 ) {
-    add(
-        ComposeEpoxyModel(*keys, composeFunction = composeFunction).apply {
-            id(id)
-        }
-    )
+    add(generateComposeEpoxyModel(id, *keys, composeFunction = composeFunction))
+}
+
+/**
+ * [generateComposeEpoxyModel] can be used directly in cases where more control over the epoxy model
+ * is needed. Eg. When the epoxy model needs to be modified before it's added.
+ */
+fun generateComposeEpoxyModel(
+    id: String,
+    vararg keys: Any,
+    composeFunction: @Composable () -> Unit
+): ComposeEpoxyModel {
+    return ComposeEpoxyModel(*keys, composeFunction = composeFunction).apply {
+        id(id)
+    }
 }
 
 @Composable


### PR DESCRIPTION
There are instances where we need to have finer control over the Compose generated Epoxy model before it's added, so this change exposes the function which generates the model.

This new function can be used directly instead of `composeInterop {}` when want to override Epoxy model parameters on the Compose generated model. Eg.  overriding row spans like: model.spanSizeOverride(3).