### PR TITLE
Change the way the Compose interop works to avoid Android 12 bug

### DIFF
--- a/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
+++ b/epoxy-compose/src/main/java/com/airbnb/epoxy/ComposeInterop.kt
@@ -126,7 +126,6 @@ inline fun composeEpoxyModel(
     modelAction.invoke(composeEpoxyModel)
 }
 
-
 @Composable
 inline fun <reified T : EpoxyModel<*>> EpoxyInterop(
     modifier: Modifier = Modifier,


### PR DESCRIPTION
The way the `composeEpoxyModel` function was written it would create a function that looked like this (in decompiled dex bytecode (for readability compiled to Java))

```java
public static final ComposeEpoxyModel composeEpoxyModel(String id, Object[] keys, Function2<? super Composer, ? super Integer, Unit> composeFunction) {
    ...
    ComposeEpoxyModel $this$composeEpoxyModel_u24lambda_u240 = new ComposeEpoxyModel(Arrays.copyOf(keys, keys.length), composeFunction);
    $this$composeEpoxyModel_u24lambda_u240.id(id);
    return $this$composeEpoxyModel_u24lambda_u240;
}
```

this would trigger a ART bug in the (non mainline patched version of Android 12) to optimize the this line away

```java
$this$composeEpoxyModel_u24lambda_u240.id(id);
```

and lead to crashes on Android 12.

More background at:
https://github.com/airbnb/epoxy/issues/1199 and
https://issuetracker.google.com/issues/197818595

This works around this issue by making sure that the creation, setting the id and adding to the controller of a `ComposeEpoxyModel` is happening in the same location in compiled bytecode.

**Note**: If you run R8 with optimization enabled, the method outlining optimization might still outline some of that inlined code again and thus still cause this problem but that is a different issue that can be dealt with by disabling outlining or all optimization.