### PR TITLE
feat: Add aggregate visibility state changed callback

### DIFF
--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/AggregateVisibilityState.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/AggregateVisibilityState.kt
@@ -1,0 +1,11 @@
+package com.airbnb.epoxy
+
+/**
+ * The complete [VisibilityState]s for a single update.
+ */
+interface AggregateVisibilityState {
+    val partiallyVisible: Boolean
+    val fullyVisible: Boolean
+    val visible: Boolean
+    val focusedVisible: Boolean
+}

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyModel.java
@@ -211,6 +211,16 @@ public abstract class EpoxyModel<T> {
   }
 
   /**
+   * The aggregate {@link com.airbnb.epoxy.VisibilityState}s for this model that were previously
+   * sent to {@link #onVisibilityStateChanged}.
+   */
+  public void onAggregateVisibilityStateChanged(
+      @NonNull AggregateVisibilityState visibilityState,
+      @NonNull T view
+  ) {
+  }
+
+  /**
    * TODO link to the wiki
    *
    * @see OnVisibilityChanged annotation

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyViewHolder.java
@@ -103,6 +103,14 @@ public class EpoxyViewHolder extends RecyclerView.ViewHolder {
     epoxyModel.onVisibilityStateChanged(visibilityState, objectToBind());
   }
 
+  public void aggregateVisibilityChanged(
+      @NonNull AggregateVisibilityState aggregateVisibilityState
+  ) {
+    assertBound();
+    // noinspection unchecked
+    epoxyModel.onAggregateVisibilityStateChanged(aggregateVisibilityState, objectToBind());
+  }
+
   public void visibilityChanged(
       @FloatRange(from = 0.0f, to = 100.0f) float percentVisibleHeight,
       @FloatRange(from = 0.0f, to = 100.0f) float percentVisibleWidth,

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityItem.kt
@@ -20,7 +20,7 @@ import androidx.recyclerview.widget.RecyclerView
  * only.
  */
 @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-class EpoxyVisibilityItem(adapterPosition: Int? = null) {
+class EpoxyVisibilityItem(adapterPosition: Int? = null) : AggregateVisibilityState {
 
     private val localVisibleRect = Rect()
 
@@ -44,10 +44,14 @@ class EpoxyVisibilityItem(adapterPosition: Int? = null) {
 
     @Px
     private var viewportWidth = 0
-    private var partiallyVisible = false
-    private var fullyVisible = false
-    private var visible = false
-    private var focusedVisible = false
+    override var partiallyVisible = false
+        private set
+    override var fullyVisible = false
+        private set
+    override var visible = false
+        private set
+    override var focusedVisible = false
+        private set
     private var viewVisibility = View.GONE
 
     /** Store last value for de-duping  */
@@ -140,6 +144,10 @@ class EpoxyVisibilityItem(adapterPosition: Int? = null) {
                 epoxyHolder.visibilityStateChanged(VisibilityState.FULL_IMPRESSION_VISIBLE)
             }
         }
+    }
+
+    fun handleAggregateVisibleState(epoxyHolder: EpoxyViewHolder) {
+        epoxyHolder.aggregateVisibilityChanged(this)
     }
 
     fun handleChanged(epoxyHolder: EpoxyViewHolder, visibilityChangedEnabled: Boolean): Boolean {

--- a/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.kt
+++ b/epoxy-adapter/src/main/java/com/airbnb/epoxy/EpoxyVisibilityTracker.kt
@@ -338,6 +338,7 @@ open class EpoxyVisibilityTracker {
             }
             vi.handleFocus(epoxyHolder, detachEvent)
             vi.handleFullImpressionVisible(epoxyHolder, detachEvent)
+            vi.handleAggregateVisibleState(epoxyHolder)
             changed = vi.handleChanged(epoxyHolder, onChangedEnabled)
         }
         return changed

--- a/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
+++ b/epoxy-adapter/src/test/java/com/airbnb/epoxy/EpoxyVisibilityTrackerTest.kt
@@ -958,6 +958,16 @@ class EpoxyVisibilityTrackerTest {
                     helper.fullImpression = state == FULL_IMPRESSION_VISIBLE
             }
         }
+
+        override fun onAggregateVisibilityStateChanged(
+            visibilityState: AggregateVisibilityState,
+            view: View
+        ) {
+            helper.aggregateVisibilityState.visible = visibilityState.visible
+            helper.aggregateVisibilityState.focusedVisible = visibilityState.focusedVisible
+            helper.aggregateVisibilityState.fullyVisible = visibilityState.fullyVisible
+            helper.aggregateVisibilityState.partiallyVisible = visibilityState.partiallyVisible
+        }
     }
 
     /**
@@ -975,6 +985,8 @@ class EpoxyVisibilityTrackerTest {
         var focused = false
         var partialImpression = false
         var fullImpression = false
+
+        val aggregateVisibilityState = MutableAggregateVisibilityState()
 
         fun assert(
             id: Int? = null,
@@ -1032,6 +1044,7 @@ class EpoxyVisibilityTrackerTest {
                     it,
                     this.visible
                 )
+                Assert.assertEquals(it, aggregateVisibilityState.visible)
             }
             partialImpression?.let {
                 Assert.assertEquals(
@@ -1039,6 +1052,7 @@ class EpoxyVisibilityTrackerTest {
                     it,
                     this.partialImpression
                 )
+                Assert.assertEquals(it, aggregateVisibilityState.partiallyVisible)
             }
             fullImpression?.let {
                 Assert.assertEquals(
@@ -1046,6 +1060,7 @@ class EpoxyVisibilityTrackerTest {
                     it,
                     this.fullImpression
                 )
+                Assert.assertEquals(it, aggregateVisibilityState.fullyVisible)
             }
             visitedStates?.let { assertVisited(it) }
         }
@@ -1069,6 +1084,13 @@ class EpoxyVisibilityTrackerTest {
                     )
                 }
             }
+        }
+
+        class MutableAggregateVisibilityState : AggregateVisibilityState {
+            override var partiallyVisible: Boolean = false
+            override var fullyVisible: Boolean = false
+            override var visible: Boolean = false
+            override var focusedVisible: Boolean = false
         }
     }
 }


### PR DESCRIPTION
To fix https://github.com/airbnb/epoxy/issues/1343, I believe a new callback that reports the latest visibility state(s) for that `EpoxyVisibilityItem` should be introduced. Without this aggregate information, client will need to somehow batch the `VisibilityState` by themselves for 1 `vi.update` cycle. To avoid object allocation, instead of using `data class AggregateVisibilityState` I just expose the properties from `EpoxyVisibilityItem` as read-only.

Alternatively to fix https://github.com/airbnb/epoxy/issues/1343, we could change the ordering of `VisibilityState` emission on `onVisibilityStateChanged`. Please let me know if that's preferred.

### Test

I have included comparing the aggregate visibility state in `EpoxyVisibilityStateTrackerTest`.
