### PR TITLE
Please allow Kotlin classes to be subclassed with `open` keyword

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyTouchHelperCallback.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyTouchHelperCallback.kt
@@ -68,7 +68,7 @@ abstract class EpoxyTouchHelperCallback : ItemTouchHelper.Callback() {
     /**
      * @see getSwipeThreshold
      */
-    protected fun getSwipeThreshold(viewHolder: EpoxyViewHolder): Float =
+    protected open fun getSwipeThreshold(viewHolder: EpoxyViewHolder): Float =
         super.getSwipeThreshold(viewHolder)
 
     override fun getMoveThreshold(viewHolder: RecyclerView.ViewHolder): Float =

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.kt
@@ -30,7 +30,7 @@ import java.util.HashMap
  *
  * @see OnModelVisibilityStateChangedListener
  */
-class EpoxyVisibilityTracker {
+open class EpoxyVisibilityTracker {
 
     /**
      * Used to listen to [RecyclerView.ItemAnimator] ending animations.
@@ -90,7 +90,7 @@ class EpoxyVisibilityTracker {
      *
      * @param recyclerView The recyclerview that the EpoxyController has its adapter added to.
      */
-    fun attach(recyclerView: RecyclerView) {
+    open fun attach(recyclerView: RecyclerView) {
         attachedRecyclerView = recyclerView
         recyclerView.addOnScrollListener(listener)
         recyclerView.addOnLayoutChangeListener(listener)
@@ -103,7 +103,7 @@ class EpoxyVisibilityTracker {
      *
      * @param recyclerView The recycler view that the EpoxyController has its adapter added to.
      */
-    fun detach(recyclerView: RecyclerView) {
+    open fun detach(recyclerView: RecyclerView) {
         recyclerView.removeOnScrollListener(listener)
         recyclerView.removeOnLayoutChangeListener(listener)
         recyclerView.removeOnChildAttachStateChangeListener(listener)


### PR DESCRIPTION
I am upgrading from 4.2.0.  My existing codebase makes use of subclassing and method overrides.  With the refactor from java to kotlin, the following need to be marked `open` in order for my codebase to compile.

https://kotlinlang.org/docs/inheritance.html