### PR TITLE
Resolve unchecked call warning for WrappedEpoxyModelClickListener

### DIFF
--- a/epoxy-modelfactorytest/src/test/resources/AllTypesModelViewModel_.java
+++ b/epoxy-modelfactorytest/src/test/resources/AllTypesModelViewModel_.java
@@ -528,7 +528,7 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
       this.onClickListener_OnClickListener = null;
     }
     else {
-      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener(onClickListener);
+      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(onClickListener);
     }
     return this;
   }

--- a/epoxy-modelfactorytest/src/test/resources/CallbackPropModelViewModel_.java
+++ b/epoxy-modelfactorytest/src/test/resources/CallbackPropModelViewModel_.java
@@ -156,7 +156,7 @@ public class CallbackPropModelViewModel_ extends EpoxyModel<CallbackPropModelVie
       this.onClickListener_OnClickListener = null;
     }
     else {
-      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener(onClickListener);
+      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(onClickListener);
     }
     return this;
   }

--- a/epoxy-modelfactorytest/src/test/resources/ksp/AllTypesModelViewModel_.java
+++ b/epoxy-modelfactorytest/src/test/resources/ksp/AllTypesModelViewModel_.java
@@ -528,7 +528,7 @@ public class AllTypesModelViewModel_ extends EpoxyModel<AllTypesModelView> imple
       this.onClickListener_OnClickListener = null;
     }
     else {
-      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener(onClickListener);
+      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(onClickListener);
     }
     return this;
   }

