### PR TITLE
 Fix KSP2 "PSI has changed since creation" errors

### DIFF
--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BaseProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BaseProcessor.kt
@@ -245,7 +245,8 @@ abstract class BaseProcessor(val kspEnvironment: SymbolProcessorEnvironment? = n
             // TODO: Potentially generate a single file per model to allow for an isolating processor
             kotlinExtensionWriter.generateExtensionsForModels(
                 generatedModels,
-                processorName
+                processorName,
+                memoizer
             )
             timer.markStepCompleted("generateKotlinExtensions")
         }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BaseProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BaseProcessor.kt
@@ -217,6 +217,10 @@ abstract class BaseProcessor(val kspEnvironment: SymbolProcessorEnvironment? = n
         // for reuse.
         val memoizer = Memoizer(environment, logger)
 
+        // Clear resource scanner caches to avoid holding stale KSP element references.
+        // In KSP2, accessing elements from previous rounds triggers "PSI has changed since creation" errors.
+        resourceProcessor.clearCachesForNewRound()
+
         val deferredElements: List<XElement> = try {
             tryOrPrintError<List<XElement>?> {
                 timer.markStepCompleted("round initialization")

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BasicGeneratedModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BasicGeneratedModelInfo.kt
@@ -89,5 +89,5 @@ internal class BasicGeneratedModelInfo(
         )
     }
 
-    override fun additionalOriginatingElements(): List<XElement> = listOf(superClassElement)
+    override fun additionalOriginatingElements(): List<XElement> = listOf(safeSuperClassElement())
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BasicGeneratedModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/BasicGeneratedModelInfo.kt
@@ -89,5 +89,5 @@ internal class BasicGeneratedModelInfo(
         )
     }
 
-    override fun additionalOriginatingElements(): List<XElement> = listOf(safeSuperClassElement())
+    override fun additionalOriginatingElements(currentMemoizer: Memoizer): List<XElement> = listOf(safeSuperClassElement(currentMemoizer))
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ConfigManager.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ConfigManager.kt
@@ -224,8 +224,14 @@ class ConfigManager internal constructor(
         )
     }
 
