### PR TITLE
Remove incorrect ksp symbol validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.1.1
+Remove incorrect ksp symbol validation in processing of @EpoxyModelClass
+
 # 5.1.0
 Updates Kotlin to 1.7.20 and KSP to 1.7.20-1.0.7, as well as the room compiler processing (xprocessing) library to 2.5.0-beta01.
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/EpoxyProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/EpoxyProcessor.kt
@@ -95,19 +95,6 @@ class EpoxyProcessor @JvmOverloads constructor(
             }
         timer.markStepCompleted("build target class models")
 
-        if (isKsp()) {
-            modelClassMap.values
-                .filterIsInstance<BasicGeneratedModelInfo>()
-                .mapNotNull { it.boundObjectTypeElement }
-                .filter { !it.validate() }
-                .let { invalidModelTypes ->
-                    timer.markStepCompleted("validate symbols")
-                    if (invalidModelTypes.isNotEmpty()) {
-                        return invalidModelTypes
-                    }
-                }
-        }
-
         addAttributesFromOtherModules(modelClassMap, memoizer)
         timer.markStepCompleted("add attributes from other modules")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=5.1.0
+VERSION_NAME=5.1.1
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy


### PR DESCRIPTION
Latest ksp/xprocessing/kotlin update breaks for us because of this incorrect approach to symbol validation. As far as I can tell it never should have worked because 1) it returns the views as the invalid symbols, not the annotated epoxy model class 2) it doesn't process the valid symbols in that same round, and the valid symbols won't ever be returned for processing in the future

Removing this logic still works fine for our code base and all tests pass, i believe I added this validation optimistically, and it never triggered until now.