--- a/epoxy-modelfactorytest/src/test/resources/ksp/CallbackPropModelViewModel_.java
+++ b/epoxy-modelfactorytest/src/test/resources/ksp/CallbackPropModelViewModel_.java
@@ -156,7 +156,7 @@ public class CallbackPropModelViewModel_ extends EpoxyModel<CallbackPropModelVie
       this.onClickListener_OnClickListener = null;
     }
     else {
-      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener(onClickListener);
+      this.onClickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(onClickListener);
     }
     return this;
   }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -1324,7 +1324,7 @@ class GeneratedModelWriter(
 
         // This model did not specify a layout in its EpoxyModelClass annotation,
         // but its superclass might
-        classElement.superType?.typeElement
+        classElement.superClass?.typeElement
             ?.let { superClass ->
                 findSuperClassWithClassAnnotation(superClass)
             }
@@ -1413,7 +1413,7 @@ class GeneratedModelWriter(
         setBitSetIfNeeded(classInfo, attribute, builder)
 
         val wrapperClickListenerConstructor = CodeBlock.of(
-            "new \$T(\$L)",
+            "new \$T<>(\$L)",
             ClassNames.EPOXY_WRAPPED_LISTENER,
             param.name
         )

--- a/epoxy-processortest/src/test/resources/DoNotHashViewModel_.java
+++ b/epoxy-processortest/src/test/resources/DoNotHashViewModel_.java
@@ -216,7 +216,7 @@ public class DoNotHashViewModel_ extends EpoxyModel<DoNotHashView> implements Ge
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/IgnoreRequireHashCodeViewModel_.java
+++ b/epoxy-processortest/src/test/resources/IgnoreRequireHashCodeViewModel_.java
@@ -169,7 +169,7 @@ public class IgnoreRequireHashCodeViewModel_ extends EpoxyModel<IgnoreRequireHas
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelProcessorTest/testKotlinModel/Model_.java
+++ b/epoxy-processortest/src/test/resources/ModelProcessorTest/testKotlinModel/Model_.java
@@ -146,7 +146,7 @@ public class Model_ extends Model implements GeneratedModel<Model.Holder>, Model
       super.setClickListener(null);
     }
     else {
-      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));
+      super.setClickListener(new WrappedEpoxyModelClickListener<>(clickListener));
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelProcessorTest/testKotlinModel/ksp/Model_.java
+++ b/epoxy-processortest/src/test/resources/ModelProcessorTest/testKotlinModel/ksp/Model_.java
@@ -147,7 +147,7 @@ public class Model_ extends Model implements GeneratedModel<Model.Holder>, Model
       super.setClickListener(null);
     }
     else {
-      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));
+      super.setClickListener(new WrappedEpoxyModelClickListener<>(clickListener));
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithDataBindingWithoutDonothashBindingModel_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithDataBindingWithoutDonothashBindingModel_.java
@@ -145,7 +145,7 @@ public class ModelWithDataBindingWithoutDonothashBindingModel_ extends DataBindi
       this.clickListener = null;
     }
     else {
-      this.clickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithPrivateViewClickListener_.java
@@ -135,7 +135,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
       super.setClickListener(null);
     }
     else {
-      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));
+      super.setClickListener(new WrappedEpoxyModelClickListener<>(clickListener));
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewClickListener_.java
@@ -135,7 +135,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
       super.clickListener = null;
     }
     else {
-      super.clickListener = new WrappedEpoxyModelClickListener(clickListener);
+      super.clickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ModelWithViewLongClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ModelWithViewLongClickListener_.java
@@ -135,7 +135,7 @@ public class ModelWithViewLongClickListener_ extends ModelWithViewLongClickListe
       super.clickListener = null;
     }
     else {
-      super.clickListener = new WrappedEpoxyModelClickListener(clickListener);
+      super.clickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestCallbackPropViewModel_.java
@@ -156,7 +156,7 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
       this.listener_OnClickListener = null;
     }
     else {
-      this.listener_OnClickListener = new WrappedEpoxyModelClickListener(listener);
+      this.listener_OnClickListener = new WrappedEpoxyModelClickListener<>(listener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropCallbackPropViewModel_.java
@@ -172,7 +172,7 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropChildViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropChildViewModel_.java
@@ -255,7 +255,7 @@ public class TestFieldPropChildViewModel_ extends EpoxyModel<TestFieldPropChildV
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropDoNotHashOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropDoNotHashOptionViewModel_.java
@@ -184,7 +184,7 @@ public class TestFieldPropDoNotHashOptionViewModel_ extends EpoxyModel<TestField
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropIgnoreRequireHashCodeOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropIgnoreRequireHashCodeOptionViewModel_.java
@@ -187,7 +187,7 @@ public class TestFieldPropIgnoreRequireHashCodeOptionViewModel_ extends EpoxyMod
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestFieldPropNullOnRecycleOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestFieldPropNullOnRecycleOptionViewModel_.java
@@ -172,7 +172,7 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
+++ b/epoxy-processortest/src/test/resources/TestManyTypesViewModel_.java
@@ -648,7 +648,7 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ViewProcessorTest/testManyTypes/TestManyTypesViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ViewProcessorTest/testManyTypes/TestManyTypesViewModel_.java
@@ -782,7 +782,7 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ViewProcessorTest/testManyTypes/ksp/TestManyTypesViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ViewProcessorTest/testManyTypes/ksp/TestManyTypesViewModel_.java
@@ -735,7 +735,7 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/DoNotHashViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/DoNotHashViewModel_.java
@@ -216,7 +216,7 @@ public class DoNotHashViewModel_ extends EpoxyModel<DoNotHashView> implements Ge
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/IgnoreRequireHashCodeViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/IgnoreRequireHashCodeViewModel_.java
@@ -169,7 +169,7 @@ public class IgnoreRequireHashCodeViewModel_ extends EpoxyModel<IgnoreRequireHas
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/ModelWithPrivateViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ksp/ModelWithPrivateViewClickListener_.java
@@ -135,7 +135,7 @@ public class ModelWithPrivateViewClickListener_ extends ModelWithPrivateViewClic
       super.setClickListener(null);
     }
     else {
-      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));
+      super.setClickListener(new WrappedEpoxyModelClickListener<>(clickListener));
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/ModelWithViewClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ksp/ModelWithViewClickListener_.java
@@ -135,7 +135,7 @@ public class ModelWithViewClickListener_ extends ModelWithViewClickListener impl
       super.clickListener = null;
     }
     else {
-      super.clickListener = new WrappedEpoxyModelClickListener(clickListener);
+      super.clickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/ModelWithViewLongClickListener_.java
+++ b/epoxy-processortest/src/test/resources/ksp/ModelWithViewLongClickListener_.java
@@ -135,7 +135,7 @@ public class ModelWithViewLongClickListener_ extends ModelWithViewLongClickListe
       super.clickListener = null;
     }
     else {
-      super.clickListener = new WrappedEpoxyModelClickListener(clickListener);
+      super.clickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/TestCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/TestCallbackPropViewModel_.java
@@ -156,7 +156,7 @@ public class TestCallbackPropViewModel_ extends EpoxyModel<TestCallbackPropView>
       this.listener_OnClickListener = null;
     }
     else {
-      this.listener_OnClickListener = new WrappedEpoxyModelClickListener(listener);
+      this.listener_OnClickListener = new WrappedEpoxyModelClickListener<>(listener);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/TestFieldPropCallbackPropViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/TestFieldPropCallbackPropViewModel_.java
@@ -172,7 +172,7 @@ public class TestFieldPropCallbackPropViewModel_ extends EpoxyModel<TestFieldPro
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/TestFieldPropChildViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/TestFieldPropChildViewModel_.java
@@ -255,7 +255,7 @@ public class TestFieldPropChildViewModel_ extends EpoxyModel<TestFieldPropChildV
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/TestFieldPropDoNotHashOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/TestFieldPropDoNotHashOptionViewModel_.java
@@ -184,7 +184,7 @@ public class TestFieldPropDoNotHashOptionViewModel_ extends EpoxyModel<TestField
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/TestFieldPropIgnoreRequireHashCodeOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/TestFieldPropIgnoreRequireHashCodeOptionViewModel_.java
@@ -187,7 +187,7 @@ public class TestFieldPropIgnoreRequireHashCodeOptionViewModel_ extends EpoxyMod
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/TestFieldPropNullOnRecycleOptionViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/TestFieldPropNullOnRecycleOptionViewModel_.java
@@ -172,7 +172,7 @@ public class TestFieldPropNullOnRecycleOptionViewModel_ extends EpoxyModel<TestF
       this.value_OnClickListener = null;
     }
     else {
-      this.value_OnClickListener = new WrappedEpoxyModelClickListener(value);
+      this.value_OnClickListener = new WrappedEpoxyModelClickListener<>(value);
     }
     return this;
   }