-    fun getDefaultBaseModel(viewElement: XTypeElement): XType? {
-        return getModelViewConfig(viewElement)?.defaultBaseModel
+    fun getDefaultBaseModel(viewElement: XTypeElement, currentEnvironment: XProcessingEnv): XType? {
+        val className = getModelViewConfig(viewElement)?.defaultBaseModelClassName
+            ?: return null
+        // Resolve the type fresh each round using the current environment to avoid
+        // accessing stale KSP elements from previous rounds.
+        // IMPORTANT: Use the currentEnvironment parameter, not the instance field,
+        // since the instance field was captured at ConfigManager creation time (round 1).
+        return currentEnvironment.findType(className)
     }
 
     fun includeAlternateLayoutsForViews(viewElement: XTypeElement): Boolean {

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/DataBindingAttributeInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/DataBindingAttributeInfo.kt
@@ -12,7 +12,9 @@ internal class DataBindingAttributeInfo(
 
     init {
         fieldName = removeSetPrefix(setterMethod.name)
-        setXType(setterMethod.parameters[0].type, modelInfo.memoizer)
+        // Use the memoizer parameter from the current round, not modelInfo.memoizer.
+        // modelInfo may have been created in a previous round and its memoizer holds stale KSP references.
+        setXType(setterMethod.parameters[0].type, memoizer)
         rootClass = modelInfo.generatedName.simpleName()
         packageName = modelInfo.generatedName.packageName()
         useInHash = !modelInfo.enableDoNotHash ||

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/DataBindingModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/DataBindingModelInfo.kt
@@ -93,6 +93,6 @@ internal class DataBindingModelInfo(
         )
     }
 
-    override fun additionalOriginatingElements() =
+    override fun additionalOriginatingElements(currentMemoizer: Memoizer) =
         listOfNotNull(annotatedElement, dataBindingClassElement)
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/DataBindingProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/DataBindingProcessor.kt
@@ -163,7 +163,7 @@ class DataBindingProcessor @JvmOverloads constructor(
             bindingModelInfo.parseDataBindingClass(logger) ?: return@filter false
             createModelWriter(memoizer).generateClassForModel(
                 bindingModelInfo,
-                originatingElements = bindingModelInfo.originatingElements()
+                originatingElements = bindingModelInfo.originatingElements(memoizer)
             )
             true
         }.also { writtenModels ->

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/EpoxyProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/EpoxyProcessor.kt
@@ -106,7 +106,7 @@ class EpoxyProcessor @JvmOverloads constructor(
         val styleableModels = modelInfos
             .filterIsInstance<BasicGeneratedModelInfo>()
             .filter { modelInfo ->
-                modelInfo.superClassElement.getAnnotation(EpoxyModelClass::class)?.getAsInt("layout") == 0 &&
+                modelInfo.safeSuperClassElement().getAnnotation(EpoxyModelClass::class)?.getAsInt("layout") == 0 &&
                     modelInfo.boundObjectTypeElement?.hasStyleableAnnotation() == true
             }
         timer.markStepCompleted("check for styleable models")

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/EpoxyProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/EpoxyProcessor.kt
@@ -106,7 +106,7 @@ class EpoxyProcessor @JvmOverloads constructor(
         val styleableModels = modelInfos
             .filterIsInstance<BasicGeneratedModelInfo>()
             .filter { modelInfo ->
-                modelInfo.safeSuperClassElement().getAnnotation(EpoxyModelClass::class)?.getAsInt("layout") == 0 &&
+                modelInfo.safeSuperClassElement(memoizer).getAnnotation(EpoxyModelClass::class)?.getAsInt("layout") == 0 &&
                     modelInfo.boundObjectTypeElement?.hasStyleableAnnotation() == true
             }
         timer.markStepCompleted("check for styleable models")
@@ -136,7 +136,7 @@ class EpoxyProcessor @JvmOverloads constructor(
     private fun writeModel(modelInfo: GeneratedModelInfo, memoizer: Memoizer) {
         createModelWriter(memoizer).generateClassForModel(
             modelInfo,
-            originatingElements = modelInfo.originatingElements()
+            originatingElements = modelInfo.originatingElements(memoizer)
         )
     }
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
@@ -17,6 +17,15 @@ import javax.lang.model.element.Modifier
 abstract class GeneratedModelInfo(val memoizer: Memoizer) {
 
     lateinit var superClassElement: XTypeElement
+
+    /**
+     * Looks up and returns the super class element by FQN, to avoid errors from accessing
+     * an XTypeElement from a previous processing round.
+     */
+    fun safeSuperClassElement(): XTypeElement {
+        return memoizer.environment.requireTypeElement(superClassElement.qualifiedName)
+    }
+
     lateinit var superClassName: TypeName
     lateinit var parameterizedGeneratedName: TypeName
     lateinit var generatedName: ClassName
@@ -86,7 +95,7 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
      */
     fun collectMethodsReturningClassType(superModelClass: XTypeElement) {
         methodsReturningClassType
-            .addAll(memoizer.getMethodsReturningClassType(superModelClass.type, memoizer))
+            .addAll(memoizer.getMethodsReturningClassType(superModelClass.qualifiedName, memoizer))
     }
 
     @Synchronized
@@ -152,8 +161,10 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
      * @return True if the super class of this generated model is also extended from a generated
      * model.
      */
-    val isSuperClassAlsoGenerated: Boolean
-        get() = superClassElement.type.isSubTypeOf(memoizer.generatedModelType)
+    fun isSuperClassAlsoGenerated(currentMemoizer: Memoizer): Boolean {
+        val generatedModelType = currentMemoizer.generatedModelType
+        return safeSuperClassElement().type.isSubTypeOf(generatedModelType)
+    }
 
     data class ConstructorInfo internal constructor(
         val modifiers: Set<Modifier>,

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelInfo.kt
@@ -21,9 +21,12 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
     /**
      * Looks up and returns the super class element by FQN, to avoid errors from accessing
      * an XTypeElement from a previous processing round.
+     *
+     * @param currentMemoizer The memoizer from the current processing round. Must be passed
+     *        explicitly to ensure we use a fresh environment, not the stale one stored in `this.memoizer`.
      */
-    fun safeSuperClassElement(): XTypeElement {
-        return memoizer.environment.requireTypeElement(superClassElement.qualifiedName)
+    fun safeSuperClassElement(currentMemoizer: Memoizer): XTypeElement {
+        return currentMemoizer.environment.requireTypeElement(superClassElement.qualifiedName)
     }
 
     lateinit var superClassName: TypeName
@@ -73,13 +76,15 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
     /**
      * The elements that influence the generation of this model.
      * eg base model class for @EpoxyModelClass, view class for @ModelView, etc
+     *
+     * @param currentMemoizer The memoizer from the current processing round.
      */
-    fun originatingElements(): List<XElement> {
+    fun originatingElements(currentMemoizer: Memoizer): List<XElement> {
         return listOfNotNull(styleBuilderInfo?.styleBuilderElement)
-            .plus(additionalOriginatingElements())
+            .plus(additionalOriginatingElements(currentMemoizer))
     }
 
-    open fun additionalOriginatingElements(): List<XElement> = emptyList()
+    open fun additionalOriginatingElements(currentMemoizer: Memoizer): List<XElement> = emptyList()
 
     /**
      * Get information about constructors of the original class so we can duplicate them in the
@@ -163,7 +168,7 @@ abstract class GeneratedModelInfo(val memoizer: Memoizer) {
      */
     fun isSuperClassAlsoGenerated(currentMemoizer: Memoizer): Boolean {
         val generatedModelType = currentMemoizer.generatedModelType
-        return safeSuperClassElement().type.isSubTypeOf(generatedModelType)
+        return safeSuperClassElement(currentMemoizer).type.isSubTypeOf(generatedModelType)
     }
 
     data class ConstructorInfo internal constructor(

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -160,7 +160,7 @@ class GeneratedModelWriter(
 
             builderHooks?.beforeFinalBuild(this)
 
-            addSuperinterface(modelInterfaceWriter.writeInterface(info, this.build().methodSpecs))
+            addSuperinterface(modelInterfaceWriter.writeInterface(info, this.build().methodSpecs, memoizer))
 
             originatingElements.forEach {
                 addOriginatingElement(it)
@@ -835,7 +835,7 @@ class GeneratedModelWriter(
         // bind!!! So we mustn't do that. So, we only call the super diff binding if we think
         // it's a custom implementation.
         if (modelImplementsBindWithDiff(
-                classInfo.safeSuperClassElement(),
+                classInfo.safeSuperClassElement(memoizer),
                 memoizer
             )
         ) {
@@ -1102,7 +1102,7 @@ class GeneratedModelWriter(
         methods: MutableList<MethodSpec>
     ) {
 
-        val originalClassElement = modelClassInfo.safeSuperClassElement()
+        val originalClassElement = modelClassInfo.safeSuperClassElement(memoizer)
         if (!originalClassElement.type.isEpoxyModelWithHolder(memoizer)) {
             return
         }
@@ -1178,7 +1178,7 @@ class GeneratedModelWriter(
             return modelInfo.getLayoutResource(resourceProcessor)
         }
 
-        val superClassElement = modelInfo.safeSuperClassElement()
+        val superClassElement = modelInfo.safeSuperClassElement(memoizer)
         if (implementsMethod(superClassElement, buildDefaultLayoutMethodBase(), environment)) {
             return null
         }
@@ -1205,7 +1205,7 @@ class GeneratedModelWriter(
      * variables that changed.
      */
     private fun generateDataBindingMethodsIfNeeded(info: GeneratedModelInfo): Iterable<MethodSpec> {
-        if (!info.safeSuperClassElement().type.isDataBindingEpoxyModel(memoizer)) {
+        if (!info.safeSuperClassElement(memoizer).type.isDataBindingEpoxyModel(memoizer)) {
             return emptyList()
         }
 
@@ -1221,7 +1221,7 @@ class GeneratedModelWriter(
 
         // If the base method is already implemented don't bother checking for the payload method
         if (implementsMethod(
-                info.safeSuperClassElement(),
+                info.safeSuperClassElement(memoizer),
                 bindVariablesMethod,
                 environment
             )
@@ -1232,7 +1232,7 @@ class GeneratedModelWriter(
         val generatedModelClass = info.generatedName
 
         val moduleName = (info as? DataBindingModelInfo)?.moduleName
-            ?: dataBindingModuleLookup.getModuleName(info.safeSuperClassElement())
+            ?: dataBindingModuleLookup.getModuleName(info.safeSuperClassElement(memoizer))
 
         val baseMethodBuilder = bindVariablesMethod.toBuilder()
 

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/GeneratedModelWriter.kt
@@ -3,7 +3,6 @@ package com.airbnb.epoxy.processor
 import androidx.annotation.LayoutRes
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XFiler
-import androidx.room.compiler.processing.XMethodElement
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.addOriginatingElement
@@ -608,7 +607,7 @@ class GeneratedModelWriter(
             addParameter(boundObjectParam)
             addParameter(TypeName.INT, "position")
 
-            if (modelInfo.isSuperClassAlsoGenerated) {
+            if (modelInfo.isSuperClassAlsoGenerated(memoizer)) {
                 // If a super class is also generated we need to make sure to call through to these
                 // methods on it as well. This is particularly important for EpoxyModelGroup.
                 addStatement("super.handlePostBind(\$L, position)", boundObjectParam.name)
@@ -836,8 +835,8 @@ class GeneratedModelWriter(
         // bind!!! So we mustn't do that. So, we only call the super diff binding if we think
         // it's a custom implementation.
         if (modelImplementsBindWithDiff(
-                classInfo.superClassElement,
-                memoizer.baseBindWithDiffMethod
+                classInfo.safeSuperClassElement(),
+                memoizer
             )
         ) {
             addStatement(
@@ -870,7 +869,7 @@ class GeneratedModelWriter(
             .addParameter(boundObjectParam)
             .addParameter(TypeName.INT, positionParamName, Modifier.FINAL)
 
-        if (modelInfo.isSuperClassAlsoGenerated) {
+        if (modelInfo.isSuperClassAlsoGenerated(memoizer)) {
             // If a super class is also generated we need to make sure to call through to these
             // methods on it as well. This is particularly important for EpoxyModelGroup.
             preBindBuilder.addStatement(
@@ -1103,7 +1102,7 @@ class GeneratedModelWriter(
         methods: MutableList<MethodSpec>
     ) {
 
-        val originalClassElement = modelClassInfo.superClassElement
+        val originalClassElement = modelClassInfo.safeSuperClassElement()
         if (!originalClassElement.type.isEpoxyModelWithHolder(memoizer)) {
             return
         }
@@ -1179,7 +1178,7 @@ class GeneratedModelWriter(
             return modelInfo.getLayoutResource(resourceProcessor)
         }
 
-        val superClassElement = modelInfo.superClassElement
+        val superClassElement = modelInfo.safeSuperClassElement()
         if (implementsMethod(superClassElement, buildDefaultLayoutMethodBase(), environment)) {
             return null
         }
@@ -1206,7 +1205,7 @@ class GeneratedModelWriter(
      * variables that changed.
      */
     private fun generateDataBindingMethodsIfNeeded(info: GeneratedModelInfo): Iterable<MethodSpec> {
-        if (!info.superClassElement.type.isDataBindingEpoxyModel(memoizer)) {
+        if (!info.safeSuperClassElement().type.isDataBindingEpoxyModel(memoizer)) {
             return emptyList()
         }
 
@@ -1222,7 +1221,7 @@ class GeneratedModelWriter(
 
         // If the base method is already implemented don't bother checking for the payload method
         if (implementsMethod(
-                info.superClassElement,
+                info.safeSuperClassElement(),
                 bindVariablesMethod,
                 environment
             )
@@ -1233,7 +1232,7 @@ class GeneratedModelWriter(
         val generatedModelClass = info.generatedName
 
         val moduleName = (info as? DataBindingModelInfo)?.moduleName
-            ?: dataBindingModuleLookup.getModuleName(info.superClassElement)
+            ?: dataBindingModuleLookup.getModuleName(info.safeSuperClassElement())
 
         val baseMethodBuilder = bindVariablesMethod.toBuilder()
 
@@ -2102,14 +2101,20 @@ class GeneratedModelWriter(
 
         fun modelImplementsBindWithDiff(
             clazz: XTypeElement,
-            baseBindWithDiffMethod: XMethodElement
+            currentMemoizer: Memoizer
         ): Boolean {
-            return clazz.getAllMethods().any {
+            // Re-resolve the type element using the current memoizer's environment to avoid
+            // accessing stale KSP elements from previous rounds. In KSP2, this triggers
+            // "PSI has changed since creation" errors.
+            val freshClazz = currentMemoizer.environment.requireType(clazz.qualifiedName).typeElement!!
+            val baseBindWithDiffMethod = currentMemoizer.baseBindWithDiffMethod
+
+            return freshClazz.getAllMethods().any {
                 it.name == baseBindWithDiffMethod.name &&
                     !it.isAbstract() &&
                     it.overrides(
                         other = baseBindWithDiffMethod,
-                        owner = clazz
+                        owner = freshClazz
                     )
             }
         }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
@@ -91,12 +91,13 @@ class ModelBuilderInterfaceWriter(
                 addAnnotation(EpoxyBuildScope::class.java)
             }
 
-            if (modelInfo.memoizer.implementsModelCollector(modelInfo.superClassElement)) {
+            val superClassElement = modelInfo.safeSuperClassElement()
+            if (modelInfo.memoizer.implementsModelCollector(superClassElement)) {
                 // If the model implements "ModelCollector" we want the builder too
                 addSuperinterface(ClassNames.MODEL_COLLECTOR)
             }
 
-            addOriginatingElement(modelInfo.superClassElement)
+            addOriginatingElement(superClassElement)
         }
 
         JavaFile.builder(modelInfo.generatedName.packageName(), modelInterface)

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelBuilderInterfaceWriter.kt
@@ -44,7 +44,8 @@ class ModelBuilderInterfaceWriter(
 
     fun writeInterface(
         modelInfo: GeneratedModelInfo,
-        methods: MutableList<MethodSpec>
+        methods: MutableList<MethodSpec>,
+        memoizer: Memoizer
     ): TypeName {
 
         val interfaceName = getBuilderInterfaceClassName(modelInfo)
@@ -91,8 +92,8 @@ class ModelBuilderInterfaceWriter(
                 addAnnotation(EpoxyBuildScope::class.java)
             }
 
-            val superClassElement = modelInfo.safeSuperClassElement()
-            if (modelInfo.memoizer.implementsModelCollector(superClassElement)) {
+            val superClassElement = modelInfo.safeSuperClassElement(memoizer)
+            if (memoizer.implementsModelCollector(superClassElement)) {
                 // If the model implements "ModelCollector" we want the builder too
                 addSuperinterface(ClassNames.MODEL_COLLECTOR)
             }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewInfo.kt
@@ -54,10 +54,10 @@ class ModelViewInfo(
             superClassElement.name != ClassNames.EPOXY_MODEL_UNTYPED.simpleName()
         ) {
             // If the view has a custom base model then we copy any custom constructors on it
-            constructors.addAll(getClassConstructors(safeSuperClassElement()))
+            constructors.addAll(getClassConstructors(safeSuperClassElement(memoizer)))
         }
 
-        collectMethodsReturningClassType(safeSuperClassElement())
+        collectMethodsReturningClassType(safeSuperClassElement(memoizer))
 
         // The bound type is the type of this view
         modelType = viewElement.type.typeName
@@ -182,5 +182,5 @@ class ModelViewInfo(
         return element.parameters.singleOrNull()?.hasDefaultValue == true
     }
 
-    override fun additionalOriginatingElements() = listOf(viewElement)
+    override fun additionalOriginatingElements(currentMemoizer: Memoizer) = listOf(viewElement)
 }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewInfo.kt
@@ -54,10 +54,10 @@ class ModelViewInfo(
             superClassElement.name != ClassNames.EPOXY_MODEL_UNTYPED.simpleName()
         ) {
             // If the view has a custom base model then we copy any custom constructors on it
-            constructors.addAll(getClassConstructors(superClassElement))
+            constructors.addAll(getClassConstructors(safeSuperClassElement()))
         }
 
-        collectMethodsReturningClassType(superClassElement)
+        collectMethodsReturningClassType(safeSuperClassElement())
 
         // The bound type is the type of this view
         modelType = viewElement.type.typeName
@@ -91,7 +91,7 @@ class ModelViewInfo(
     private fun lookUpSuperClassElement(): XTypeElement {
         val classToExtend = viewAnnotation.getAsType("baseModelClass")
             ?.takeIf { !it.isVoidObject() && !it.isVoid() }
-            ?: configManager.getDefaultBaseModel(viewElement)
+            ?: configManager.getDefaultBaseModel(viewElement, environment)
             ?: return memoizer.epoxyModelClassElementUntyped
 
         val superElement =

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewProcessor.kt
@@ -612,10 +612,10 @@ class ModelViewProcessor @JvmOverloads constructor(
         modelClassMap.values.forEach { modelViewInfo ->
             // Skip generated model super classes since it will already contain all of the functions
             // necessary for included attributes, and duplicating them is a waste.
-            if (modelViewInfo.isSuperClassAlsoGenerated) return@forEach
+            if (modelViewInfo.isSuperClassAlsoGenerated(memoizer)) return@forEach
 
             memoizer.getInheritedEpoxyAttributes(
-                modelViewInfo.superClassElement.type,
+                modelViewInfo.safeSuperClassElement().type,
                 modelViewInfo.generatedName.packageName(),
                 logger
             ).let { modelViewInfo.addAttributes(it) }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewProcessor.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewProcessor.kt
@@ -615,7 +615,7 @@ class ModelViewProcessor @JvmOverloads constructor(
             if (modelViewInfo.isSuperClassAlsoGenerated(memoizer)) return@forEach
 
             memoizer.getInheritedEpoxyAttributes(
-                modelViewInfo.safeSuperClassElement().type,
+                modelViewInfo.safeSuperClassElement(memoizer).type,
                 modelViewInfo.generatedName.packageName(),
                 logger
             ).let { modelViewInfo.addAttributes(it) }
@@ -690,7 +690,7 @@ class ModelViewProcessor @JvmOverloads constructor(
 
         val modelWriter = createModelWriter(memoizer)
         ModelViewWriter(modelWriter, this)
-            .writeModels(modelsToWrite, originatingConfigElements())
+            .writeModels(modelsToWrite, originatingConfigElements(), memoizer)
 
         if (styleableModelsToWrite.isEmpty()) {
             // Make sure all models have been processed and written before we generate interface information

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewWriter.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ModelViewWriter.kt
@@ -18,12 +18,13 @@ internal class ModelViewWriter(
 
     fun writeModels(
         models: List<ModelViewInfo>,
-        originatingConfigElements: List<XElement>
+        originatingConfigElements: List<XElement>,
+        memoizer: Memoizer
     ) {
         models.forEach("Write model view classes") { modelInfo ->
             modelWriter.generateClassForModel(
                 modelInfo,
-                originatingElements = originatingConfigElements + modelInfo.originatingElements(),
+                originatingElements = originatingConfigElements + modelInfo.originatingElements(memoizer),
                 builderHooks = generateBuilderHook(modelInfo)
             )
         }

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ParisStyleAttributeInfo.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/ParisStyleAttributeInfo.kt
@@ -30,7 +30,10 @@ class ParisStyleAttributeInfo(
         fieldName = PARIS_STYLE_ATTR_NAME
         rootClass = modelInfo.generatedName.simpleName()
         this.packageName = packageName
-        setXType(modelInfo.memoizer.parisStyleType, modelInfo.memoizer)
+        // Use the memoizer parameter from the current round, not modelInfo.memoizer from round 1.
+        // modelInfo may have been created in a previous round and its memoizer holds stale KSP references.
+        // In KSP2, accessing types from previous rounds triggers "PSI has changed since creation" errors.
+        setXType(memoizer.parisStyleType, memoizer)
         styleBuilderClass = styleBuilderClassName
         ignoreRequireHashCode = true
         isGenerated = true

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/Type.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/Type.kt
@@ -11,10 +11,9 @@ import com.squareup.javapoet.WildcardTypeName
  * This helps to memoize the look up of a type's information.
  */
 class Type(val xType: XType, memoizer: Memoizer) {
-    val typeName: TypeName by lazy {
-        xType.typeNameWithWorkaround(memoizer)
-    }
-    val typeEnum: TypeEnum by lazy { TypeEnum.from(xType, typeName, memoizer) }
+    // Compute both typeName and typeEnum eagerly to avoid accessing stale xType in later rounds
+    val typeName: TypeName = xType.typeNameWithWorkaround(memoizer)
+    val typeEnum: TypeEnum = TypeEnum.from(xType, memoizer)
 
     enum class TypeEnum {
         StringOrCharSequence,
@@ -31,9 +30,10 @@ class Type(val xType: XType, memoizer: Memoizer) {
         Unknown;
 
         companion object {
-            fun from(xType: XType, typeName: TypeName, memoizer: Memoizer): TypeEnum {
+            fun from(xType: XType, memoizer: Memoizer): TypeEnum {
 
                 val nonNullType by lazy { xType.makeNonNullable() }
+                val typeName by lazy { xType.typeNameWithWorkaround(memoizer) }
 
                 return when {
                     xType.isInt() -> Int

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/resourcescanning/KspResourceScanner.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/resourcescanning/KspResourceScanner.kt
@@ -37,6 +37,12 @@ class KspResourceScanner(environmentProvider: () -> XProcessingEnv) :
     private val cache =
         mutableMapOf<Pair<KClass<out Annotation>, XElement>, List<AnnotationWithReferenceValue>>()
 
+    override fun clearCachesForNewRound() {
+        // Clear the cache to avoid holding references to stale XElement objects from previous rounds.
+        // In KSP2, accessing elements from previous rounds triggers "PSI has changed since creation" errors.
+        cache.clear()
+    }
+
     override fun getResourceValueListInternal(
         annotation: KClass<out Annotation>,
         element: XElement,

--- a/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/resourcescanning/ResourceScanner.kt
+++ b/epoxy-processor/src/main/java/com/airbnb/epoxy/processor/resourcescanning/ResourceScanner.kt
@@ -122,4 +122,13 @@ abstract class ResourceScanner(val environmentProvider: () -> XProcessingEnv) {
     }
 
     abstract fun getImports(classElement: XTypeElement): List<String>
+
+    /**
+     * Clears any caches that may hold references to KSP elements.
+     * This must be called at the start of each round to avoid accessing stale PSI elements
+     * in KSP2, which would trigger "PSI has changed since creation" errors.
+     */
+    open fun clearCachesForNewRound() {
+        // Default implementation does nothing. KspResourceScanner overrides this to clear its cache.
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=5.2.1-airbnb14
+VERSION_NAME=5.2.1-airbnb16
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,8 @@ org.gradle.configuration-cache=true
 
 # Publishing configuration for vanniktech/gradle-maven-publish-plugin
 mavenCentralPublishing=true
-RELEASE_SIGNING_ENABLED=true
+# Signing can be disabled with -PdoNotSignRelease=true
+signAllPublications=true
 mavenCentralAutomaticPublishing=true
 
 # Dokka fails without a larger metaspace https://github.com/Kotlin/dokka/issues/1405

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=5.2.1-airbnb16
+VERSION_NAME=5.2.1
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=5.2.0
+VERSION_NAME=5.2.1-airbnb14
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Epoxy is a system for composing complex screens with a ReyclerView in Android.
 POM_URL=https://github.com/airbnb/epoxy

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -19,11 +19,13 @@ publishing {
     }
 }
 
-mavenPublishing {
-    if (findProperty("doNotSignRelease").toString().toBoolean()) {
-        println("Skipping release signing")
-    } else {
-        println("Signing release with gpg")
-        signAllPublications()
-    }
+// Apply conditional signing logic by setting the property at configuration time
+// This must happen before the mavenPublishing plugin reads the property
+if (findProperty("doNotSignRelease").toString().toBoolean()) {
+    println("Skipping release signing")
+    // Override the signAllPublications property to disable signing
+    ext.set("signAllPublications", "false")
+} else {
+    println("Signing release with gpg")
+    // signAllPublications is already set to true in gradle.properties
 }


### PR DESCRIPTION
### Summary

  - Fixes critical crashes in KSP2 where accessing elements from previous processing rounds causes KaInvalidLifetimeOwnerAccessException: PSI has changed since creation
  - This issue affects any project with multi-round annotation processing (deferred elements from round 1 accessed in round 2+)

  ### Problem

  In KSP2, PSI elements become invalid after each processing round. Epoxy's processor held references to stale KSP types/elements via:
  - Cached XElement objects in KspResourceScanner
  - XType stored in PackageModelViewSettings
  - Lazy properties in GeneratedModelInfo, Type, and other classes
  - Stale memoizer references captured in round 1, accessed in round 2+

  ### Solution

  Applied fixes across the processor:

  1. Cache Invalidation: Added clearCachesForNewRound() to KspResourceScanner to clear element caches between rounds
  2. Store Stable Identifiers: Changed PackageModelViewSettings to store defaultBaseModelClassName: String instead of XType
  3. Pass Current Context: Updated method signatures throughout the codebase to accept currentMemoizer: Memoizer parameter instead of relying on stale captured references:
    - GeneratedModelInfo.isSuperClassAlsoGenerated()
    - GeneratedModelInfo.safeSuperClassElement()
    - GeneratedModelInfo.originatingElements()
    - GeneratedModelWriter.modelImplementsBindWithDiff()
    - ConfigManager.getDefaultBaseModel()
  4. Fresh Type Resolution: Changed Memoizer.getMethodsReturningClassType() to accept classQualifiedName: String and resolve types fresh each round
  5. Eager Initialization: Changed Type.kt's typeName and typeEnum from lazy to eager initialization to capture values when xType is still fresh
  6. Exception Handling: Added try-catch in Memoizer.implementsModelCollector() for cases where XProcessing library has internal stale state