### PR TITLE
Dispose composition of `ComposeView` when unbinding `ComposeEpoxyModel`

### DIFF
--- a/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
+++ b/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
@@ -46,6 +46,11 @@ class ComposeEpoxyModel(
         view.setContent(composeFunction)
     }
 
+    override fun unbind(view: ComposeView) {
+        super.unbind(view)
+        view.disposeComposition()
+    }
+
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
         if (other !is ComposeEpoxyModel) return false


### PR DESCRIPTION
Right now the composition of `ComposeView` in `ComposeEpoxyModel` isn't properly disposed. This leads to issues where e.g. when navigating to away from the screen where the `ComposeEpoxyModel` is rendered, and then coming back, the model isn't rendered anymore.

This PR fixes this by calling `ComposeView.disposeComposition()` when unbinding the `ComposeView` from the model.