--- a/epoxy-processortest/src/test/resources/ksp/TestManyTypesViewModel_.java
+++ b/epoxy-processortest/src/test/resources/ksp/TestManyTypesViewModel_.java
@@ -648,7 +648,7 @@ public class TestManyTypesViewModel_ extends EpoxyModel<TestManyTypesView> imple
       this.clickListener_OnClickListener = null;
     }
     else {
-      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener(clickListener);
+      this.clickListener_OnClickListener = new WrappedEpoxyModelClickListener<>(clickListener);
     }
     return this;
   }


### PR DESCRIPTION
Generated classes that contain a View.ClickListener attribute has a method similar to the following:

```java
public DateViewHolder_ clickListener(
      @NonNull final OnModelClickListener<DateViewHolder_, ViewBindingHolder> clickListener) {
    onMutation();
    if (clickListener == null) {
      super.setClickListener(null);
    }
    else {
      super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));
    }
    return this;
  }
```

The code `new WrappedEpoxyModelClickListener(clickListener)` causes a warning similar to 

```bash
 warning: [unchecked] unchecked call to WrappedEpoxyModelClickListener(OnModelClickListener<T,V>) as a member of the raw type WrappedEpoxyModelClickListener
            super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));
                                   ^
  where T,V are type-variables:
    T extends EpoxyModel<?> declared in class WrappedEpoxyModelClickListener
    V extends Object declared in class WrappedEpoxyModelClickListener
```

This PR resolves the warning by writing `super.setClickListener(new WrappedEpoxyModelClickListener<>(clickListener));` to the generated code instead of `super.setClickListener(new WrappedEpoxyModelClickListener(clickListener));`

Also, `XTypeElement.superType` is Deprecated. Hence replacing it with `XTypeElement.superClass`